### PR TITLE
Remove operator type, set values override for rhoai

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,9 +211,9 @@ chart-snapshots: ## Create snapshots for all chart configurations
 	@echo "==> Creating default snapshot..."
 	$(call helm-template,$(HELM_SNAPSHOT_DIR)/default.snap.yaml,)
 	@echo "==> Creating skipCrdCheck snapshot for ODH..."
-	$(call helm-template,$(HELM_SNAPSHOT_DIR)/skip-crd-check-odh.snap.yaml,--set global.skipCrdCheck=true --set operator.type=odh)
+	$(call helm-template,$(HELM_SNAPSHOT_DIR)/skip-crd-check-odh.snap.yaml,--set global.skipCrdCheck=true)
 	@echo "==> Creating skipCrdCheck snapshot for RHOAI..."
-	$(call helm-template,$(HELM_SNAPSHOT_DIR)/skip-crd-check-rhoai.snap.yaml,--set global.skipCrdCheck=true --set operator.type=rhoai)
+	$(call helm-template,$(HELM_SNAPSHOT_DIR)/skip-crd-check-rhoai.snap.yaml,-f chart/rhoai-values.yaml --set global.skipCrdCheck=true)
 	@echo "==> Snapshots updated!"
 
 .PHONY: chart-test
@@ -223,11 +223,11 @@ chart-test: ## Test chart against all snapshots
 	@diff .helm-test-default.yaml $(HELM_SNAPSHOT_DIR)/default.snap.yaml
 	@rm .helm-test-default.yaml
 	@echo "==> Testing skipCrdCheck ODH configuration..."
-	$(call helm-template,.helm-test-skip-crd-odh.yaml,--set global.skipCrdCheck=true --set operator.type=odh)
+	$(call helm-template,.helm-test-skip-crd-odh.yaml,--set global.skipCrdCheck=true)
 	@diff .helm-test-skip-crd-odh.yaml $(HELM_SNAPSHOT_DIR)/skip-crd-check-odh.snap.yaml
 	@rm .helm-test-skip-crd-odh.yaml
 	@echo "==> Testing skipCrdCheck RHOAI configuration..."
-	$(call helm-template,.helm-test-skip-crd-rhoai.yaml,--set global.skipCrdCheck=true --set operator.type=rhoai)
+	$(call helm-template,.helm-test-skip-crd-rhoai.yaml,-f chart/rhoai-values.yaml --set global.skipCrdCheck=true)
 	@diff .helm-test-skip-crd-rhoai.yaml $(HELM_SNAPSHOT_DIR)/skip-crd-check-rhoai.snap.yaml
 	@rm .helm-test-skip-crd-rhoai.yaml
 	@echo "==> All tests passed!"

--- a/chart/api-docs.md
+++ b/chart/api-docs.md
@@ -27,18 +27,16 @@ A Helm chart for installing ODH/RHOAI dependencies and component configurations
 | components.kueue.dependencies | object | `{"certManager":true,"kueue":true}` | Dependencies required by Kueue |
 | components.kueue.dsc | object | `{"managementState":"Unmanaged"}` | DSC configuration for Kueue |
 | components.kueue.dsc.managementState | string | `"Unmanaged"` | Management state for Kueue (Unmanaged or Removed) |
-| components.modelregistry | object | `{"defaults":{"odh":{"registriesNamespace":"odh-model-registry"},"rhoai":{"registriesNamespace":"rhoai-model-registries"}},"dependencies":{},"dsc":{"managementState":"Managed","registriesNamespace":null}}` | Model Registry component |
-| components.modelregistry.defaults | object | `{"odh":{"registriesNamespace":"odh-model-registry"},"rhoai":{"registriesNamespace":"rhoai-model-registries"}}` | Operator-type-specific defaults for dsc fields |
+| components.modelregistry | object | `{"dependencies":{},"dsc":{"managementState":"Managed","registriesNamespace":"odh-model-registry"}}` | Model Registry component |
 | components.modelregistry.dependencies | object | `{}` | Dependencies required by Model Registry |
-| components.modelregistry.dsc | object | `{"managementState":"Managed","registriesNamespace":null}` | DSC configuration for Model Registry |
+| components.modelregistry.dsc | object | `{"managementState":"Managed","registriesNamespace":"odh-model-registry"}` | DSC configuration for Model Registry |
 | components.modelregistry.dsc.managementState | string | `"Managed"` | Management state for Model Registry (Managed or Removed) |
