### PR TITLE
RHOAIENG-38764: add support to monitoring service and trustedCABundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,7 @@ helm-install-verify: ## Install helm chart and verify installation
 	@$(MAKE) prepare-authorino-tls KUSTOMIZE_MODE=false
 	@echo ""
 	@echo "=== Step 6: Final helm upgrade with wait condition ==="
+	$(K8S_CLI) describe nodes | grep -A 9 "Allocated resources:"
 	helm upgrade --install odh ./chart -n opendatahub-gitops --wait --timeout 10m
 
 .PHONY: helm-uninstall

--- a/chart/api-docs.md
+++ b/chart/api-docs.md
@@ -115,4 +115,7 @@ A Helm chart for installing ODH/RHOAI dependencies and component configurations
 | operator.odh | object | `{"applicationsNamespace":"opendatahub","monitoringNamespace":"opendatahub","olm":{"channel":"fast-3","name":"opendatahub-operator","namespace":"opendatahub-operator-system","source":"community-operators"}}` | ODH operator settings |
 | operator.rhoai | object | `{"applicationsNamespace":"redhat-ods-applications","monitoringNamespace":"redhat-ods-monitoring","olm":{"channel":"fast-3.x","name":"rhods-operator","namespace":"redhat-ods-operator","source":"redhat-operators"}}` | RHOAI operator settings |
 | operator.type | string | `"odh"` | Operator type: odh (Open Data Hub) or rhoai (Red Hat OpenShift AI) |
+| services.monitoring | object | `{"dependencies":{"clusterObservability":true,"opentelemetry":true,"tempo":true},"dsci":{"alerting":{},"managementState":"Managed","metrics":{},"traces":{}}}` | Monitoring service configuration |
+| trustedCABundle.customCABundle | string | `""` |  |
+| trustedCABundle.managementState | string | `"Managed"` |  |
 

--- a/chart/api-docs.md
+++ b/chart/api-docs.md
@@ -116,6 +116,7 @@ A Helm chart for installing ODH/RHOAI dependencies and component configurations
 | operator.rhoai | object | `{"applicationsNamespace":"redhat-ods-applications","monitoringNamespace":"redhat-ods-monitoring","olm":{"channel":"fast-3.x","name":"rhods-operator","namespace":"redhat-ods-operator","source":"redhat-operators"}}` | RHOAI operator settings |
 | operator.type | string | `"odh"` | Operator type: odh (Open Data Hub) or rhoai (Red Hat OpenShift AI) |
 | services.monitoring | object | `{"dependencies":{"clusterObservability":true,"opentelemetry":true,"tempo":true},"dsci":{"alerting":{},"managementState":"Managed","metrics":{},"traces":{}}}` | Monitoring service configuration |
-| trustedCABundle.customCABundle | string | `""` |  |
-| trustedCABundle.managementState | string | `"Managed"` |  |
+| trustedCABundle | object | `{"customCABundle":"","managementState":"Managed"}` | Trusted CA bundle configuration |
+| trustedCABundle.customCABundle | string | `""` | A custom CA bundle that will be available for all components in the Data Science Cluster (DSC). |
+| trustedCABundle.managementState | string | `"Managed"` | Management state for trusted CA bundle (Managed or Removed) |
 

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -16,7 +16,7 @@ Namespace: {{ .Release.Namespace }}
 === Enabled Dependencies ===
 
 {{- range $name, $dep := .Values.dependencies }}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" $name "dependency" $dep "dependencies" $.Values.dependencies "components" $.Values.components) }}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" $name "dependency" $dep "dependencies" $.Values.dependencies "components" $.Values.components "services" $.Values.services) }}
 {{- if eq $shouldInstall "true" }}
   - {{ $name }}
 {{- end }}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -13,6 +13,14 @@ Namespace: {{ .Release.Namespace }}
   - {{ $name }}: {{ $comp.dsc.managementState }}
 {{- end }}
 
+=== Enabled Services ===
+
+{{- range $name, $svc := .Values.services }}
+{{- if $svc.dsci }}
+  - {{ $name }}: {{ $svc.dsci.managementState }}
+{{- end }}
+{{- end }}
+
 === Enabled Dependencies ===
 
 {{- range $name, $dep := .Values.dependencies }}

