### PR TITLE
fix: add cert-manager as jobset dependency

### DIFF
--- a/chart/templates/definitions/_dependencies.tpl
+++ b/chart/templates/definitions/_dependencies.tpl
@@ -32,7 +32,8 @@ kueue:
   - certManager
 leaderWorkerSet:
   - certManager
-jobSet: []
+jobSet:
+  - certManager
 rhcl:
   - certManager
   - leaderWorkerSet

--- a/dependencies/operators/job-set-operator/kustomization.yaml
+++ b/dependencies/operators/job-set-operator/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 components:
+  - ../../../components/operators/cert-manager/
   - ../../../components/operators/job-set-operator/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Given the [official docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/ai_workloads/jobset-operator#js-install_js-install), cert-manager is a prerequisites to the jobset operator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Added cert-manager as a required component for the job-set-operator, establishing the dependency relationship and updating the operator's resource composition.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->