-| components.modelregistry.dsc.registriesNamespace | string | `nil` | Registries namespace for Model Registry (overrides defaults) |
-| components.workbenches | object | `{"defaults":{"odh":{"workbenchNamespace":"opendatahub"},"rhoai":{"workbenchNamespace":"rhods-notebooks"}},"dependencies":{},"dsc":{"managementState":"Managed","workbenchNamespace":null}}` | Workbenches component |
-| components.workbenches.defaults | object | `{"odh":{"workbenchNamespace":"opendatahub"},"rhoai":{"workbenchNamespace":"rhods-notebooks"}}` | Operator-type-specific defaults for dsc fields |
+| components.modelregistry.dsc.registriesNamespace | string | `"odh-model-registry"` | Registries namespace for Model Registry (overrides defaults) |
+| components.workbenches | object | `{"dependencies":{},"dsc":{"managementState":"Managed","workbenchNamespace":"opendatahub"}}` | Workbenches component |
 | components.workbenches.dependencies | object | `{}` | Dependencies required by Workbenches |
-| components.workbenches.dsc | object | `{"managementState":"Managed","workbenchNamespace":null}` | DSC configuration for Workbenches |
+| components.workbenches.dsc | object | `{"managementState":"Managed","workbenchNamespace":"opendatahub"}` | DSC configuration for Workbenches |
 | components.workbenches.dsc.managementState | string | `"Managed"` | Management state for Workbenches (Managed or Removed) |
-| components.workbenches.dsc.workbenchNamespace | string | `nil` | Workbench namespace for Workbenches (overrides defaults) |
+| components.workbenches.dsc.workbenchNamespace | string | `"opendatahub"` | Workbench namespace for Workbenches (overrides defaults) |
 | dependencies.certManager | object | `{"dependencies":{},"enabled":"auto","olm":{"channel":"stable-v1","name":"openshift-cert-manager-operator","namespace":"cert-manager-operator"}}` | Cert Manager operator |
 | dependencies.certManager.dependencies | object | `{}` | Dependencies required by cert-manager |
 | dependencies.certManager.enabled | string | `"auto"` | Enable cert-manager: auto (if needed), true (always), false (never) |
@@ -72,14 +70,18 @@ A Helm chart for installing ODH/RHOAI dependencies and component configurations
 | dependencies.tempo | object | `{"dependencies":{"opentelemetry":true},"enabled":"auto","olm":{"channel":"stable","name":"tempo-product","namespace":"openshift-tempo-operator"}}` | Tempo operator |
 | dependencies.tempo.dependencies | object | `{"opentelemetry":true}` | Dependencies required by tempo |
 | dependencies.tempo.enabled | string | `"auto"` | Enable tempo: auto (if needed), true (always), false (never) |
+| displayName | string | `"OpenDataHub"` |  |
 | global.installationType | string | `"olm"` | Installation type for dependencies (currently only olm is supported) |
 | global.labels | object | `{}` | Common labels applied to all resources |
 | global.olm.installPlanApproval | string | `"Automatic"` | Install plan approval mode (Automatic or Manual) |
 | global.olm.source | string | `"redhat-operators"` | Default catalog source for OLM subscriptions |
 | global.olm.sourceNamespace | string | `"openshift-marketplace"` | Namespace of the catalog source |
 | global.skipCrdCheck | bool | `false` | Skip CRD existence check - render all CRs regardless. Set to true for ArgoCD or when running helm multiple times |
+| operator.applicationsNamespace | string | `"opendatahub"` |  |
 | operator.enabled | bool | `true` | Enable operator installation |
-| operator.odh | object | `{"applicationsNamespace":"opendatahub","monitoringNamespace":"opendatahub","olm":{"channel":"fast-3","name":"opendatahub-operator","namespace":"opendatahub-operator-system","source":"community-operators"}}` | ODH operator settings |
-| operator.rhoai | object | `{"applicationsNamespace":"redhat-ods-applications","monitoringNamespace":"redhat-ods-monitoring","olm":{"channel":"fast-3.x","name":"rhods-operator","namespace":"redhat-ods-operator","source":"redhat-operators"}}` | RHOAI operator settings |
-| operator.type | string | `"odh"` | Operator type: odh (Open Data Hub) or rhoai (Red Hat OpenShift AI) |
+| operator.monitoringNamespace | string | `"opendatahub"` |  |
+| operator.olm.channel | string | `"fast-3"` |  |
+| operator.olm.name | string | `"opendatahub-operator"` |  |
+| operator.olm.namespace | string | `"opendatahub-operator-system"` |  |
+| operator.olm.source | string | `"community-operators"` |  |
 