--- a/chart/templates/dependencies/cert-manager/operator.yaml
+++ b/chart/templates/dependencies/cert-manager/operator.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.certManager -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "certManager" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "certManager" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- $installType := include "rhoai-dependencies.installationType" (dict "dependency" $dep "global" .Values.global) -}}
 {{- if eq $installType "olm" }}

--- a/chart/templates/dependencies/cluster-observability/operator.yaml
+++ b/chart/templates/dependencies/cluster-observability/operator.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.clusterObservability -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "clusterObservability" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "clusterObservability" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- $installType := include "rhoai-dependencies.installationType" (dict "dependency" $dep "global" .Values.global) -}}
 {{- if eq $installType "olm" }}

--- a/chart/templates/dependencies/custom-metrics-autoscaler/operator.yaml
+++ b/chart/templates/dependencies/custom-metrics-autoscaler/operator.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.customMetricsAutoscaler -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "customMetricsAutoscaler" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "customMetricsAutoscaler" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- $installType := include "rhoai-dependencies.installationType" (dict "dependency" $dep "global" .Values.global) -}}
 {{- if eq $installType "olm" }}

--- a/chart/templates/dependencies/job-set/config.yaml
+++ b/chart/templates/dependencies/job-set/config.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.jobSet -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "jobSet" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "jobSet" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if include "rhoai-dependencies.crdExists" (dict "crdName" "jobsetoperators.operator.openshift.io" "root" $) }}
 apiVersion: operator.openshift.io/v1

--- a/chart/templates/dependencies/job-set/operator.yaml
+++ b/chart/templates/dependencies/job-set/operator.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.jobSet -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "jobSet" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "jobSet" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- $installType := include "rhoai-dependencies.installationType" (dict "dependency" $dep "global" .Values.global) -}}
 {{- if eq $installType "olm" }}

--- a/chart/templates/dependencies/kueue/config.yaml
+++ b/chart/templates/dependencies/kueue/config.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.kueue -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "kueue" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "kueue" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if include "rhoai-dependencies.crdExists" (dict "crdName" "kueues.kueue.openshift.io" "root" $) }}
 apiVersion: kueue.openshift.io/v1

--- a/chart/templates/dependencies/kueue/operator.yaml
+++ b/chart/templates/dependencies/kueue/operator.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.kueue -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "kueue" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "kueue" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- $installType := include "rhoai-dependencies.installationType" (dict "dependency" $dep "global" .Values.global) -}}
 {{- if eq $installType "olm" }}

--- a/chart/templates/dependencies/leader-worker-set/config.yaml
+++ b/chart/templates/dependencies/leader-worker-set/config.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.leaderWorkerSet -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "leaderWorkerSet" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "leaderWorkerSet" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if include "rhoai-dependencies.crdExists" (dict "crdName" "leaderworkersetoperators.operator.openshift.io" "root" $) }}
 apiVersion: operator.openshift.io/v1

--- a/chart/templates/dependencies/leader-worker-set/operator.yaml
+++ b/chart/templates/dependencies/leader-worker-set/operator.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.leaderWorkerSet -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "leaderWorkerSet" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "leaderWorkerSet" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- $installType := include "rhoai-dependencies.installationType" (dict "dependency" $dep "global" .Values.global) -}}
 {{- if eq $installType "olm" }}

--- a/chart/templates/dependencies/nfd/config.yaml
+++ b/chart/templates/dependencies/nfd/config.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.nfd -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "nfd" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "nfd" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if include "rhoai-dependencies.crdExists" (dict "crdName" "nodefeaturediscoveries.nfd.openshift.io" "root" $) }}
 {{- if and $dep.config $dep.config.spec }}

--- a/chart/templates/dependencies/nfd/operator.yaml
+++ b/chart/templates/dependencies/nfd/operator.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.nfd -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "nfd" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "nfd" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- $installType := include "rhoai-dependencies.installationType" (dict "dependency" $dep "global" .Values.global) -}}
 {{- if eq $installType "olm" }}

