### PR TITLE
RHOAIENG-38713: add kserve configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,9 +226,10 @@ chart-test: ## Test chart against all snapshots
 	@rm .helm-test-skip-crd.yaml
 	@echo "==> All tests passed!"
 
-HELM_DOCS = $(shell pwd)/bin/helm-docs
+HELM_DOCS ?= $(LOCALBIN)/helm-docs
 .PHONY: helm-docs-ensure
-helm-docs-ensure: ##Download helm-docs locally if necessary.
+helm-docs-ensure: $(HELM_DOCS) ## Download helm-docs locally if necessary.
+$(HELM_DOCS): $(LOCALBIN)
 	$(call go-install-tool,$(HELM_DOCS),github.com/norwoodj/helm-docs/cmd/helm-docs,$(HELM_DOCS_VERSION))
 
 .PHONY: helm-docs

--- a/chart/api-docs.md
+++ b/chart/api-docs.md
@@ -10,8 +10,11 @@ A Helm chart for installing ODH/RHOAI dependencies and component configurations
 |-----|------|---------|-------------|
 | components.aipipelines | object | `{"managementState":"Managed"}` | AI Pipelines component |
 | components.aipipelines.managementState | string | `"Managed"` | Management state for AI Pipelines (Managed or Removed) |
-| components.kserve | object | `{"managementState":"Managed"}` | KServe model serving component |
+| components.kserve | object | `{"managementState":"Managed","nim":{"managementState":"Managed"},"rawDeploymentServiceConfig":"Headless"}` | KServe model serving component |
 | components.kserve.managementState | string | `"Managed"` | Management state for KServe (Managed or Removed). Auto-enables: certManager, leaderWorkerSet, jobSet, rhcl |
+| components.kserve.nim | object | `{"managementState":"Managed"}` | Enables NVIDIA NIM integration. |
+| components.kserve.nim.managementState | string | `"Managed"` | Management state for NIM (Managed or Removed) |
+| components.kserve.rawDeploymentServiceConfig | string | `"Headless"` | Raw deployment service config for KServe (Headless or Headed) |
 | components.kueue | object | `{"managementState":"Unmanaged"}` | Kueue job queuing component |
 | components.kueue.managementState | string | `"Unmanaged"` | Management state for Kueue (Unmanaged or Removed). Auto-enables: kueue operator |
 | dependencies.certManager | object | `{"enabled":"auto","olm":{"channel":"stable-v1","name":"openshift-cert-manager-operator","namespace":"cert-manager-operator"}}` | Cert Manager operator |

--- a/chart/templates/operator/datasciencecluster.yaml
+++ b/chart/templates/operator/datasciencecluster.yaml
@@ -12,9 +12,9 @@ metadata:
 spec:
   components:
     aipipelines:
-      managementState: {{ .Values.components.aipipelines.managementState }}
+      {{- .Values.components.aipipelines | toYaml | nindent 6 }}
     kserve:
-      managementState: {{ .Values.components.kserve.managementState }}
+      {{- .Values.components.kserve | toYaml | nindent 6 }}
     kueue:
-      managementState: {{ .Values.components.kueue.managementState }}
+      {{- .Values.components.kueue | toYaml | nindent 6 }}
 {{- end }}

--- a/chart/test/snapshots/skip-crd-check.snap.yaml
+++ b/chart/test/snapshots/skip-crd-check.snap.yaml
@@ -94,6 +94,7 @@ spec:
       managementState: Managed
     kserve:
       managementState: Managed
+      rawDeploymentServiceConfig: Headless
     kueue:
       managementState: Unmanaged
 ---

--- a/chart/test/snapshots/skip-crd-check.snap.yaml
+++ b/chart/test/snapshots/skip-crd-check.snap.yaml
@@ -94,6 +94,8 @@ spec:
       managementState: Managed
     kserve:
       managementState: Managed