--- a/chart/rhoai-values.yaml
+++ b/chart/rhoai-values.yaml
@@ -1,0 +1,20 @@
+displayName: OpenshiftAI
+
+operator:
+  monitoringNamespace: redhat-ods-monitoring
+  applicationsNamespace: redhat-ods-applications
+
+  olm:
+    channel: fast-3.x
+    name: rhods-operator
+    namespace: redhat-ods-operator
+    source: redhat-operators
+
+components:
+  modelregistry:
+    dsc:
+      registriesNamespace: rhoai-model-registries
+
+  workbenches:
+    dsc:
+      workbenchNamespace: rhods-notebooks

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,10 +1,8 @@
-{{- $operatorType := .Values.operator.type }}
-
-🎉 {{ $operatorType | upper }} Chart installed successfully!
+🎉 {{ .Values.displayName }} Chart installed successfully!
 
 === Installation Summary ===
 
-Operator: {{ $operatorType | upper }}
+Operator: {{ .Values.displayName }}
 Namespace: {{ .Release.Namespace }}
 
 === Enabled Components ===

--- a/chart/templates/definitions/_helpers.tpl
+++ b/chart/templates/definitions/_helpers.tpl
@@ -197,12 +197,7 @@ Arguments (passed as dict):
   - root: root context ($)
 */}}
 {{- define "rhoai-dependencies.componentDSCConfig" -}}
-{{- $operatorType := .root.Values.operator.type -}}
 {{- $dsc := .component.dsc | default dict -}}
-{{- $defaults := dict -}}
-{{- if and .component.defaults (index .component.defaults $operatorType) -}}
-  {{- $defaults = index .component.defaults $operatorType -}}
-{{- end -}}
-{{- merge $dsc $defaults | toYaml -}}
+{{- merge $dsc | toYaml -}}
 {{- end }}
 

--- a/chart/templates/operator/dscinitialization.yaml
+++ b/chart/templates/operator/dscinitialization.yaml
@@ -2,8 +2,7 @@
 DSCInitialization configuration
 */ -}}
 {{- if include "rhoai-dependencies.crdExists" (dict "crdName" "dscinitializations.dscinitialization.opendatahub.io" "root" $) }}
-{{- $operatorType := .Values.operator.type -}}
-{{- $operatorConfig := index .Values.operator $operatorType -}}
+{{- $operatorConfig := .Values.operator -}}
 apiVersion: dscinitialization.opendatahub.io/v2
 kind: DSCInitialization
 metadata:

--- a/chart/templates/operator/operator.yaml
+++ b/chart/templates/operator/operator.yaml
@@ -3,8 +3,7 @@ ODH/RHOAI Operator Installation
 Installs either Open Data Hub or Red Hat OpenShift AI operator via OLM
 */ -}}
 {{- if .Values.operator.enabled }}
