### PR TITLE
add MariaDB operator dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The repository is designed to be applied in **layers**, providing flexibility in
 | **Custom Metrics Autoscaler** | Event-driven autoscaler based on KEDA | `openshift-keda` | Model Serving | |
 | **Tempo Operator** | Distributed tracing backend | `openshift-tempo-operator` | Tracing infrastructure | |
 | **Red Hat Connectivity Link** | Multicloud application connectivity and API management | `kuadrant-system` | Model Serving (KServe) | Leader Worker Set, Cert-Manager |
+| **MariaDB Operator** | MariaDB for OpenShift | `mariadb-operator` | TrustyAI (optional, only if using database mode) | |
 
 #### Operator Configuration Requirements
 
@@ -96,6 +97,35 @@ Additional configuration is needed to enable TLS for Authorino. This is done in 
    ```bash
    kubectl get authorino authorino -n <kuadrant-namespace> -o jsonpath='{.spec.listener.tls}'
    ```
+
+##### MariaDB Operator
+
+MariaDB operator is an optional dependency in case the user is planning to use TrustyAI with Database mode.
+As such, it is not listed by default among other dependencies in `dependencies/operators/kustomization.yaml`, and has specific installation steps.
+
+**Due to TLS issues with newer MariaDB versions, the recommended version is v0.29**
+
+###### Installation steps:
+
+1. Apply MariaDB Operator resources using:
+  ```bash
+  kubectl apply -k dependencies/operators/maria-db 
+  ```
+
+2. Get InstallPlan name for MariaDB Operator v0.29 using:
+  ```bash
+  kubectl get installplan -n mariadb-operator | grep v0.29 | sed 's/ .*//'
+  ```
+
+3. Approve the InstallPlan using (insert the previously-obtained InstallPlan name):
+  ``` bash
+  kubectl patch installplan <install-plan-name> -n mariadb-operator --type merge -p '{"spec":{"approved":true}}'
+  ```
+
+4. Wait for the MariaDB Operator installation to complete. Verify that the operator pod is running using:
+  ```bash
+  kubectl get pods -n mariadb-operator -l control-plane=controller-manager
+  ```
 
 #### Adding New Dependencies
 

--- a/components/operators/maria-db/kustomization.yaml
+++ b/components/operators/maria-db/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - operatorgroup.yaml
+  - subscription.yaml
+  - namespace.yaml

--- a/components/operators/maria-db/namespace.yaml
+++ b/components/operators/maria-db/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mariadb-operator

--- a/components/operators/maria-db/operatorgroup.yaml
+++ b/components/operators/maria-db/operatorgroup.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: mariadb-operator
+  namespace: mariadb-operator

--- a/components/operators/maria-db/subscription.yaml
+++ b/components/operators/maria-db/subscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: mariadb-operator
+  namespace: mariadb-operator
+spec:
+  channel: alpha
+  installPlanApproval: Manual
+  name: mariadb-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: mariadb-operator.v0.29.0 # due to TLS issues with newer MariaDB versions, the recommended version is v0.29

--- a/dependencies/operators/kustomization.yaml
+++ b/dependencies/operators/kustomization.yaml
@@ -14,3 +14,5 @@ components:
   # TODO: The following operators need a manual configuration. It needs to be added if used llamastackoperator.
   # - ../../components/operators/nfd
   # - ../../components/operators/nvidia-gpu-operator
+  # MariaDB operator is an optional dependency for TrustyAI in Database mode, check README.md for more details
+  # - ../../components/operators/maria-db

--- a/dependencies/operators/maria-db/kustomization.yaml
+++ b/dependencies/operators/maria-db/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../components/operators/maria-db/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add MariaDB operator dependency.

JIRA ref: [RHOAIENG-38705](https://issues.redhat.com/browse/RHOAIENG-38705)

## How Has This Been Tested?
Tested on my cluster so far, individual deployment, as well as with other dependencies.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MariaDB Operator is now available as an optional dependency for Database mode.

* **Documentation**
  * Added installation and configuration guide for the MariaDB Operator, with TLS notes and a four-step install/verification workflow (recommended v0.29).

* **Chores**
  * Dependency verification optionally validates a version-pinned MariaDB Operator and checks operator pod readiness when present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->