+      nim:
+        managementState: Managed
       rawDeploymentServiceConfig: Headless
     kueue:
       managementState: Unmanaged

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -84,7 +84,7 @@
       "description": "High-level features that configure DSC managementState and auto-enable their dependencies.",
       "properties": {
         "kserve": {
-          "$ref": "#/definitions/component"
+          "$ref": "#/definitions/kserveComponent"
         },
         "kueue": {
           "$ref": "#/definitions/kueueComponent"
@@ -247,6 +247,40 @@
           "enum": ["Unmanaged", "Removed"],
           "default": "Removed",
           "description": "Management state for kueue in DSC. Unmanaged enables auto-dependencies, Removed does not."
+        }
+      },
+      "required": ["managementState"],
+      "additionalProperties": false
+    },
+    "kserveComponent": {
+      "type": "object",
+      "description": "Component configuration - configures DSC managementState and triggers automatic dependency installation",
+      "properties": {
+        "managementState": {
+          "type": "string",
+          "enum": ["Managed", "Removed"],
+          "default": "Removed",
+          "description": "Management state for this component in DSC. Managed enables auto-dependencies, Removed does not."
+        },
+        "rawDeploymentServiceConfig": {
+          "type": "string",
+          "enum": ["Headless", "Head"],
+          "default": "Headless",
+          "description": "Raw deployment service config for KServe. Headless does not enable auto-dependencies, Head does."
+        },
+        "nim": {
+          "type": "object",
+          "description": "NIM configuration for KServe",
+          "properties": {
+            "managementState": {
+              "type": "string",
+              "enum": ["Managed", "Removed"],
+              "default": "Managed",
+              "description": "Management state for NIM in DSC. Managed enables auto-dependencies, Removed does not."
+            }
+          },
+          "required": ["managementState"],
+          "additionalProperties": false
         }
       },
       "required": ["managementState"],

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -264,23 +264,28 @@
         },
         "rawDeploymentServiceConfig": {
           "type": "string",
-          "enum": ["Headless", "Head"],
+          "enum": ["Headless", "Headed"],
           "default": "Headless",
           "description": "Raw deployment service config for KServe. Headless does not enable auto-dependencies, Head does."
         },
         "nim": {
-          "type": "object",
-          "description": "NIM configuration for KServe",
-          "properties": {
-            "managementState": {
-              "type": "string",
-              "enum": ["Managed", "Removed"],
-              "default": "Managed",
-              "description": "Management state for NIM in DSC. Managed enables auto-dependencies, Removed does not."
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "description": "NIM configuration for KServe",
+              "properties": {
+                "managementState": {
+                  "type": "string",
+                  "enum": ["Managed", "Removed"],
+                  "default": "Managed",
+                  "description": "Management state for NIM in DSC. Managed enables auto-dependencies, Removed does not."
+                }
+              },
+              "required": ["managementState"],
+              "additionalProperties": false
             }
-          },
-          "required": ["managementState"],
-          "additionalProperties": false
+          ]
         }
       },
       "required": ["managementState"],

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -131,6 +131,12 @@
     }
   },
   "definitions": {
+    "defaultManagementState": {
+      "type": "string",
+      "enum": ["Managed", "Removed"],
+      "default": "Removed",
+      "description": "Management state for component in DSC. Managed enables components and auto dependencies management, Removed does not."
+    },
     "operatorConfig": {
       "type": "object",
       "description": "Operator installation configuration",
@@ -229,10 +235,7 @@
       "description": "Component configuration - configures DSC managementState and triggers automatic dependency installation",
       "properties": {
         "managementState": {
-          "type": "string",
-          "enum": ["Managed", "Removed"],
-          "default": "Removed",
-          "description": "Management state for this component in DSC. Managed enables auto-dependencies, Removed does not."
+          "$ref": "#/definitions/defaultManagementState"
         }
       },
       "required": ["managementState"],
@@ -257,35 +260,27 @@
       "description": "Component configuration - configures DSC managementState and triggers automatic dependency installation",
       "properties": {
         "managementState": {
-          "type": "string",
-          "enum": ["Managed", "Removed"],
-          "default": "Removed",
-          "description": "Management state for this component in DSC. Managed enables auto-dependencies, Removed does not."
+          "$ref": "#/definitions/defaultManagementState"
         },
         "rawDeploymentServiceConfig": {
           "type": "string",
           "enum": ["Headless", "Headed"],
           "default": "Headless",
-          "description": "Raw deployment service config for KServe. Headless does not enable auto-dependencies, Head does."
+          "description": "Configures the type of service that is created for InferenceServices using RawDeployment."
         },
         "nim": {
-          "oneOf": [
-            { "type": "null" },
-            {
-              "type": "object",
-              "description": "NIM configuration for KServe",
-              "properties": {
-                "managementState": {
-                  "type": "string",
-                  "enum": ["Managed", "Removed"],
-                  "default": "Managed",
-                  "description": "Management state for NIM in DSC. Managed enables auto-dependencies, Removed does not."
-                }
-              },
-              "required": ["managementState"],
-              "additionalProperties": false
+          "type": "object",
+          "description": "NIM configuration for KServe",
+          "properties": {
+            "managementState": {
+              "type": "string",
+              "enum": ["Managed", "Removed"],
+              "default": "Managed",
+              "description": "Management state for NIM in DSC."
             }
-          ]
+          },
+          "required": ["managementState"],
+          "additionalProperties": false
         }
       },
       "required": ["managementState"],

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -58,6 +58,10 @@ components:
   kserve:
     # -- Management state for KServe (Managed or Removed). Auto-enables: certManager, leaderWorkerSet, jobSet, rhcl
     managementState: Managed
+    # -- Raw deployment service config for KServe (Headless or Head)
+    rawDeploymentServiceConfig: Headless
+    # -- Configures and enables NVIDIA NIM integration
+    nim: null
 
   # -- Kueue job queuing component
   kueue:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -58,10 +58,12 @@ components:
   kserve:
     # -- Management state for KServe (Managed or Removed). Auto-enables: certManager, leaderWorkerSet, jobSet, rhcl
     managementState: Managed
-    # -- Raw deployment service config for KServe (Headless or Head)
+    # -- Raw deployment service config for KServe (Headless or Headed)
     rawDeploymentServiceConfig: Headless
-    # -- Configures and enables NVIDIA NIM integration
-    nim: null
+    # -- Enables NVIDIA NIM integration.
+    nim:
+      # -- Management state for NIM (Managed or Removed)
+      managementState: Managed
 
   # -- Kueue job queuing component
   kueue:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add kserve DSC additional configuration

Jira task: https://issues.redhat.com/browse/RHOAIENG-38713

## How Has This Been Tested?
Run locally the chart to verify correct installation and DSC reach ready status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KServe gains new settings: nim.managementState (default "Managed") and rawDeploymentServiceConfig (default "Headless"); KServe now supports nested component configuration and stricter schema validation (allowed values for managementState and service mode).

* **Chores**
  * Build tooling improved: documentation tooling path is now configurable and ensured as part of the build.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->