-{{- $operatorType := .Values.operator.type -}}
-{{- $operatorConfig := index .Values.operator $operatorType -}}
+{{- $operatorConfig := .Values.operator -}}
 {{- $installType := include "rhoai-dependencies.installationType" (dict "dependency" $operatorConfig "global" .Values.global) -}}
 {{- if eq $installType "olm" }}
 {{- $config := dict "env" (list (dict "name" "DISABLE_DSC_CONFIG" "value" "true")) -}}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4,6 +4,10 @@
   "description": "Configuration values for the RHOAI Dependencies Helm chart",
   "type": "object",
   "properties": {
+    "displayName": {
+      "type": "string",
+      "description": "Display name for the chart"
+    },
     "global": {
       "type": "object",
       "description": "Global settings applied to all resources",
@@ -61,22 +65,19 @@
           "default": true,
           "description": "Enable operator installation"
         },
-        "type": {
+        "monitoringNamespace": {
           "type": "string",
-          "enum": ["odh", "rhoai"],
-          "default": "rhoai",
-          "description": "Operator type to install: odh (Open Data Hub) or rhoai (Red Hat OpenShift AI)"
+          "description": "Namespace for monitoring components (used in DSCInitialization)"
         },
-        "odh": {
-          "$ref": "#/definitions/operatorConfig",
-          "description": "ODH operator settings"
+        "applicationsNamespace": {
+          "type": "string",
+          "description": "Namespace for applications (used in DSCInitialization)"
         },
-        "rhoai": {
-          "$ref": "#/definitions/operatorConfig",
-          "description": "RHOAI operator settings"
+        "olm": {
+          "$ref": "#/definitions/olmConfig"
         }
       },
-      "required": ["enabled", "type"],
+      "required": ["enabled"],
       "additionalProperties": false
     },
     "components": {
@@ -146,41 +147,31 @@
       "default": "Removed",
       "description": "Management state for component in DSC. Managed enables components and auto dependencies management, Removed does not."
     },
-    "operatorConfig": {
+    "dependencyDeps": {
       "type": "object",
-      "description": "Operator installation configuration",
+      "description": "Boolean map of dependencies required by this dependency",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "componentDeps": {
+      "type": "object",
+      "description": "Boolean map of dependencies required by this component",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "operatorTypeDefaults": {
+      "type": "object",
+      "description": "Operator-type-specific defaults for dsc fields",
       "properties": {
-        "monitoringNamespace": {
-          "type": "string",
-          "description": "Namespace for monitoring components (used in DSCInitialization)"
-        },
-        "applicationsNamespace": {
-          "type": "string",
-          "description": "Namespace for applications (used in DSCInitialization)"
-        },
-        "olm": {
+        "odh": {
           "type": "object",
-          "description": "OLM settings for the operator",
-          "properties": {
-            "channel": {
-              "type": "string",
-              "description": "Subscription channel"
-            },
-            "name": {
-              "type": "string",
-              "description": "Operator name in the catalog"
-            },
-            "namespace": {
-              "type": "string",
-              "description": "Namespace where the operator will be installed"
-            },
-            "source": {
-              "type": "string",
-              "description": "Catalog source"
-            }
-          },
-          "required": ["channel", "name", "namespace", "source"],
-          "additionalProperties": false
+          "additionalProperties": true
+        },
+        "rhoai": {
+          "type": "object",
+          "additionalProperties": true
         }
       },
       "additionalProperties": false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,3 +1,5 @@
+displayName: OpenDataHub
+
 global:
   # -- Installation type for dependencies (currently only olm is supported)
   installationType: olm
@@ -24,30 +26,14 @@ operator:
   # -- Enable operator installation
   enabled: true
 
-  # -- Operator type: odh (Open Data Hub) or rhoai (Red Hat OpenShift AI)
-  type: odh
+  monitoringNamespace: opendatahub
+  applicationsNamespace: opendatahub
 
-  # -- ODH operator settings
-  odh:
-    monitoringNamespace: opendatahub
-    applicationsNamespace: opendatahub
-
-    olm:
-      channel: fast-3
-      name: opendatahub-operator
-      namespace: opendatahub-operator-system
-      source: community-operators
-
-  # -- RHOAI operator settings
-  rhoai:
-    monitoringNamespace: redhat-ods-monitoring
-    applicationsNamespace: redhat-ods-applications
-
-    olm:
-      channel: fast-3.x
-      name: rhods-operator
-      namespace: redhat-ods-operator
-      source: redhat-operators
+  olm:
+    channel: fast-3
+    name: opendatahub-operator
+    namespace: opendatahub-operator-system
+    source: community-operators
 
 # =============================================================================
 # COMPONENTS - High-level features that auto-enable their dependencies
@@ -118,13 +104,7 @@ components:
       # -- Management state for Model Registry (Managed or Removed)
       managementState: Managed
       # -- Registries namespace for Model Registry (overrides defaults)
-      registriesNamespace:
-    # -- Operator-type-specific defaults for dsc fields
-    defaults:
-      odh:
-        registriesNamespace: odh-model-registry
-      rhoai:
-        registriesNamespace: rhoai-model-registries
+      registriesNamespace: odh-model-registry
 
   # -- Workbenches component
   workbenches:
@@ -135,13 +115,7 @@ components:
       # -- Management state for Workbenches (Managed or Removed)
       managementState: Managed
       # -- Workbench namespace for Workbenches (overrides defaults)
-      workbenchNamespace:
-    # -- Operator-type-specific defaults for dsc fields
-    defaults:
-      odh:
-        workbenchNamespace: opendatahub
-      rhoai:
-        workbenchNamespace: rhods-notebooks
+      workbenchNamespace: opendatahub
 
 # =============================================================================
 # DEPENDENCIES - Operators required by components


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In this PR, an alternative idea on how to manage odh and rhoai installation.

With this solution, we could release 2 different helm chart:

1. helm chart for odh installation, which defaults to odh values.yaml
2. helm chart for rhoai installation. Once we publish the chart, we could merge the `values.yaml` with `rhoai-values.yaml` and rename the chart itself. To merge values, it could be done with something like: `yq -n 'load("chart/values.yaml") * load("chart/rhoai-values.yaml")' > merged-values.yaml`