### PR TITLE
Add OpenTelemetry as dependency for Cluster Observability Operator and Tempo Operator + minor adjustments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,7 +331,7 @@ Always test your changes before submitting a PR.
 
 1. **Validate Kustomize Build**:
 
-  Run `make validate` to validate the kustomization files.
+  Run `make validate-all` to validate the kustomization files.
 
 2. **Check for YAML Errors**:
 

--- a/README.md
+++ b/README.md
@@ -63,37 +63,6 @@ The repository is designed to be applied in **layers**, providing flexibility in
 
 Some operators require additional configuration. Below are the configuration requirements for each operator:
 
-##### Tempo Operator
-
-The Tempo Operator requires object storage configuration and a custom resource (**TempoStack** or **TempoMonolithic**) to be created after the operator is installed.
-
-###### Configuration Steps:
-
-1. Follow the [Red Hat Distributed Tracing Platform Documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/distributed_tracing/distr-tracing-tempo-installing) to:
-   - Set up object storage (S3, GCS, or Azure)
-   - Create the storage secret
-   - Create a TempoStack or TempoMonolithic custom resource
-
-2. Place your Tempo configuration manifests in the `configurations/tempo-operator/` directory
-
-3. Create a `kustomization.yaml` file in `configurations/tempo-operator/` that includes your manifests:
-   ```yaml
-   apiVersion: kustomize.config.k8s.io/v1beta1
-   kind: Kustomization
-   
-   resources:
-     - namespace.yaml
-     - tempo-storage-secret.yaml
-     - tempostack.yaml  # or tempomonolithic.yaml
-   ```
-
-4. Update `configurations/kustomization.yaml` to include the tempo-operator directory:
-   ```yaml
-   resources:
-     - kueue-operator
-     - tempo-operator
-   ```
-
 ##### Red Hat Connectivity Link operator
 
 Additional configuration is needed to enable TLS for Authorino. This is done in two stages:

--- a/chart/templates/definitions/_dependencies.tpl
+++ b/chart/templates/definitions/_dependencies.tpl
@@ -38,8 +38,10 @@ rhcl:
   - leaderWorkerSet
 certManager: []
 customMetricsAutoscaler: []
-clusterObservability: []
+clusterObservability:
+  - opentelemetry
 opentelemetry: []
-tempo: []
+tempo:
+  - opentelemetry
 {{- end }}
 

--- a/dependencies/operators/cluster-observability-operator/kustomization.yaml
+++ b/dependencies/operators/cluster-observability-operator/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 components:
+  - ../../../components/operators/opentelemetry-product/
   - ../../../components/operators/cluster-observability-operator/

--- a/dependencies/operators/tempo-operator/kustomization.yaml
+++ b/dependencies/operators/tempo-operator/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 components:
+  - ../../../components/operators/opentelemetry-product/
   - ../../../components/operators/tempo-product/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR

* adds "auto" dependency on OpenTelemetry operator if either Cluster Observability Operator or Tempo Operator are selected for installation. While OpenTelemetry is not necessary needed for these 2 operators to run correctly, it doesn't make sense in the context of ODH/RHOAI because these operators don't add any value on their own for ODH/RHOAI.
On the other hand, OpenTelemetry can be used alone as users can opt for their own processing of metrics/traces scraped by OpenTelemetry operator.

* replaces reference of `make validate` with `make validate-all`
* removes mention of having to create TempoStack/TempoMonolithic manually for Tempo operator. This is not needed as ODH/RHOAI operator handles it automatically. fyi @RomanFilip 

## How Has This Been Tested?
Locally as so far observability dependencies are not enabled by default. Also lint checks and others were run using `make validate-all`. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated validation steps in the contributing guide to use the `make validate-all` command.
  * Removed Tempo Operator configuration documentation from the README.

* **Chores**
  * Integrated OpenTelemetry as a dependency for cluster observability and tempo operators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->