### PR TITLE
feat: add ray support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,9 +289,9 @@ Add your component to `chart/templates/operator/datasciencecluster.yaml`:
 spec:
   components:
     kserve:
-      managementState: {{ .Values.components.kserve.managementState }}
+      {{- .Values.components.kserve | toYaml | nindent 6 }}
     yourComponent:
-      managementState: {{ .Values.components.yourComponent.managementState }}
+      {{- .Values.components.yourComponent | toYaml | nindent 6 }}
 ```
 
 #### Step 4: Update JSON Schema
@@ -317,10 +317,10 @@ Add your component to `chart/values.schema.json` under the `components` section.
    make chart-snapshots
    ```
 
-3. **Test on a cluster** (optional):
+3. **Test on a cluster**:
 
    ```bash
-   helm upgrade --install rhoai ./chart -n opendatahub-gitops --create-namespace
+   make helm-install-verify
    ```
 
 ## Testing Your Changes

--- a/chart/README.md
+++ b/chart/README.md
@@ -86,7 +86,7 @@ High-level features that:
 
 | managementState | Dependencies auto-enabled | Available for |
 |-----------------|---------------------------|---------------|
-| `Managed` | Yes | kserve, aipipelines |
+| `Managed` | Yes | kserve, aipipelines, ray |
 | `Unmanaged` | Yes | kueue |
 | `Removed` | No | all |
 
@@ -95,6 +95,7 @@ High-level features that:
 | `kserve` | KServe model serving | certManager, leaderWorkerSet, jobSet, rhcl |
 | `kueue` | Kueue job queuing | kueue |
 | `aipipelines` | AI Pipelines | - |
+| `ray` | Ray distributed computing | certManager |
 
 ### Dependencies
 

--- a/chart/api-docs.md
+++ b/chart/api-docs.md
@@ -17,6 +17,8 @@ A Helm chart for installing ODH/RHOAI dependencies and component configurations
 | components.kserve.rawDeploymentServiceConfig | string | `"Headless"` | Raw deployment service config for KServe (Headless or Headed) |
 | components.kueue | object | `{"managementState":"Unmanaged"}` | Kueue job queuing component |
 | components.kueue.managementState | string | `"Unmanaged"` | Management state for Kueue (Unmanaged or Removed). Auto-enables: kueue operator |
+| components.ray | object | `{"managementState":"Managed"}` | Ray component |
+| components.ray.managementState | string | `"Managed"` | Management state for Ray (Managed or Removed) |
 | dependencies.certManager | object | `{"enabled":"auto","olm":{"channel":"stable-v1","name":"openshift-cert-manager-operator","namespace":"cert-manager-operator"}}` | Cert Manager operator |
 | dependencies.certManager.enabled | string | `"auto"` | Enable cert-manager: auto (if needed), true (always), false (never) |
 | dependencies.clusterObservability | object | `{"enabled":"auto","olm":{"channel":"stable","name":"cluster-observability-operator","namespace":"openshift-cluster-observability-operator"}}` | Cluster Observability operator |

--- a/chart/templates/definitions/_dependencies.tpl
+++ b/chart/templates/definitions/_dependencies.tpl
@@ -17,6 +17,8 @@ kueue:
   - certManager
   - kueue
 aipipelines: []
+ray:
+  - certManager
 {{- end }}
 
 {{/*

--- a/chart/templates/operator/datasciencecluster.yaml
+++ b/chart/templates/operator/datasciencecluster.yaml
@@ -17,4 +17,6 @@ spec:
       {{- .Values.components.kserve | toYaml | nindent 6 }}
     kueue:
       {{- .Values.components.kueue | toYaml | nindent 6 }}
+    ray:
+      {{- .Values.components.ray | toYaml | nindent 6 }}
 {{- end }}

--- a/chart/test/snapshots/skip-crd-check.snap.yaml
+++ b/chart/test/snapshots/skip-crd-check.snap.yaml
@@ -99,6 +99,8 @@ spec:
       rawDeploymentServiceConfig: Headless
     kueue:
       managementState: Unmanaged
+    ray:
+      managementState: Managed
 ---
 # Source: odh-rhoai-chart/templates/dependencies/job-set/config.yaml
 apiVersion: operator.openshift.io/v1

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -91,6 +91,9 @@
         },
         "aipipelines": {
           "$ref": "#/definitions/component"
+        },
+        "ray": {
+          "$ref": "#/definitions/component"
         }
       },
       "additionalProperties": false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -75,6 +75,11 @@ components:
     # -- Management state for AI Pipelines (Managed or Removed)
     managementState: Managed
 
+  # -- Ray component
+  ray:
+    # -- Management state for Ray (Managed or Removed)
+    managementState: Managed
+
 # =============================================================================
 # DEPENDENCIES - Operators required by components
 #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add support to Ray component in chart, defaulting to Managed

Jira task: https://issues.redhat.com/browse/RHOAIENG-38717

## How Has This Been Tested?

Install helm chart locally, and wait DSC to be ready

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Ray distributed computing component is now available as a configurable managed component in the deployment.

* **Documentation**
  * Updated contribution guidelines and testing workflow documentation.
  * Enhanced API documentation with new component configuration references.

* **Chores**
  * Updated configuration schema and default values to support the new Ray component.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->