--- a/chart/templates/dependencies/nvidia-gpu-operator/config.yaml
+++ b/chart/templates/dependencies/nvidia-gpu-operator/config.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.nvidiaGPUOperator -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "nvidiaGPUOperator" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "nvidiaGPUOperator" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if include "rhoai-dependencies.crdExists" (dict "crdName" "clusterpolicies.nvidia.com" "root" $) }}
 {{- if and $dep.config $dep.config.spec }}

--- a/chart/templates/dependencies/nvidia-gpu-operator/operator.yaml
+++ b/chart/templates/dependencies/nvidia-gpu-operator/operator.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.nvidiaGPUOperator -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "nvidiaGPUOperator" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "nvidiaGPUOperator" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- $installType := include "rhoai-dependencies.installationType" (dict "dependency" $dep "global" .Values.global) -}}
 {{- if eq $installType "olm" }}

--- a/chart/templates/dependencies/opentelemetry/operator.yaml
+++ b/chart/templates/dependencies/opentelemetry/operator.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.opentelemetry -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "opentelemetry" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "opentelemetry" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- $installType := include "rhoai-dependencies.installationType" (dict "dependency" $dep "global" .Values.global) -}}
 {{- if eq $installType "olm" }}

--- a/chart/templates/dependencies/rhcl/authorino-tls.yaml
+++ b/chart/templates/dependencies/rhcl/authorino-tls.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.rhcl -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "rhcl" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "rhcl" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if and $dep.config $dep.config.tlsEnabled }}
 {{- if include "rhoai-dependencies.crdExists" (dict "crdName" "authorinos.operator.authorino.kuadrant.io" "root" $) }}

--- a/chart/templates/dependencies/rhcl/config.yaml
+++ b/chart/templates/dependencies/rhcl/config.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.rhcl -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "rhcl" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "rhcl" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if include "rhoai-dependencies.crdExists" (dict "crdName" "kuadrants.kuadrant.io" "root" $) }}
 apiVersion: kuadrant.io/v1beta1

--- a/chart/templates/dependencies/rhcl/operator.yaml
+++ b/chart/templates/dependencies/rhcl/operator.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.rhcl -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "rhcl" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "rhcl" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- $installType := include "rhoai-dependencies.installationType" (dict "dependency" $dep "global" .Values.global) -}}
 {{- if eq $installType "olm" }}

