### PR TITLE
Add Training Operator chart

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -101,6 +101,7 @@ High-level features that:
 | `modelregistry` | Model Registry | Managed | - |
 | `ray` | Ray distributed computing | Managed | certManager |
 | `trainer` | Trainer | Managed | certManager, jobSet |
+| `trainingoperator` | Kubeflow Training Operator | Removed | - |
 | `trustyai` | TrustyAI | Managed | - |
 | `workbenches` | Workbenches | Managed | - |
 

--- a/chart/api-docs.md
+++ b/chart/api-docs.md
@@ -47,6 +47,10 @@ A Helm chart for installing ODH/RHOAI dependencies and component configurations
 | components.trainer.dependencies | object | `{"certManager":true,"jobSet":true}` | Dependencies required by Trainer |
 | components.trainer.dsc | object | `{"managementState":"Managed"}` | DSC configuration for Trainer |
 | components.trainer.dsc.managementState | string | `"Managed"` | Management state for Trainer (Managed or Removed) |
+| components.trainingoperator | object | `{"dependencies":{},"dsc":{"managementState":"Removed"}}` | Kubeflow Training Operator component |
+| components.trainingoperator.dependencies | object | `{}` | Dependencies required by Kubeflow Training Operator |
+| components.trainingoperator.dsc | object | `{"managementState":"Removed"}` | DSC configuration for Kubeflow Training Operator |
+| components.trainingoperator.dsc.managementState | string | `"Removed"` | Management state for Kubeflow Training Operator (Managed or Removed) |
 | components.trustyai | object | `{"dependencies":{},"dsc":{"eval":{"lmeval":{"permitCodeExecution":"deny","permitOnline":"deny"}},"managementState":"Managed"}}` | TrustyAI component |
 | components.trustyai.dependencies | object | `{}` | Dependencies required by TrustyAI |
 | components.trustyai.dsc | object | `{"eval":{"lmeval":{"permitCodeExecution":"deny","permitOnline":"deny"}},"managementState":"Managed"}` | DSC configuration for TrustyAI |

--- a/chart/templates/operator/datasciencecluster.yaml
+++ b/chart/templates/operator/datasciencecluster.yaml
@@ -29,6 +29,8 @@ spec:
       {{- include "rhoai-dependencies.componentDSCConfig" (dict "component" .Values.components.ray "root" $) | nindent 6 }}
     trainer:
       {{- include "rhoai-dependencies.componentDSCConfig" (dict "component" .Values.components.trainer "root" $) | nindent 6 }}
+    trainingoperator:
+      {{- include "rhoai-dependencies.componentDSCConfig" (dict "component" .Values.components.trainingoperator "root" $) | nindent 6 }}
     trustyai:
       {{- include "rhoai-dependencies.componentDSCConfig" (dict "component" .Values.components.trustyai "root" $) | nindent 6 }}
     workbenches:

--- a/chart/test/snapshots/skip-crd-check-odh.snap.yaml
+++ b/chart/test/snapshots/skip-crd-check-odh.snap.yaml
@@ -114,6 +114,8 @@ spec:
       managementState: Managed
     trainer:
       managementState: Managed
+    trainingoperator:
+      managementState: Removed
     trustyai:
       eval:
         lmeval:

--- a/chart/test/snapshots/skip-crd-check-rhoai.snap.yaml
+++ b/chart/test/snapshots/skip-crd-check-rhoai.snap.yaml
@@ -114,6 +114,8 @@ spec:
       managementState: Managed
     trainer:
       managementState: Managed
+    trainingoperator:
+      managementState: Removed
     trustyai:
       eval:
         lmeval:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -110,6 +110,9 @@
         "trainer": {
           "$ref": "#/definitions/component"
         },
+        "trainingoperator": {
+          "$ref": "#/definitions/component"
+        },
         "trustyai": {
           "$ref": "#/definitions/trustyaiComponent"
         },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -158,6 +158,15 @@ components:
       # -- Management state for Trainer (Managed or Removed)
       managementState: Managed
 
+  # -- Kubeflow Training Operator component
+  trainingoperator:
+    # -- Dependencies required by Kubeflow Training Operator
+    dependencies: {}
+    # -- DSC configuration for Kubeflow Training Operator
+    dsc:
+      # -- Management state for Kubeflow Training Operator (Managed or Removed)
+      managementState: Removed
+
   # -- TrustyAI component
   trustyai:
     # -- Dependencies required by TrustyAI


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add Kubeflow Training Operator to the helm chart

JIRA ref: [RHOAIENG-42187](https://issues.redhat.com/browse/RHOAIENG-42187)

## How Has This Been Tested?
Tested helm installation on cluster

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation entry for the Kubeflow Training Operator, marked as Removed.

* **Chores**
  * Added the Training Operator to chart configuration and values schema with default Removed state.

* **Tests**
  * Updated chart snapshots to include the Training Operator entry with managementState set to Removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->