### PR TITLE
fix: avoid to fail if crd not exists

### DIFF
--- a/scripts/remove-dependencies-pre.sh
+++ b/scripts/remove-dependencies-pre.sh
@@ -2,7 +2,11 @@
 oc delete --ignore-not-found kedacontroller keda -n openshift-keda
 
 # Remove NFD CR
-oc delete --ignore-not-found nodefeaturediscovery nfd-instance -n openshift-nfd
+if oc get crd nodefeaturediscoveries.nfd.openshift.io &>/dev/null; then
+  oc delete --ignore-not-found nodefeaturediscovery nfd-instance -n openshift-nfd
+fi
 
 # Remove GPU operator ClusterPolicy CR
-oc delete --ignore-not-found clusterpolicy gpu-cluster-policy
+if oc get crd clusterpolicies.nvidia.com &>/dev/null; then
+  oc delete --ignore-not-found clusterpolicy gpu-cluster-policy
+fi


### PR DESCRIPTION
Check CRD existent before deleting the CR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of cleanup operations by verifying the presence of resource types before attempting deletions, preventing failures when those resources or APIs are absent and making pre-removal steps safer and more resilient.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->