--- a/chart/templates/dependencies/tempo/operator.yaml
+++ b/chart/templates/dependencies/tempo/operator.yaml
@@ -1,5 +1,5 @@
 {{- $dep := .Values.dependencies.tempo -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "tempo" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "tempo" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
 {{- if eq $shouldInstall "true" }}
 {{- $installType := include "rhoai-dependencies.installationType" (dict "dependency" $dep "global" .Values.global) -}}
 {{- if eq $installType "olm" }}

--- a/chart/templates/operator/dscinitialization.yaml
+++ b/chart/templates/operator/dscinitialization.yaml
@@ -22,6 +22,6 @@ spec:
     {{- end }}
   applicationsNamespace: {{ $operatorConfig.applicationsNamespace }}
   trustedCABundle:
-    managementState: "Managed"
-    customCABundle: ""
+    managementState: {{ .Values.trustedCABundle.managementState }}
+    customCABundle: {{ .Values.trustedCABundle.customCABundle }}
 {{- end }}

--- a/chart/templates/operator/dscinitialization.yaml
+++ b/chart/templates/operator/dscinitialization.yaml
@@ -12,9 +12,14 @@ metadata:
   name: default-dsci
 spec:
   monitoring:
-    managementState: "Managed"
+    managementState: {{ .Values.services.monitoring.dsci.managementState }}
     namespace: {{ $operatorConfig.monitoringNamespace }}
-    metrics: {}
+  {{- range $key, $value := .Values.services.monitoring.dsci }}
+    {{- if and (ne $key "managementState") (not (empty $value)) }}
+      {{ $key }}:
+        {{- $value | toYaml | nindent 6 }}
+      {{- end }}
+    {{- end }}
   applicationsNamespace: {{ $operatorConfig.applicationsNamespace }}
   trustedCABundle:
     managementState: "Managed"

--- a/chart/test/snapshots/all-components-managed.snap.yaml
+++ b/chart/test/snapshots/all-components-managed.snap.yaml
@@ -121,8 +121,8 @@ spec:
     namespace: opendatahub
   applicationsNamespace: opendatahub
   trustedCABundle:
-    managementState: "Managed"
-    customCABundle: ""
+    managementState: Managed
+    customCABundle:
 ---
 # Source: odh-rhoai-chart/templates/operator/datasciencecluster.yaml
 apiVersion: datasciencecluster.opendatahub.io/v2

--- a/chart/test/snapshots/all-components-managed.snap.yaml
+++ b/chart/test/snapshots/all-components-managed.snap.yaml
@@ -8,6 +8,15 @@ metadata:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
 ---
+# Source: odh-rhoai-chart/templates/dependencies/cluster-observability/operator.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cluster-observability-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: odh-rhoai-chart/templates/dependencies/custom-metrics-autoscaler/operator.yaml
 apiVersion: v1
 kind: Namespace
@@ -62,11 +71,29 @@ metadata:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
 ---
+# Source: odh-rhoai-chart/templates/dependencies/opentelemetry/operator.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-opentelemetry-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: odh-rhoai-chart/templates/dependencies/tempo/operator.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-tempo-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -90,9 +117,8 @@ metadata:
   name: default-dsci
 spec:
   monitoring:
-    managementState: "Managed"
+    managementState: Managed
     namespace: opendatahub
-    metrics: {}
   applicationsNamespace: opendatahub
   trustedCABundle:
     managementState: "Managed"
@@ -214,6 +240,18 @@ metadata:
 spec:
   upgradeStrategy: Default
 ---
+# Source: odh-rhoai-chart/templates/dependencies/cluster-observability/operator.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cluster-observability-operator
+  namespace: openshift-cluster-observability-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  upgradeStrategy: Default
+---
 # Source: odh-rhoai-chart/templates/dependencies/custom-metrics-autoscaler/operator.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -294,12 +332,36 @@ spec:
   targetNamespaces:
     - nvidia-gpu-operator
 ---
+# Source: odh-rhoai-chart/templates/dependencies/opentelemetry/operator.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: opentelemetry-product
+  namespace: openshift-opentelemetry-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  upgradeStrategy: Default
+---
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: rhcl-operator
   namespace: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  upgradeStrategy: Default
+---
+# Source: odh-rhoai-chart/templates/dependencies/tempo/operator.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: tempo-product
+  namespace: openshift-tempo-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -331,6 +393,22 @@ spec:
   channel: stable-v1
   installPlanApproval: Automatic
   name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+# Source: odh-rhoai-chart/templates/dependencies/cluster-observability/operator.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-observability-operator
+  namespace: openshift-cluster-observability-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cluster-observability-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ---
@@ -430,6 +508,22 @@ spec:
   source: certified-operators
   sourceNamespace: openshift-marketplace
 ---
+# Source: odh-rhoai-chart/templates/dependencies/opentelemetry/operator.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opentelemetry-product
+  namespace: openshift-opentelemetry-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: opentelemetry-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -443,6 +537,22 @@ spec:
   channel: stable
   installPlanApproval: Automatic
   name: rhcl-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+# Source: odh-rhoai-chart/templates/dependencies/tempo/operator.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: tempo-product
+  namespace: openshift-tempo-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: tempo-product
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ---

--- a/chart/test/snapshots/default.snap.yaml
+++ b/chart/test/snapshots/default.snap.yaml
@@ -8,6 +8,15 @@ metadata:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
 ---
+# Source: odh-rhoai-chart/templates/dependencies/cluster-observability/operator.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cluster-observability-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: odh-rhoai-chart/templates/dependencies/custom-metrics-autoscaler/operator.yaml
 apiVersion: v1
 kind: Namespace
@@ -44,11 +53,29 @@ metadata:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
 ---
+# Source: odh-rhoai-chart/templates/dependencies/opentelemetry/operator.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-opentelemetry-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: odh-rhoai-chart/templates/dependencies/tempo/operator.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-tempo-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -68,6 +95,18 @@ kind: OperatorGroup
 metadata:
   name: openshift-cert-manager-operator
   namespace: cert-manager-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  upgradeStrategy: Default
+---
+# Source: odh-rhoai-chart/templates/dependencies/cluster-observability/operator.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cluster-observability-operator
+  namespace: openshift-cluster-observability-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -126,12 +165,36 @@ spec:
   targetNamespaces:
     - openshift-lws-operator
 ---
+# Source: odh-rhoai-chart/templates/dependencies/opentelemetry/operator.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: opentelemetry-product
+  namespace: openshift-opentelemetry-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  upgradeStrategy: Default
+---
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: rhcl-operator
   namespace: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  upgradeStrategy: Default
+---
+# Source: odh-rhoai-chart/templates/dependencies/tempo/operator.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: tempo-product
+  namespace: openshift-tempo-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -163,6 +226,22 @@ spec:
   channel: stable-v1
   installPlanApproval: Automatic
   name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+# Source: odh-rhoai-chart/templates/dependencies/cluster-observability/operator.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-observability-operator
+  namespace: openshift-cluster-observability-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cluster-observability-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ---
@@ -230,6 +309,22 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ---
+# Source: odh-rhoai-chart/templates/dependencies/opentelemetry/operator.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opentelemetry-product
+  namespace: openshift-opentelemetry-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: opentelemetry-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -243,6 +338,22 @@ spec:
   channel: stable
   installPlanApproval: Automatic
   name: rhcl-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+# Source: odh-rhoai-chart/templates/dependencies/tempo/operator.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: tempo-product
+  namespace: openshift-tempo-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: tempo-product
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ---

--- a/chart/test/snapshots/skip-crd-check-odh.snap.yaml
+++ b/chart/test/snapshots/skip-crd-check-odh.snap.yaml
@@ -8,6 +8,15 @@ metadata:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
 ---
+# Source: odh-rhoai-chart/templates/dependencies/cluster-observability/operator.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cluster-observability-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: odh-rhoai-chart/templates/dependencies/custom-metrics-autoscaler/operator.yaml
 apiVersion: v1
 kind: Namespace
@@ -44,11 +53,29 @@ metadata:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
 ---
+# Source: odh-rhoai-chart/templates/dependencies/opentelemetry/operator.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-opentelemetry-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: odh-rhoai-chart/templates/dependencies/tempo/operator.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-tempo-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -72,9 +99,8 @@ metadata:
   name: default-dsci
 spec:
   monitoring:
-    managementState: "Managed"
+    managementState: Managed
     namespace: opendatahub
-    metrics: {}
   applicationsNamespace: opendatahub
   trustedCABundle:
     managementState: "Managed"
@@ -196,6 +222,18 @@ metadata:
 spec:
   upgradeStrategy: Default
 ---
+# Source: odh-rhoai-chart/templates/dependencies/cluster-observability/operator.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cluster-observability-operator
+  namespace: openshift-cluster-observability-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  upgradeStrategy: Default
+---
 # Source: odh-rhoai-chart/templates/dependencies/custom-metrics-autoscaler/operator.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -248,12 +286,36 @@ spec:
   targetNamespaces:
     - openshift-lws-operator
 ---
+# Source: odh-rhoai-chart/templates/dependencies/opentelemetry/operator.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: opentelemetry-product
+  namespace: openshift-opentelemetry-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  upgradeStrategy: Default
+---
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: rhcl-operator
   namespace: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  upgradeStrategy: Default
+---
+# Source: odh-rhoai-chart/templates/dependencies/tempo/operator.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: tempo-product
+  namespace: openshift-tempo-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -285,6 +347,22 @@ spec:
   channel: stable-v1
   installPlanApproval: Automatic
   name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+# Source: odh-rhoai-chart/templates/dependencies/cluster-observability/operator.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-observability-operator
+  namespace: openshift-cluster-observability-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cluster-observability-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ---
@@ -352,6 +430,22 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ---
+# Source: odh-rhoai-chart/templates/dependencies/opentelemetry/operator.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opentelemetry-product
+  namespace: openshift-opentelemetry-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: opentelemetry-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -365,6 +459,22 @@ spec:
   channel: stable
   installPlanApproval: Automatic
   name: rhcl-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+# Source: odh-rhoai-chart/templates/dependencies/tempo/operator.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: tempo-product
+  namespace: openshift-tempo-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: tempo-product
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ---

--- a/chart/test/snapshots/skip-crd-check-odh.snap.yaml
+++ b/chart/test/snapshots/skip-crd-check-odh.snap.yaml
@@ -103,8 +103,8 @@ spec:
     namespace: opendatahub
   applicationsNamespace: opendatahub
   trustedCABundle:
-    managementState: "Managed"
-    customCABundle: ""
+    managementState: Managed
+    customCABundle:
 ---
 # Source: odh-rhoai-chart/templates/operator/datasciencecluster.yaml
 apiVersion: datasciencecluster.opendatahub.io/v2

--- a/chart/test/snapshots/skip-crd-check-rhoai.snap.yaml
+++ b/chart/test/snapshots/skip-crd-check-rhoai.snap.yaml
@@ -8,6 +8,15 @@ metadata:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
 ---
+# Source: odh-rhoai-chart/templates/dependencies/cluster-observability/operator.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cluster-observability-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: odh-rhoai-chart/templates/dependencies/custom-metrics-autoscaler/operator.yaml
 apiVersion: v1
 kind: Namespace
@@ -44,11 +53,29 @@ metadata:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
 ---
+# Source: odh-rhoai-chart/templates/dependencies/opentelemetry/operator.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-opentelemetry-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: odh-rhoai-chart/templates/dependencies/tempo/operator.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-tempo-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -72,9 +99,8 @@ metadata:
   name: default-dsci
 spec:
   monitoring:
-    managementState: "Managed"
+    managementState: Managed
     namespace: redhat-ods-monitoring
-    metrics: {}
   applicationsNamespace: redhat-ods-applications
   trustedCABundle:
     managementState: "Managed"
@@ -196,6 +222,18 @@ metadata:
 spec:
   upgradeStrategy: Default
 ---
+# Source: odh-rhoai-chart/templates/dependencies/cluster-observability/operator.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cluster-observability-operator
+  namespace: openshift-cluster-observability-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  upgradeStrategy: Default
+---
 # Source: odh-rhoai-chart/templates/dependencies/custom-metrics-autoscaler/operator.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -248,12 +286,36 @@ spec:
   targetNamespaces:
     - openshift-lws-operator
 ---
+# Source: odh-rhoai-chart/templates/dependencies/opentelemetry/operator.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: opentelemetry-product
+  namespace: openshift-opentelemetry-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  upgradeStrategy: Default
+---
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: rhcl-operator
   namespace: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  upgradeStrategy: Default
+---
+# Source: odh-rhoai-chart/templates/dependencies/tempo/operator.yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: tempo-product
+  namespace: openshift-tempo-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -285,6 +347,22 @@ spec:
   channel: stable-v1
   installPlanApproval: Automatic
   name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+# Source: odh-rhoai-chart/templates/dependencies/cluster-observability/operator.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-observability-operator
+  namespace: openshift-cluster-observability-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cluster-observability-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ---
@@ -352,6 +430,22 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ---
+# Source: odh-rhoai-chart/templates/dependencies/opentelemetry/operator.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opentelemetry-product
+  namespace: openshift-opentelemetry-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: opentelemetry-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -365,6 +459,22 @@ spec:
   channel: stable
   installPlanApproval: Automatic
   name: rhcl-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+# Source: odh-rhoai-chart/templates/dependencies/tempo/operator.yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: tempo-product
+  namespace: openshift-tempo-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: tempo-product
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ---

--- a/chart/test/snapshots/skip-crd-check-rhoai.snap.yaml
+++ b/chart/test/snapshots/skip-crd-check-rhoai.snap.yaml
@@ -103,8 +103,8 @@ spec:
     namespace: redhat-ods-monitoring
   applicationsNamespace: redhat-ods-applications
   trustedCABundle:
-    managementState: "Managed"
-    customCABundle: ""
+    managementState: Managed
+    customCABundle:
 ---
 # Source: odh-rhoai-chart/templates/operator/datasciencecluster.yaml
 apiVersion: datasciencecluster.opendatahub.io/v2

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -79,6 +79,20 @@
       "required": ["enabled", "type"],
       "additionalProperties": false
     },
+    "trustedCABundle": {
+      "type": "object",
+      "description": "Trusted CA bundle configuration",
+      "properties": {
+        "managementState": {
+          "$ref": "#/definitions/defaultManagementState"
+        },
+        "customCABundle": {
+          "type": "string",
+          "description": "Custom CA bundle"
+        }
+      },
+      "additionalProperties": false
+    },
     "components": {
       "type": "object",
       "description": "High-level features that configure DSC managementState and auto-enable their dependencies.",
@@ -121,6 +135,26 @@
         },
         "llamastackoperator": {
           "$ref": "#/definitions/component"
+        }
+      },
+      "additionalProperties": false
+    },
+    "services": {
+      "type": "object",
+      "description": "Services configuration",
+      "properties": {
+        "monitoring": {
+          "type": "object",
+          "description": "Monitoring service configuration",
+          "properties": {
+            "dependencies": {
+              "$ref": "#/definitions/serviceDeps"
+            },
+            "dsci": {
+              "$ref": "#/definitions/monitoringConfig"
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -222,6 +256,13 @@
     "componentDeps": {
       "type": "object",
       "description": "Boolean map of dependencies required by this component",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "serviceDeps": {
+      "type": "object",
+      "description": "Boolean map of dependencies required by this service",
       "additionalProperties": {
         "type": "boolean"
       }
@@ -629,6 +670,32 @@
         }
       },
       "required": ["enabled"],
+      "additionalProperties": false
+    },
+    "monitoringConfig": {
+      "type": "object",
+      "description": "Monitoring configuration",
+      "properties": {
+        "managementState": {
+          "$ref": "#/definitions/defaultManagementState"
+        },
+        "metrics": {
+          "type": "object",
+          "description": "Metrics configuration"
+        },
+        "traces": {
+          "type": "object",
+          "description": "Traces configuration"
+        },
+        "alerting": {
+          "type": "object",
+          "description": "Alerting configuration"
+        },
+        "collectorReplicas": {
+          "type": "integer",
+          "description": "Collector replicas"
+        }
+      },
       "additionalProperties": false
     }
   },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -49,6 +49,23 @@ operator:
       namespace: redhat-ods-operator
       source: redhat-operators
 
+trustedCABundle:
+  managementState: Managed
+  customCABundle: ""
+
+services:
+  # -- Monitoring service configuration
+  monitoring:
+    dependencies:
+      clusterObservability: true
+      opentelemetry: true
+      tempo: true
+    dsci:
+      managementState: Managed
+      metrics: {}
+      traces: {}
+      alerting: {}
+
 # =============================================================================
 # COMPONENTS - High-level features that auto-enable their dependencies
 # Components configure the DataScienceCluster (DSC) managementState.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -49,8 +49,11 @@ operator:
       namespace: redhat-ods-operator
       source: redhat-operators
 
+# -- Trusted CA bundle configuration
 trustedCABundle:
+  # -- Management state for trusted CA bundle (Managed or Removed)
   managementState: Managed
+  # -- A custom CA bundle that will be available for all components in the Data Science Cluster (DSC).
   customCABundle: ""
 
 services:

--- a/scripts/wait-for-crds.sh
+++ b/scripts/wait-for-crds.sh
@@ -21,8 +21,8 @@ CRDS=(
     "leaderworkersetoperators.operator.openshift.io"
     "jobsetoperators.operator.openshift.io"
     "kuadrants.kuadrant.io"
-    "nodefeaturediscoveries.nfd.openshift.io"
-    "clusterpolicies.nvidia.com"
+    # "nodefeaturediscoveries.nfd.openshift.io"
+    # "clusterpolicies.nvidia.com"
     "datascienceclusters.datasciencecluster.opendatahub.io"
     "dscinitializations.dscinitialization.opendatahub.io"
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add support to manage DSCI configurations

Jira task: https://issues.redhat.com/browse/RHOAIENG-38764

## How Has This Been Tested?
With snapshot

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dependency checks now consider active services when deciding installs.
  * Added configurable services.monitoring and operator trusted CA bundle.

* **Behavioral Changes**
  * Chart rendering may add operator namespaces, OperatorGroups, and Subscriptions driven by service-aware dependency logic.
  * Initialization now sources monitoring values from the services config; monitoring metrics block adjusted.

* **Documentation**
  * API docs updated to include services.monitoring and trusted CA bundle fields.

* **Chores**
  * Startup script no longer waits for two specific CRDs; install verification prints node resource allocations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->