### PR TITLE
 Add RHOAI operator Helm chart with Konflux build pipeline

### DIFF
--- a/.tekton/rhoai-operator-helm.yaml
+++ b/.tekton/rhoai-operator-helm.yaml
@@ -1,0 +1,200 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/odh-gitops?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: "{{revision}}"
+    build.appstudio.redhat.com/target_branch: "{{target_branch}}"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: opendatahub-poc
+    appstudio.openshift.io/component: poc-rhoai-operator-helm
+    pipelines.appstudio.openshift.io/type: build
+  name: poc-rhoai-operator-helm-on-push
+  namespace: open-data-hub-tenant
+spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-poc-rhoai-operator-helm
+  params:
+    - name: git-url
+      value: "{{source_url}}"
+    - name: revision
+      value: "{{revision}}"
+    - name: output-image
+      value: quay.io/redhat-user-workloads/open-data-hub-tenant/poc-rhoai-operator-helm:{{revision}}
+    - name: path-context
+      value: "charts/rhoai-operator"
+    - name: hermetic
+      value: "false"
+  pipelineSpec:
+    description: |
+      Pipeline for building the RHOAI operator Helm chart as an OCI artifact.
+    params:
+      - description: Source Repository URL
+        name: git-url
+        type: string
+      - default: ""
+        description: Revision of the Source Repository
+        name: revision
+        type: string
+      - description: Fully Qualified Output Image
+        name: output-image
+        type: string
+      - default: .
+        description: Path to the Helm chart directory
+        name: path-context
+        type: string
+      - default: "false"
+        description: Skip checks against built image
+        name: skip-checks
+        type: string
+      - default: "false"
+        description: Execute the build with network isolation
+        name: hermetic
+        type: string
+      - default: ""
+        description: Build dependencies to be prefetched by Cachi2
+        name: prefetch-input
+        type: string
+      - default: ""
+        description: Image tag expiration time
+        name: image-expires-after
+        type: string
+      - default: "false"
+        description: Build a source image
+        name: build-source-image
+        type: string
+    results:
+      - description: ""
+        name: IMAGE_URL
+        value: $(tasks.build-helm-chart.results.IMAGE_URL)
+      - description: ""
+        name: IMAGE_DIGEST
+        value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+      - description: ""
+        name: CHAINS-GIT_URL
+        value: $(tasks.clone-repository.results.url)
+      - description: ""
+        name: CHAINS-GIT_COMMIT
+        value: $(tasks.clone-repository.results.commit)
+    tasks:
+      - name: init
+        taskRef:
+          params:
+            - name: name
+              value: init
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-init:0.3@sha256:aa6f8632cc23d605c5942505ff1d00280db16a6fda5c4c56c4ed9ae936b5fbc6
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: clone-repository
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.revision)
+          - name: ociStorage
+            value: $(params.output-image).git
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+        runAfter:
+          - init
+        taskRef:
+          params:
+            - name: name
+              value: git-clone-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:306b69e6db435ad4a7cf258b6219d9b998eb37da44f5e9ac882ac86a08109154
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: basic-auth
+            workspace: git-auth
+      - name: prefetch-dependencies
+        params:
+          - name: input
+            value: $(params.prefetch-input)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+          - name: ociStorage
+            value: $(params.output-image).prefetch
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+        runAfter:
+          - clone-repository
+        taskRef:
+          params:
+            - name: name
+              value: prefetch-dependencies-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:c07551efbd7fc414ae1245ddd93579b00317fee0734980f539fd8aea3cfcb945
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: git-basic-auth
+            workspace: git-auth
+          - name: netrc
+            workspace: netrc
+      - name: build-helm-chart
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: CHART_CONTEXT
+            value: $(params.path-context)
+          - name: COMMIT_SHA
+            value: $(tasks.clone-repository.results.commit)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: VERSION_SUFFIX
+            value: ""
+        runAfter:
+          - prefetch-dependencies
+        taskRef:
+          params:
+            - name: name
+              value: build-helm-chart-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-build-helm-chart-oci-ta:0.3@sha256:23de031fcad1479aa718ddfa764ca0532452a2d75dd2f1c23161bd6142c7251a
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: build-source-image
+        params:
+          - name: BINARY_IMAGE
+            value: $(tasks.build-helm-chart.results.IMAGE_URL)
+          - name: BINARY_IMAGE_DIGEST
+            value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        runAfter:
+          - build-helm-chart
+        taskRef:
+          params:
+            - name: name
+              value: source-build-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:c35ba219390d77a48ee19347e5ee8d13e5c23e3984299e02291d6da1ed8a986c
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.build-source-image)
+            operator: in
+            values:
+              - "true"
+    workspaces:
+      - name: git-auth
+        optional: true
+      - name: netrc
+        optional: true
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: "{{ git_auth_secret }}"

--- a/charts/rhoai-operator/Chart.yaml
+++ b/charts/rhoai-operator/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: rhoai-operator
+description: OpenDataHub/RHOAI Operator for vanilla Kubernetes (without OLM)
+type: application
+version: 1.0.0
+appVersion: "3.4.0-ea.1"
+keywords:
+  - opendatahub
+  - rhoai
+  - operator
+  - kserve
+maintainers:
+  - name: Red Hat

--- a/charts/rhoai-operator/crds/customresourcedefinition-auths-services-platform-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-auths-services-platform-opendatahub-io.yaml
@@ -1,0 +1,144 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: auths.services.platform.opendatahub.io
+spec:
+  group: services.platform.opendatahub.io
+  names:
+    kind: Auth
+    listKind: AuthList
+    plural: auths
+    singular: auth
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Auth is the Schema for the auths API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AuthSpec defines the desired state of Auth
+              properties:
+                adminGroups:
+                  description: AdminGroups cannot contain 'system:authenticated' (security risk) or empty strings, and must not be empty
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-validations:
+                    - message: AdminGroups cannot be empty
+                      rule: size(self) > 0
+                    - message: AdminGroups cannot contain 'system:authenticated' or empty strings
+                      rule: self.all(group, group != 'system:authenticated' && group != '')
+                allowedGroups:
+                  description: AllowedGroups cannot contain empty strings, but 'system:authenticated' is allowed for general access
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-validations:
+                    - message: AllowedGroups cannot contain empty strings
+                      rule: self.all(group, group != '')
+              required:
+                - adminGroups
+                - allowedGroups
+              type: object
+            status:
+              description: AuthStatus defines the observed state of Auth
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: Auth name must be auth
+              rule: self.metadata.name == 'auth'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-dashboards-components-platform-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-dashboards-components-platform-opendatahub-io.yaml
@@ -1,0 +1,142 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: dashboards.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: Dashboard
+    listKind: DashboardList
+    plural: dashboards
+    singular: dashboard
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+        - description: URL
+          jsonPath: .status.url
+          name: URL
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Dashboard is the Schema for the dashboards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DashboardSpec defines the desired state of Dashboard (Dashboard CR only).
+              properties:
+                gateway:
+                  description: Gateway configuration for dashboard ingress (synced from GatewayConfig by the DSC controller when creating the Dashboard CR).
+                  properties:
+                    domain:
+                      description: |-
+                        Domain is the fully qualified domain name for the gateway.
+                        Example: "rhods-dashboard.apps.example.com"
+                      maxLength: 253
+                      pattern: ^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$
+                      type: string
+                  required:
+                    - domain
+                  type: object
+              type: object
+            status:
+              description: DashboardStatus defines the observed state of Dashboard
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                url:
+                  type: string
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: Dashboard name must be default-dashboard
+              rule: self.metadata.name == 'default-dashboard'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-datascienceclusters-datasciencecluster-opendatahub.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-datascienceclusters-datasciencecluster-opendatahub.yaml
@@ -1,0 +1,2023 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datascienceclusters.datasciencecluster.opendatahub.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: opendatahub-operator-controller-manager-webhook-service
+          namespace: opendatahub-operator
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+        - v1
+        - v2
+  group: datasciencecluster.opendatahub.io
+  names:
+    kind: DataScienceCluster
+    listKind: DataScienceClusterList
+    plural: datascienceclusters
+    shortNames:
+      - dsc
+    singular: datasciencecluster
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: DataScienceCluster is the Schema for the datascienceclusters API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DataScienceClusterSpec defines the desired state of the cluster.
+              properties:
+                components:
+                  description: Override and fine tune specific component configurations.
+                  properties:
+                    codeflare:
+                      description: |-
+                        CodeFlare component configuration.
+                        If CodeFlare Operator has been installed in the cluster, it should be uninstalled first before enabling component.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    dashboard:
+                      description: Dashboard component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    datasciencepipelines:
+                      description: DataSciencePipeline component configuration.
+                      properties:
+                        argoWorkflowsControllers:
+                          properties:
+                            managementState:
+                              default: Managed
+                              description: |-
+                                Set to one of the following values:
+
+                                - "Managed" : the operator is actively managing the bundled Argo Workflows controllers.
+                                              It will only upgrade the Argo Workflows controllers if it is safe to do so. This is the default
+                                              behavior.
+
+                                - "Removed" : the operator is not managing the bundled Argo Workflows controllers and will not install it.
+                                              If it is installed, the operator will remove it but will not remove other Argo Workflows
+                                              installations.
+                              enum:
+                                - Managed
+                                - Removed
+                              pattern: ^(Managed|Unmanaged|Force|Removed)$
+                              type: string
+                          type: object
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    feastoperator:
+                      description: Feast Operator component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    kserve:
+                      description: |-
+                        Kserve component configuration.
+                        Only RawDeployment mode is supported.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        modelsAsService:
+                          description: Configures and enables Models as a Service integration
+                          properties:
+                            managementState:
+                              default: Removed
+                              enum:
+                                - Managed
+                                - Removed
+                              pattern: ^(Managed|Unmanaged|Force|Removed)$
+                              type: string
+                          type: object
+                        nim:
+                          description: Configures and enables NVIDIA NIM integration
+                          properties:
+                            airGapped:
+                              default: false
+                              description: |-
+                                When true, NIM integration assumes an air-gapped cluster. External API calls
+                                and the NIM model list ConfigMap creation are skipped, while status conditions
+                                are marked successful with an air-gapped message.
+                              type: boolean
+                            managementState:
+                              default: Managed
+                              enum:
+                                - Managed
+                                - Removed
+                              pattern: ^(Managed|Unmanaged|Force|Removed)$
+                              type: string
+                          type: object
+                        rawDeploymentServiceConfig:
+                          default: Headless
+                          description: |-
+                            Configures the type of service that is created for InferenceServices using RawDeployment.
+                            The values for RawDeploymentServiceConfig can be "Headless" (default value) or "Headed".
+                            Headless: to set "ServiceClusterIPNone = true" in the 'inferenceservice-config' configmap for Kserve.
+                            Headed: to set "ServiceClusterIPNone = false" in the 'inferenceservice-config' configmap for Kserve.
+                          enum:
+                            - Headless
+                            - Headed
+                          type: string
+                      type: object
+                    kueue:
+                      description: Kueue component configuration.
+                      properties:
+                        defaultClusterQueueName:
+                          default: default
+                          description: Configures the automatically created cluster queue name.
+                          type: string
+                        defaultLocalQueueName:
+                          default: default
+                          description: Configures the automatically created, in the managed namespaces, local queue name.
+                          type: string
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed"   : the operator is actively managing the component and trying to keep it active.
+                                            It will only upgrade the component if it is safe to do so
+
+                            - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
+
+                            - "Removed"   : the operator is actively managing the component and will not install it,
+                                            or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Unmanaged
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    llamastackoperator:
+                      description: LlamaStack Operator component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    modelmeshserving:
+                      description: ModelMeshServing component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    modelregistry:
+                      description: ModelRegistry component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        registriesNamespace:
+                          default: odh-model-registries
+                          description: Namespace for model registries to be installed, configurable only once when model registry is enabled, defaults to "odh-model-registries"
+                          maxLength: 63
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                        - message: RegistriesNamespace is immutable when model registry is Managed
+                          rule: (!has(self.managementState) || self.managementState != 'Managed') || (oldSelf.registriesNamespace == '') || (!has(oldSelf.managementState) || oldSelf.managementState != 'Managed') || (self.registriesNamespace == oldSelf.registriesNamespace)
+                    ray:
+                      description: Ray component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    trainingoperator:
+                      description: Training Operator component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    trustyai:
+                      description: TrustyAI component configuration.
+                      properties:
+                        eval:
+                          description: Eval configuration for TrustyAI evaluations
+                          properties:
+                            lmeval:
+                              description: LMEval configuration for model evaluations
+                              properties:
+                                permitCodeExecution:
+                                  default: deny
+                                  description: PermitCodeExecution controls whether code execution is allowed during evaluations
+                                  enum:
+                                    - allow
+                                    - deny
+                                  type: string
+                                permitOnline:
+                                  default: deny
+                                  description: PermitOnline controls whether online access is allowed during evaluations
+                                  enum:
+                                    - allow
+                                    - deny
+                                  type: string
+                              type: object
+                          required:
+                            - lmeval
+                          type: object
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        workbenchNamespace:
+                          default: opendatahub
+                          description: Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to "opendatahub"
+                          maxLength: 63
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                          type: string
+                          x-kubernetes-validations:
+                            - message: WorkbenchNamespace is immutable
+                              rule: self == oldSelf
+                      type: object
+                  type: object
+              type: object
+            status:
+              description: DataScienceClusterStatus defines the observed state of DataScienceCluster.
+              properties:
+                components:
+                  description: Expose component's specific status
+                  properties:
+                    codeflare:
+                      description: CodeFlare component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    dashboard:
+                      description: Dashboard component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        url:
+                          type: string
+                      type: object
+                    datasciencepipelines:
+                      description: DataSciencePipeline component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    feastoperator:
+                      description: Feast Operator component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    kserve:
+                      description: Kserve component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    kueue:
+                      description: Kueue component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed"   : present for backwards compatibility with OLM upgrades, but not supported at runtime.
+                                            The operator will reject this value. Use "Unmanaged" or "Removed" instead.
+
+                            - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
+
+                            - "Removed"   : the operator is actively managing the component and will not install it,
+                                            or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Unmanaged
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    llamastackoperator:
+                      description: LlamaStack Operator component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    modelmeshserving:
+                      description: ModelMeshServing component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    modelregistry:
+                      description: ModelRegistry component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        registriesNamespace:
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    ray:
+                      description: Ray component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    trainingoperator:
+                      description: Training Operator component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    trustyai:
+                      description: TrustyAI component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    workbenches:
+                      description: Workbenches component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        workbenchNamespace:
+                          type: string
+                      type: object
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                errorMessage:
+                  type: string
+                installedComponents:
+                  additionalProperties:
+                    type: boolean
+                  description: List of components with status if installed or not
+                  type: object
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                relatedObjects:
+                  description: |-
+                    RelatedObjects is a list of objects created and maintained by this operator.
+                    Object references will be added to this list after they have been created AND found in the cluster.
+                  items:
+                    description: ObjectReference contains enough information to let you inspect or modify the referred object.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                release:
+                  description: Version and release type
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v2
+      schema:
+        openAPIV3Schema:
+          description: DataScienceCluster is the Schema for the datascienceclusters API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DataScienceClusterSpec defines the desired state of the cluster.
+              properties:
+                components:
+                  description: Override and fine tune specific component configurations.
+                  properties:
+                    aipipelines:
+                      description: AIPipelines component configuration.
+                      properties:
+                        argoWorkflowsControllers:
+                          properties:
+                            managementState:
+                              default: Managed
+                              description: |-
+                                Set to one of the following values:
+
+                                - "Managed" : the operator is actively managing the bundled Argo Workflows controllers.
+                                              It will only upgrade the Argo Workflows controllers if it is safe to do so. This is the default
+                                              behavior.
+
+                                - "Removed" : the operator is not managing the bundled Argo Workflows controllers and will not install it.
+                                              If it is installed, the operator will remove it but will not remove other Argo Workflows
+                                              installations.
+                              enum:
+                                - Managed
+                                - Removed
+                              pattern: ^(Managed|Unmanaged|Force|Removed)$
+                              type: string
+                          type: object
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    dashboard:
+                      description: Dashboard component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    feastoperator:
+                      description: Feast Operator component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    kserve:
+                      description: |-
+                        Kserve component configuration.
+                        Only RawDeployment mode is supported.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        modelsAsService:
+                          description: Configures and enables Models as a Service integration
+                          properties:
+                            managementState:
+                              default: Removed
+                              enum:
+                                - Managed
+                                - Removed
+                              pattern: ^(Managed|Unmanaged|Force|Removed)$
+                              type: string
+                          type: object
+                        nim:
+                          description: Configures and enables NVIDIA NIM integration
+                          properties:
+                            airGapped:
+                              default: false
+                              description: |-
+                                When true, NIM integration assumes an air-gapped cluster. External API calls
+                                and the NIM model list ConfigMap creation are skipped, while status conditions
+                                are marked successful with an air-gapped message.
+                              type: boolean
+                            managementState:
+                              default: Managed
+                              enum:
+                                - Managed
+                                - Removed
+                              pattern: ^(Managed|Unmanaged|Force|Removed)$
+                              type: string
+                          type: object
+                        rawDeploymentServiceConfig:
+                          default: Headless
+                          description: |-
+                            Configures the type of service that is created for InferenceServices using RawDeployment.
+                            The values for RawDeploymentServiceConfig can be "Headless" (default value) or "Headed".
+                            Headless: to set "ServiceClusterIPNone = true" in the 'inferenceservice-config' configmap for Kserve.
+                            Headed: to set "ServiceClusterIPNone = false" in the 'inferenceservice-config' configmap for Kserve.
+                          enum:
+                            - Headless
+                            - Headed
+                          type: string
+                      type: object
+                    kueue:
+                      description: Kueue component configuration.
+                      properties:
+                        defaultClusterQueueName:
+                          default: default
+                          description: Configures the automatically created cluster queue name.
+                          type: string
+                        defaultLocalQueueName:
+                          default: default
+                          description: Configures the automatically created, in the managed namespaces, local queue name.
+                          type: string
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed"   : present for backwards compatibility with OLM upgrades, but not supported at runtime.
+                                            The operator will reject this value. Use "Unmanaged" or "Removed" instead.
+
+                            - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
+
+                            - "Removed"   : the operator is actively managing the component and will not install it,
+                                            or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Unmanaged
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    llamastackoperator:
+                      description: LlamaStack Operator component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    mlflowoperator:
+                      description: MLflow Operator component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    modelregistry:
+                      description: ModelRegistry component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        registriesNamespace:
+                          default: odh-model-registries
+                          description: Namespace for model registries to be installed, configurable only once when model registry is enabled, defaults to "odh-model-registries"
+                          maxLength: 63
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                        - message: RegistriesNamespace is immutable when model registry is Managed
+                          rule: (!has(self.managementState) || self.managementState != 'Managed') || (oldSelf.registriesNamespace == '') || (!has(oldSelf.managementState) || oldSelf.managementState != 'Managed') || (self.registriesNamespace == oldSelf.registriesNamespace)
+                    ray:
+                      description: Ray component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    sparkoperator:
+                      description: SparkOperator component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    trainer:
+                      description: Trainer component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    trainingoperator:
+                      description: Training Operator component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    trustyai:
+                      description: TrustyAI component configuration.
+                      properties:
+                        eval:
+                          description: Eval configuration for TrustyAI evaluations
+                          properties:
+                            lmeval:
+                              description: LMEval configuration for model evaluations
+                              properties:
+                                permitCodeExecution:
+                                  default: deny
+                                  description: PermitCodeExecution controls whether code execution is allowed during evaluations
+                                  enum:
+                                    - allow
+                                    - deny
+                                  type: string
+                                permitOnline:
+                                  default: deny
+                                  description: PermitOnline controls whether online access is allowed during evaluations
+                                  enum:
+                                    - allow
+                                    - deny
+                                  type: string
+                              type: object
+                          required:
+                            - lmeval
+                          type: object
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches component configuration.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        workbenchNamespace:
+                          default: opendatahub
+                          description: Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to "opendatahub"
+                          maxLength: 63
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                          type: string
+                          x-kubernetes-validations:
+                            - message: WorkbenchNamespace is immutable
+                              rule: self == oldSelf
+                      type: object
+                  type: object
+              type: object
+            status:
+              description: DataScienceClusterStatus defines the observed state of DataScienceCluster.
+              properties:
+                components:
+                  description: Expose component's specific status
+                  properties:
+                    aipipelines:
+                      description: AIPipelines component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    dashboard:
+                      description: Dashboard component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        url:
+                          type: string
+                      type: object
+                    feastoperator:
+                      description: Feast Operator component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    kserve:
+                      description: Kserve component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    kueue:
+                      description: Kueue component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed"   : present for backwards compatibility with OLM upgrades, but not supported at runtime.
+                                            The operator will reject this value. Use "Unmanaged" or "Removed" instead.
+
+                            - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
+
+                            - "Removed"   : the operator is actively managing the component and will not install it,
+                                            or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Unmanaged
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    llamastackoperator:
+                      description: LlamaStack Operator component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    mlflowoperator:
+                      description: MLflow Operator component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    modelregistry:
+                      description: ModelRegistry component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        registriesNamespace:
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    ray:
+                      description: Ray component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    sparkoperator:
+                      description: SparkOperator component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    trainer:
+                      description: Trainer component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    trainingoperator:
+                      description: Training Operator component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    trustyai:
+                      description: TrustyAI component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    workbenches:
+                      description: Workbenches component status.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        releases:
+                          items:
+                            description: ComponentRelease represents the detailed status of a component release.
+                            properties:
+                              name:
+                                type: string
+                              repoUrl:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        workbenchNamespace:
+                          type: string
+                      type: object
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                errorMessage:
+                  type: string
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                relatedObjects:
+                  description: |-
+                    RelatedObjects is a list of objects created and maintained by this operator.
+                    Object references will be added to this list after they have been created AND found in the cluster.
+                  items:
+                    description: ObjectReference contains enough information to let you inspect or modify the referred object.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                release:
+                  description: Version and release type
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-datasciencepipelines-components-platform-opendatah.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-datasciencepipelines-components-platform-opendatah.yaml
@@ -1,0 +1,160 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: datasciencepipelines.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: DataSciencePipelines
+    listKind: DataSciencePipelinesList
+    plural: datasciencepipelines
+    singular: datasciencepipelines
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DataSciencePipelines is the Schema for the datasciencepipelines API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DataSciencePipelinesSpec defines the desired state of DataSciencePipelines
+              properties:
+                argoWorkflowsControllers:
+                  properties:
+                    managementState:
+                      default: Managed
+                      description: |-
+                        Set to one of the following values:
+
+                        - "Managed" : the operator is actively managing the bundled Argo Workflows controllers.
+                                      It will only upgrade the Argo Workflows controllers if it is safe to do so. This is the default
+                                      behavior.
+
+                        - "Removed" : the operator is not managing the bundled Argo Workflows controllers and will not install it.
+                                      If it is installed, the operator will remove it but will not remove other Argo Workflows
+                                      installations.
+                      enum:
+                        - Managed
+                        - Removed
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                  type: object
+              type: object
+            status:
+              description: DataSciencePipelinesStatus defines the observed state of DataSciencePipelines
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                releases:
+                  items:
+                    description: ComponentRelease represents the detailed status of a component release.
+                    properties:
+                      name:
+                        type: string
+                      repoUrl:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: DataSciencePipelines name must be default-datasciencepipelines
+              rule: self.metadata.name == 'default-datasciencepipelines'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-dscinitializations-dscinitialization-opendatahub-i.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-dscinitializations-dscinitialization-opendatahub-i.yaml
@@ -1,0 +1,859 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: dscinitializations.dscinitialization.opendatahub.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: opendatahub-operator-controller-manager-webhook-service
+          namespace: opendatahub-operator
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+        - v1
+        - v2
+  group: dscinitialization.opendatahub.io
+  names:
+    kind: DSCInitialization
+    listKind: DSCInitializationList
+    plural: dscinitializations
+    shortNames:
+      - dsci
+    singular: dscinitialization
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: Current Phase
+          jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Created At
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: DSCInitialization is the Schema for the dscinitializations API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DSCInitializationSpec defines the desired state of DSCInitialization.
+              properties:
+                applicationsNamespace:
+                  default: opendatahub
+                  description: Namespace for applications to be installed, non-configurable, default to "opendatahub"
+                  maxLength: 63
+                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: ApplicationsNamespace is immutable
+                      rule: self == oldSelf
+                devFlags:
+                  description: |-
+                    Internal development useful field to test customizations.
+                    This is not recommended to be used in production environment.
+                  properties:
+                    logLevel:
+                      description: Override Zap log level. Can be "debug", "info", "error" or a number (more verbose).
+                      type: string
+                    logmode:
+                      default: production
+                      description: '## DEPRECATED ##: Ignored, use LogLevel instead'
+                      enum:
+                        - devel
+                        - development
+                        - prod
+                        - production
+                        - default
+                      type: string
+                    manifestsUri:
+                      description: |-
+                        ## DEPRECATED ## : ManifestsUri set on DSCI is not maintained.
+                        Custom manifests uri for odh-manifests
+                      type: string
+                  type: object
+                monitoring:
+                  description: Enable monitoring on specified namespace
+                  properties:
+                    alerting:
+                      description: Alerting configuration for Prometheus
+                      type: object
+                    collectorReplicas:
+                      description: |-
+                        CollectorReplicas specifies the number of replicas in opentelemetry-collector. If not set, it defaults
+                        to 1 on single-node clusters and 2 on multi-node clusters.
+                      format: int32
+                      type: integer
+                    managementState:
+                      description: |-
+                        Set to one of the following values:
+
+                        - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                      It will only upgrade the component if it is safe to do so
+
+                        - "Removed" : the operator is actively managing the component and will not install it,
+                                      or if it is installed, the operator will try to remove it
+                      enum:
+                        - Managed
+                        - Removed
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                    metrics:
+                      description: metrics collection
+                      properties:
+                        exporters:
+                          additionalProperties:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          description: |-
+                            Exporters defines custom metrics exporters for sending metrics to external observability tools.
+                            Each key represents the exporter name, and the value contains the exporter configuration.
+                            The configuration follows the OpenTelemetry Collector exporter format.
+                            Reserved names 'prometheus' and 'otlp/tempo' cannot be used as they conflict with built-in exporters.
+                            Maximum 10 exporters allowed, each config must be less than 10KB (enforced at reconciliation time).
+                          type: object
+                          x-kubernetes-validations:
+                            - message: exporter name 'prometheus' is reserved and cannot be used
+                              rule: '!(''prometheus'' in self)'
+                            - message: exporter name 'otlp/tempo' is reserved and cannot be used
+                              rule: '!(''otlp/tempo'' in self)'
+                            - message: maximum 10 exporters allowed
+                              rule: size(self) <= 10
+                        replicas:
+                          description: |-
+                            Replicas specifies the number of replicas in monitoringstack. If not set, it defaults
+                            to 1 on single-node clusters and 2 on multi-node clusters.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        storage:
+                          description: MetricsStorage defines the storage configuration for the monitoring service
+                          properties:
+                            retention:
+                              default: 90d
+                              description: Retention specifies how long metrics data should be retained (e.g., "1d", "2w")
+                              type: string
+                            size:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              default: 5Gi
+                              description: Size specifies the storage size for the MonitoringStack (e.g, "5Gi", "10Mi")
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                        - message: Non-zero replicas require metrics.storage to be configured
+                          rule: has(self.storage) || !has(self.replicas) || self.replicas == 0
+                    namespace:
+                      default: opendatahub
+                      description: |-
+                        monitoring spec exposed to DSCI api
+                        Namespace for monitoring if it is enabled
+                      maxLength: 63
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: MonitoringNamespace is immutable
+                          rule: self == oldSelf
+                    traces:
+                      description: Tracing configuration for OpenTelemetry instrumentation
+                      properties:
+                        exporters:
+                          additionalProperties:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          description: |-
+                            Exporters defines custom trace exporters for sending traces to external observability tools.
+                            Each key represents the exporter name, and the value contains the exporter configuration.
+                            The configuration follows the OpenTelemetry Collector exporter format.
+                          type: object
+                        sampleRatio:
+                          default: "0.1"
+                          description: |-
+                            SampleRatio determines the sampling rate for traces
+                            Value should be between 0.0 (no sampling) and 1.0 (sample all traces)
+                          pattern: ^(0(\.[0-9]+)?|1(\.0+)?)$
+                          type: string
+                        storage:
+                          description: TracesStorage defines the storage configuration for tracing
+                          properties:
+                            backend:
+                              default: pv
+                              description: |-
+                                Backend defines the storage backend type.
+                                Valid values are "pv", "s3", and "gcs".
+                              enum:
+                                - pv
+                                - s3
+                                - gcs
+                              type: string
+                            retention:
+                              default: 2160h
+                              description: Retention specifies how long trace data should be retained globally (e.g., "60m", "10h")
+                              type: string
+                            secret:
+                              description: |-
+                                Secret specifies the secret name for storage credentials.
+                                This field is required when the backend is not "pv".
+                              type: string
+                            size:
+                              description: |-
+                                Size specifies the size of the storage.
+                                This field is optional.
+                              type: string
+                          required:
+                            - backend
+                          type: object
+                          x-kubernetes-validations:
+                            - message: When backend is s3 or gcs, the 'secret' field must be specified and non-empty
+                              rule: 'self.backend != ''pv'' ? (has(self.secret) && self.secret != "") : true'
+                            - message: Size is supported when backend is pv only
+                              rule: 'self.backend != ''pv'' ? !has(self.size) : true'
+                        tls:
+                          description: TLS configuration for Tempo gRPC connections
+                          properties:
+                            caConfigMap:
+                              description: |-
+                                CAConfigMap specifies the name of the ConfigMap containing the CA certificate
+                                Required for mutual TLS authentication
+                              type: string
+                            certificateSecret:
+                              description: |-
+                                CertificateSecret specifies the name of the secret containing TLS certificates
+                                If not specified, OpenShift service serving certificates will be used
+                              type: string
+                            enabled:
+                              description: |-
+                                Enabled enables TLS for Tempo OTLP ingestion (gRPC/HTTP) and query APIs (HTTP)
+                                TLS is disabled by default to maintain backward compatibility
+                              type: boolean
+                          type: object
+                      required:
+                        - storage
+                      type: object
+                  type: object
+                  x-kubernetes-validations:
+                    - message: Alerting configuration requires metrics.storage to be configured
+                      rule: 'has(self.alerting) ? has(self.metrics.storage)  : true'
+                    - message: CollectorReplicas can only be set when metrics.storage or traces are configured, and must be > 0
+                      rule: '!has(self.collectorReplicas) || (self.collectorReplicas > 0 && (self.metrics.storage != null || self.traces != null))'
+                serviceMesh:
+                  description: |-
+                    Configures Service Mesh as networking layer for Data Science Clusters components.
+                    The Service Mesh is a mandatory prerequisite for single model serving (KServe) and
+                    you should review this configuration if you are planning to use KServe.
+                    For other components, it enhances user experience; e.g. it provides unified
+                    authentication giving a Single Sign On experience.
+                  properties:
+                    auth:
+                      description: |-
+                        Auth holds configuration of authentication and authorization services
+                        used by Service Mesh in Opendatahub.
+                      properties:
+                        audiences:
+                          default:
+                            - https://kubernetes.default.svc
+                          description: |-
+                            Audiences is a list of the identifiers that the resource server presented
+                            with the token identifies as. Audience-aware token authenticators will verify
+                            that the token was intended for at least one of the audiences in this list.
+                            If no audiences are provided, the audience will default to the audience of the
+                            Kubernetes apiserver (kubernetes.default.svc).
+                          items:
+                            type: string
+                          type: array
+                        namespace:
+                          description: |-
+                            Namespace where it is deployed. If not provided, the default is to
+                            use '-auth-provider' suffix on the ApplicationsNamespace of the DSCI.
+                          maxLength: 63
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                          type: string
+                      type: object
+                    controlPlane:
+                      description: ControlPlane holds configuration of Service Mesh used by Opendatahub.
+                      properties:
+                        metricsCollection:
+                          default: Istio
+                          description: |-
+                            MetricsCollection specifies if metrics from components on the Mesh namespace
+                            should be collected. Setting the value to "Istio" will collect metrics from the
+                            control plane and any proxies on the Mesh namespace (like gateway pods). Setting
+                            to "None" will disable metrics collection.
+                          enum:
+                            - Istio
+                            - None
+                          type: string
+                        name:
+                          default: data-science-smcp
+                          description: Name is a name Service Mesh Control Plane. Defaults to "data-science-smcp".
+                          type: string
+                        namespace:
+                          default: istio-system
+                          description: Namespace is a namespace where Service Mesh is deployed. Defaults to "istio-system".
+                          maxLength: 63
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                          type: string
+                      type: object
+                    managementState:
+                      default: Removed
+                      enum:
+                        - Managed
+                        - Unmanaged
+                        - Removed
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                  type: object
+                trustedCABundle:
+                  description: |-
+                    When set to `Managed`, adds odh-trusted-ca-bundle Configmap to all namespaces that includes
+                    cluster-wide Trusted CA Bundle in .data["ca-bundle.crt"].
+                    Additionally, this fields allows admins to add custom CA bundles to the configmap using the .CustomCABundle field.
+                  properties:
+                    customCABundle:
+                      description: |-
+                        A custom CA bundle that will be available for  all  components in the
+                        Data Science Cluster(DSC). This bundle will be stored in odh-trusted-ca-bundle
+                        ConfigMap .data.odh-ca-bundle.crt .
+                      type: string
+                    managementState:
+                      default: Removed
+                      description: managementState indicates whether and how the operator should manage customized CA bundle
+                      enum:
+                        - Managed
+                        - Removed
+                        - Unmanaged
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                  required:
+                    - customCABundle
+                    - managementState
+                  type: object
+              type: object
+            status:
+              description: DSCInitializationStatus defines the observed state of DSCInitialization.
+              properties:
+                conditions:
+                  description: Conditions describes the state of the DSCInitializationStatus resource
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                errorMessage:
+                  type: string
+                phase:
+                  description: |-
+                    Phase describes the Phase of DSCInitializationStatus
+                    This is used by OLM UI to provide status information to the user
+                  type: string
+                relatedObjects:
+                  description: |-
+                    RelatedObjects is a list of objects created and maintained by this operator.
+                    Object references will be added to this list after they have been created AND found in the cluster
+                  items:
+                    description: ObjectReference contains enough information to let you inspect or modify the referred object.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                release:
+                  description: Version and release type
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: Current Phase
+          jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Created At
+          type: string
+      name: v2
+      schema:
+        openAPIV3Schema:
+          description: DSCInitialization is the Schema for the dscinitializations API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DSCInitializationSpec defines the desired state of DSCInitialization.
+              properties:
+                applicationsNamespace:
+                  default: opendatahub
+                  description: Namespace for applications to be installed, non-configurable, default to "opendatahub"
+                  maxLength: 63
+                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: ApplicationsNamespace is immutable
+                      rule: self == oldSelf
+                devFlags:
+                  description: |-
+                    Internal development useful field to test customizations.
+                    This is not recommended to be used in production environment.
+                  properties:
+                    logLevel:
+                      description: Override Zap log level. Can be "debug", "info", "error" or a number (more verbose).
+                      type: string
+                  type: object
+                monitoring:
+                  description: Enable monitoring on specified namespace
+                  properties:
+                    alerting:
+                      description: Alerting configuration for Prometheus
+                      type: object
+                    collectorReplicas:
+                      description: |-
+                        CollectorReplicas specifies the number of replicas in opentelemetry-collector. If not set, it defaults
+                        to 1 on single-node clusters and 2 on multi-node clusters.
+                      format: int32
+                      type: integer
+                    managementState:
+                      description: |-
+                        Set to one of the following values:
+
+                        - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                      It will only upgrade the component if it is safe to do so
+
+                        - "Removed" : the operator is actively managing the component and will not install it,
+                                      or if it is installed, the operator will try to remove it
+                      enum:
+                        - Managed
+                        - Removed
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                    metrics:
+                      description: metrics collection
+                      properties:
+                        exporters:
+                          additionalProperties:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          description: |-
+                            Exporters defines custom metrics exporters for sending metrics to external observability tools.
+                            Each key represents the exporter name, and the value contains the exporter configuration.
+                            The configuration follows the OpenTelemetry Collector exporter format.
+                            Reserved names 'prometheus' and 'otlp/tempo' cannot be used as they conflict with built-in exporters.
+                            Maximum 10 exporters allowed, each config must be less than 10KB (enforced at reconciliation time).
+                          type: object
+                          x-kubernetes-validations:
+                            - message: exporter name 'prometheus' is reserved and cannot be used
+                              rule: '!(''prometheus'' in self)'
+                            - message: exporter name 'otlp/tempo' is reserved and cannot be used
+                              rule: '!(''otlp/tempo'' in self)'
+                            - message: maximum 10 exporters allowed
+                              rule: size(self) <= 10
+                        replicas:
+                          description: |-
+                            Replicas specifies the number of replicas in monitoringstack. If not set, it defaults
+                            to 1 on single-node clusters and 2 on multi-node clusters.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        storage:
+                          description: MetricsStorage defines the storage configuration for the monitoring service
+                          properties:
+                            retention:
+                              default: 90d
+                              description: Retention specifies how long metrics data should be retained (e.g., "1d", "2w")
+                              type: string
+                            size:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              default: 5Gi
+                              description: Size specifies the storage size for the MonitoringStack (e.g, "5Gi", "10Mi")
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                        - message: Non-zero replicas require metrics.storage to be configured
+                          rule: has(self.storage) || !has(self.replicas) || self.replicas == 0
+                    namespace:
+                      default: opendatahub
+                      description: |-
+                        monitoring spec exposed to DSCI api
+                        Namespace for monitoring if it is enabled
+                      maxLength: 63
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: MonitoringNamespace is immutable
+                          rule: self == oldSelf
+                    traces:
+                      description: Tracing configuration for OpenTelemetry instrumentation
+                      properties:
+                        exporters:
+                          additionalProperties:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          description: |-
+                            Exporters defines custom trace exporters for sending traces to external observability tools.
+                            Each key represents the exporter name, and the value contains the exporter configuration.
+                            The configuration follows the OpenTelemetry Collector exporter format.
+                          type: object
+                        sampleRatio:
+                          default: "0.1"
+                          description: |-
+                            SampleRatio determines the sampling rate for traces
+                            Value should be between 0.0 (no sampling) and 1.0 (sample all traces)
+                          pattern: ^(0(\.[0-9]+)?|1(\.0+)?)$
+                          type: string
+                        storage:
+                          description: TracesStorage defines the storage configuration for tracing
+                          properties:
+                            backend:
+                              default: pv
+                              description: |-
+                                Backend defines the storage backend type.
+                                Valid values are "pv", "s3", and "gcs".
+                              enum:
+                                - pv
+                                - s3
+                                - gcs
+                              type: string
+                            retention:
+                              default: 2160h
+                              description: Retention specifies how long trace data should be retained globally (e.g., "60m", "10h")
+                              type: string
+                            secret:
+                              description: |-
+                                Secret specifies the secret name for storage credentials.
+                                This field is required when the backend is not "pv".
+                              type: string
+                            size:
+                              description: |-
+                                Size specifies the size of the storage.
+                                This field is optional.
+                              type: string
+                          required:
+                            - backend
+                          type: object
+                          x-kubernetes-validations:
+                            - message: When backend is s3 or gcs, the 'secret' field must be specified and non-empty
+                              rule: 'self.backend != ''pv'' ? (has(self.secret) && self.secret != "") : true'
+                            - message: Size is supported when backend is pv only
+                              rule: 'self.backend != ''pv'' ? !has(self.size) : true'
+                        tls:
+                          description: TLS configuration for Tempo gRPC connections
+                          properties:
+                            caConfigMap:
+                              description: |-
+                                CAConfigMap specifies the name of the ConfigMap containing the CA certificate
+                                Required for mutual TLS authentication
+                              type: string
+                            certificateSecret:
+                              description: |-
+                                CertificateSecret specifies the name of the secret containing TLS certificates
+                                If not specified, OpenShift service serving certificates will be used
+                              type: string
+                            enabled:
+                              description: |-
+                                Enabled enables TLS for Tempo OTLP ingestion (gRPC/HTTP) and query APIs (HTTP)
+                                TLS is disabled by default to maintain backward compatibility
+                              type: boolean
+                          type: object
+                      required:
+                        - storage
+                      type: object
+                  type: object
+                  x-kubernetes-validations:
+                    - message: Alerting configuration requires metrics.storage to be configured
+                      rule: 'has(self.alerting) ? has(self.metrics.storage)  : true'
+                    - message: CollectorReplicas can only be set when metrics.storage or traces are configured, and must be > 0
+                      rule: '!has(self.collectorReplicas) || (self.collectorReplicas > 0 && (self.metrics.storage != null || self.traces != null))'
+                trustedCABundle:
+                  description: |-
+                    When set to `Managed`, adds odh-trusted-ca-bundle Configmap to all namespaces that includes
+                    cluster-wide Trusted CA Bundle in .data["ca-bundle.crt"].
+                    Additionally, this fields allows admins to add custom CA bundles to the configmap using the .CustomCABundle field.
+                  properties:
+                    customCABundle:
+                      description: |-
+                        A custom CA bundle that will be available for  all  components in the
+                        Data Science Cluster(DSC). This bundle will be stored in odh-trusted-ca-bundle
+                        ConfigMap .data.odh-ca-bundle.crt .
+                      type: string
+                    managementState:
+                      default: Removed
+                      description: managementState indicates whether and how the operator should manage customized CA bundle
+                      enum:
+                        - Managed
+                        - Removed
+                        - Unmanaged
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                  required:
+                    - customCABundle
+                    - managementState
+                  type: object
+              type: object
+            status:
+              description: DSCInitializationStatus defines the observed state of DSCInitialization.
+              properties:
+                conditions:
+                  description: Conditions describes the state of the DSCInitializationStatus resource
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                errorMessage:
+                  type: string
+                phase:
+                  description: |-
+                    Phase describes the Phase of DSCInitializationStatus
+                    This is used by OLM UI to provide status information to the user
+                  type: string
+                relatedObjects:
+                  description: |-
+                    RelatedObjects is a list of objects created and maintained by this operator.
+                    Object references will be added to this list after they have been created AND found in the cluster
+                  items:
+                    description: ObjectReference contains enough information to let you inspect or modify the referred object.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                release:
+                  description: Version and release type
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-feastoperators-components-platform-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-feastoperators-components-platform-opendatahub-io.yaml
@@ -1,0 +1,139 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: feastoperators.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: FeastOperator
+    listKind: FeastOperatorList
+    plural: feastoperators
+    singular: feastoperator
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: FeastOperator is the Schema for the FeastOperator API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: FeastOperatorSpec defines the desired state of FeastOperator
+              type: object
+            status:
+              description: FeastOperatorStatus defines the observed state of FeastOperator
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                releases:
+                  items:
+                    description: ComponentRelease represents the detailed status of a component release.
+                    properties:
+                      name:
+                        type: string
+                      repoUrl:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: FeastOperator name must be 'default-feastoperator'
+              rule: self.metadata.name == 'default-feastoperator'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-featuretrackers-features-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-featuretrackers-features-opendatahub-io.yaml
@@ -1,0 +1,126 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: featuretrackers.features.opendatahub.io
+spec:
+  group: features.opendatahub.io
+  names:
+    kind: FeatureTracker
+    listKind: FeatureTrackerList
+    plural: featuretrackers
+    singular: featuretracker
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            FeatureTracker represents a cluster-scoped resource in the Data Science Cluster,
+            specifically designed for monitoring and managing objects created via the internal Features API.
+            This resource serves a crucial role in cross-namespace resource management, acting as
+            an owner reference for various resources. The primary purpose of the FeatureTracker
+            is to enable efficient garbage collection by Kubernetes. This is essential for
+            ensuring that resources are automatically cleaned up and reclaimed when they are
+            no longer required.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: FeatureTrackerSpec defines the desired state of FeatureTracker.
+              properties:
+                appNamespace:
+                  type: string
+                source:
+                  description: Source describes the type of object that created the related Feature to this FeatureTracker.
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+              type: object
+            status:
+              description: FeatureTrackerStatus defines the observed state of FeatureTracker.
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                phase:
+                  description: |-
+                    Phase describes the Phase of FeatureTracker reconciliation state.
+                    This is used by OLM UI to provide status information to the user.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-gatewayconfigs-services-platform-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-gatewayconfigs-services-platform-opendatahub-io.yaml
@@ -1,0 +1,285 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: gatewayconfigs.services.platform.opendatahub.io
+spec:
+  group: services.platform.opendatahub.io
+  names:
+    kind: GatewayConfig
+    listKind: GatewayConfigList
+    plural: gatewayconfigs
+    singular: gatewayconfig
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: GatewayConfig is the Schema for the gatewayconfigs API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GatewayConfigSpec defines the desired state of GatewayConfig
+              properties:
+                authProxyTimeout:
+                  description: |-
+                    AuthProxyTimeout defines the timeout for external authorization service calls (e.g., "5s", "10s")
+                    This controls how long Envoy waits for a response from the authentication proxy before timing out 403 response.
+                  type: string
+                authTimeout:
+                  description: |-
+                    AuthTimeout is the duration Envoy waits for auth proxy responses.
+                    Requests timeout with 403 if exceeded.
+                    Deprecated: Use AuthProxyTimeout instead.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                  type: string
+                certificate:
+                  description: Certificate specifies configuration of the TLS certificate securing communication for the gateway.
+                  properties:
+                    secretName:
+                      description: |-
+                        SecretName specifies the name of the Kubernetes Secret resource that contains a
+                        TLS certificate secure HTTP communications for the KNative network.
+                      type: string
+                    type:
+                      default: OpenshiftDefaultIngress
+                      description: |-
+                        Type specifies if the TLS certificate should be generated automatically, or if the certificate
+                        is provided by the user. Allowed values are:
+                        * SelfSigned: A certificate is going to be generated using an own private key.
+                        * Provided: Pre-existence of the TLS Secret (see SecretName) with a valid certificate is assumed.
+                        * OpenshiftDefaultIngress: Default ingress certificate configured for OpenShift
+                      enum:
+                        - SelfSigned
+                        - Provided
+                        - OpenshiftDefaultIngress
+                      type: string
+                  type: object
+                cookie:
+                  description: Cookie configuration (applies to both OIDC and OpenShift OAuth)
+                  properties:
+                    expire:
+                      default: 24h
+                      description: |-
+                        Expire duration for OAuth2 proxy session cookie (e.g., "24h", "8h")
+                        This controls how long the session cookie is valid before requiring re-authentication.
+                      type: string
+                    refresh:
+                      default: 1h
+                      description: |-
+                        Refresh duration for OAuth2 proxy to refresh access tokens (e.g., "2h", "1h", "30m")
+                        This must be LESS than the OIDC provider's Access Token Lifespan to avoid token expiration.
+                        For example, if Keycloak Access Token Lifespan is 1 hour, set this to "30m" or "45m".
+                      type: string
+                  type: object
+                domain:
+                  description: |-
+                    Domain specifies the host name for intercepting incoming requests.
+                    Most likely, you will want to use a wildcard name, like *.example.com.
+                    If not set, the domain of the OpenShift Ingress is used.
+                    If you choose to generate a certificate, this is the domain used for the certificate request.
+                    Example: *.example.com, example.com, apps.example.com
+                  pattern: ^(\*\.)?([a-z0-9]([-a-z0-9]*[a-z0-9])?\.)*[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                enableK8sTokenValidation:
+                  default: true
+                  description: |-
+                    EnableK8sTokenValidation enables Kubernetes service account token validation via TokenReview API.
+                    When enabled, kube-auth-proxy validates bearer tokens as service account tokens alongside OAuth/OIDC authentication.
+                    This allows service accounts to authenticate via bearer tokens while human users authenticate via OAuth/OIDC.
+                  type: boolean
+                ingressMode:
+                  description: |-
+                    IngressMode specifies how the Gateway is exposed externally.
+                    "OcpRoute" uses ClusterIP with standard OpenShift Routes (default for new deployments).
+                    "LoadBalancer" uses a LoadBalancer service type (requires cloud or MetalLB).
+                  enum:
+                    - OcpRoute
+                    - LoadBalancer
+                  type: string
+                networkPolicy:
+                  description: NetworkPolicy configuration for kube-auth-proxy
+                  properties:
+                    ingress:
+                      description: |-
+                        Ingress defines ingress NetworkPolicy rules.
+                        When nil, ingress rules are applied by default (allows traffic from Gateway pods and monitoring namespaces).
+                        When specified, Enabled must be set to true to apply rules or false to skip NetworkPolicy creation.
+                        Set Enabled=false only in development environments or when using alternative network security controls.
+                      properties:
+                        enabled:
+                          description: |-
+                            Enabled determines whether ingress rules are applied.
+                            When true, creates NetworkPolicy allowing traffic only from Gateway pods and monitoring namespaces.
+                          type: boolean
+                      required:
+                        - enabled
+                      type: object
+                  type: object
+                oidc:
+                  description: OIDC configuration (used when cluster is in OIDC authentication mode)
+                  properties:
+                    clientID:
+                      description: OIDC client ID
+                      type: string
+                    clientSecretRef:
+                      description: Reference to secret containing client secret
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    issuerURL:
+                      description: OIDC issuer URL
+                      type: string
+                    secretNamespace:
+                      description: |-
+                        Namespace where the client secret is located
+                        If not specified, defaults to openshift-ingress
+                      type: string
+                  required:
+                    - clientID
+                    - clientSecretRef
+                    - issuerURL
+                  type: object
+                providerCASecretName:
+                  description: |-
+                    ProviderCASecretName is the name of the secret containing the CA certificate for the authentication provider
+                    Used when the OAuth/OIDC provider uses a self-signed or custom CA certificate.
+                    Secret must exist in the openshift-ingress namespace and contain a 'ca.crt' key with the PEM-encoded CA certificate.
+                  type: string
+                subdomain:
+                  description: |-
+                    Subdomain configuration for the GatewayConfig
+                    Example: my-gateway, custom-gateway
+                  maxLength: 63
+                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                  type: string
+                verifyProviderCertificate:
+                  default: true
+                  description: |-
+                    VerifyProviderCertificate controls TLS certificate verification for the authentication provider.
+                    When true (default), certificates are verified against the system trust store and providerCASecretName.
+                    When false, certificate verification is disabled (development/testing only).
+                    WARNING: Setting this to false disables security and should only be used in non-production environments.
+                    For production use with self-signed certificates, use ProviderCASecretName instead.
+                  type: boolean
+              type: object
+            status:
+              description: GatewayConfigStatus defines the observed state of GatewayConfig
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                domain:
+                  description: |-
+                    Domain is the computed gateway domain (subdomain + cluster domain or default)
+                    This is the single source of truth for the gateway domain used by all components
+                  type: string
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: GatewayConfig name must be default-gateway
+              rule: self.metadata.name == 'default-gateway'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-hardwareprofiles-infrastructure-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-hardwareprofiles-infrastructure-opendatahub-io.yaml
@@ -1,0 +1,361 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: hardwareprofiles.infrastructure.opendatahub.io
+spec:
+  group: infrastructure.opendatahub.io
+  names:
+    kind: HardwareProfile
+    listKind: HardwareProfileList
+    plural: hardwareprofiles
+    singular: hardwareprofile
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: HardwareProfile is the Schema for the hardwareprofiles API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HardwareProfileSpec defines the desired state of HardwareProfile.
+              properties:
+                identifiers:
+                  description: The array of identifiers
+                  items:
+                    properties:
+                      defaultCount:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: The default count can be an integer or a string.
+                        x-kubernetes-int-or-string: true
+                      displayName:
+                        description: The display name of identifier.
+                        type: string
+                      identifier:
+                        description: The resource identifier of the hardware device.
+                        type: string
+                      maxCount:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: The maximum count can be an integer or a string.
+                        x-kubernetes-int-or-string: true
+                      minCount:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: The minimum count can be an integer or a string.
+                        x-kubernetes-int-or-string: true
+                      resourceType:
+                        description: The type of identifier. could be "CPU", "Memory", or "Accelerator". Leave it undefined for the other types.
+                        enum:
+                          - CPU
+                          - Memory
+                          - Accelerator
+                        type: string
+                    required:
+                      - defaultCount
+                      - displayName
+                      - identifier
+                      - minCount
+                    type: object
+                  type: array
+                scheduling:
+                  description: SchedulingSpec specifies how workloads using this hardware profile should be scheduled.
+                  properties:
+                    kueue:
+                      description: |-
+                        Kueue specifies queue-based scheduling configuration.
+                        This field is only valid when schedulingType is "Queue".
+                      properties:
+                        localQueueName:
+                          description: |-
+                            LocalQueueName specifies the name of the local queue to use for workload scheduling.
+                            When specified, workloads using this hardware profile will be submitted to the
+                            specified queue and the queue's configuration will determine the actual node
+                            placement and tolerations.
+                          minLength: 1
+                          type: string
+                        priorityClass:
+                          description: PriorityClass specifies the name of the WorkloadPriorityClass associated with the HardwareProfile.
+                          type: string
+                      required:
+                        - localQueueName
+                      type: object
+                    node:
+                      description: |-
+                        node specifies direct node scheduling configuration.
+                        This field is only valid when schedulingType is "Node".
+                      properties:
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            NodeSelector specifies the node selector to use for direct node scheduling.
+                            Workloads will be scheduled only on nodes that match all the specified labels.
+                          type: object
+                        tolerations:
+                          description: |-
+                            Tolerations specifies the tolerations to apply to workloads for direct node scheduling.
+                            These tolerations allow workloads to be scheduled on nodes with matching taints.
+                          items:
+                            description: |-
+                              The pod this Toleration is attached to tolerates any taint that matches
+                              the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: |-
+                                  Effect indicates the taint effect to match. Empty means match all taint effects.
+                                  When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: |-
+                                  Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                  If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: |-
+                                  Operator represents a key's relationship to the value.
+                                  Valid operators are Exists and Equal. Defaults to Equal.
+                                  Exists is equivalent to wildcard for value, so that a pod can
+                                  tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: |-
+                                  TolerationSeconds represents the period of time the toleration (which must be
+                                  of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                  it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                  negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: |-
+                                  Value is the taint value the toleration matches to.
+                                  If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type:
+                      description: |-
+                        SchedulingType is the scheduling method discriminator.
+                        Users must set this value to indicate which scheduling method to use.
+                        The value of this field should match exactly one configured scheduling method.
+                        Valid values are "Queue" and "Node".
+                      enum:
+                        - Queue
+                        - Node
+                      type: string
+                  required:
+                    - type
+                  type: object
+                  x-kubernetes-validations:
+                    - message: When schedulingType is 'Queue', the 'kueue.localQueueName' field must be specified and non-empty, and the 'node' field must not be set
+                      rule: 'self.type == ''Queue'' ? (has(self.kueue) && has(self.kueue.localQueueName) && !has(self.node)) : true'
+                    - message: When schedulingType is 'Node', the 'node' field must be set, and the 'kueue' field must not be set
+                      rule: 'self.type == ''Node'' ? (has(self.node) && !has(self.kueue)) : true'
+              type: object
+            status:
+              description: HardwareProfileStatus defines the observed state of HardwareProfile.
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - deprecated: true
+      deprecationWarning: infrastructure.opendatahub.io/v1alpha1 is deprecated; please use infrastructure.opendatahub.io/v1
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: HardwareProfile is the Schema for the hardwareprofiles API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HardwareProfileSpec defines the desired state of HardwareProfile.
+              properties:
+                identifiers:
+                  description: The array of identifiers
+                  items:
+                    properties:
+                      defaultCount:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: The default count can be an integer or a string.
+                        x-kubernetes-int-or-string: true
+                      displayName:
+                        description: The display name of identifier.
+                        type: string
+                      identifier:
+                        description: The resource identifier of the hardware device.
+                        type: string
+                      maxCount:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: The maximum count can be an integer or a string.
+                        x-kubernetes-int-or-string: true
+                      minCount:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: The minimum count can be an integer or a string.
+                        x-kubernetes-int-or-string: true
+                      resourceType:
+                        description: The type of identifier. could be "CPU", "Memory", or "Accelerator". Leave it undefined for the other types.
+                        enum:
+                          - CPU
+                          - Memory
+                          - Accelerator
+                        type: string
+                    required:
+                      - defaultCount
+                      - displayName
+                      - identifier
+                      - minCount
+                    type: object
+                  type: array
+                scheduling:
+                  description: SchedulingSpec specifies how workloads using this hardware profile should be scheduled.
+                  properties:
+                    kueue:
+                      description: |-
+                        Kueue specifies queue-based scheduling configuration.
+                        This field is only valid when schedulingType is "Queue".
+                      properties:
+                        localQueueName:
+                          description: |-
+                            LocalQueueName specifies the name of the local queue to use for workload scheduling.
+                            When specified, workloads using this hardware profile will be submitted to the
+                            specified queue and the queue's configuration will determine the actual node
+                            placement and tolerations.
+                          minLength: 1
+                          type: string
+                        priorityClass:
+                          description: PriorityClass specifies the name of the WorkloadPriorityClass associated with the HardwareProfile.
+                          type: string
+                      required:
+                        - localQueueName
+                      type: object
+                    node:
+                      description: |-
+                        node specifies direct node scheduling configuration.
+                        This field is only valid when schedulingType is "Node".
+                      properties:
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            NodeSelector specifies the node selector to use for direct node scheduling.
+                            Workloads will be scheduled only on nodes that match all the specified labels.
+                          type: object
+                        tolerations:
+                          description: |-
+                            Tolerations specifies the tolerations to apply to workloads for direct node scheduling.
+                            These tolerations allow workloads to be scheduled on nodes with matching taints.
+                          items:
+                            description: |-
+                              The pod this Toleration is attached to tolerates any taint that matches
+                              the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: |-
+                                  Effect indicates the taint effect to match. Empty means match all taint effects.
+                                  When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: |-
+                                  Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                  If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: |-
+                                  Operator represents a key's relationship to the value.
+                                  Valid operators are Exists and Equal. Defaults to Equal.
+                                  Exists is equivalent to wildcard for value, so that a pod can
+                                  tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: |-
+                                  TolerationSeconds represents the period of time the toleration (which must be
+                                  of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                  it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                  negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: |-
+                                  Value is the taint value the toleration matches to.
+                                  If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type:
+                      description: |-
+                        SchedulingType is the scheduling method discriminator.
+                        Users must set this value to indicate which scheduling method to use.
+                        The value of this field should match exactly one configured scheduling method.
+                        Valid values are "Queue" and "Node".
+                      enum:
+                        - Queue
+                        - Node
+                      type: string
+                  required:
+                    - type
+                  type: object
+                  x-kubernetes-validations:
+                    - message: When schedulingType is 'Queue', the 'kueue.localQueueName' field must be specified and non-empty, and the 'node' field must not be set
+                      rule: 'self.type == ''Queue'' ? (has(self.kueue) && has(self.kueue.localQueueName) && !has(self.node)) : true'
+                    - message: When schedulingType is 'Node', the 'node' field must be set, and the 'kueue' field must not be set
+                      rule: 'self.type == ''Node'' ? (has(self.node) && !has(self.kueue)) : true'
+              type: object
+            status:
+              description: HardwareProfileStatus defines the observed state of HardwareProfile.
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-kserves-components-platform-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-kserves-components-platform-opendatahub-io.yaml
@@ -1,0 +1,180 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: kserves.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: Kserve
+    listKind: KserveList
+    plural: kserves
+    singular: kserve
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Kserve is the Schema for the kserves API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KserveSpec defines the desired state of Kserve
+              properties:
+                modelsAsService:
+                  description: Configures and enables Models as a Service integration
+                  properties:
+                    managementState:
+                      default: Removed
+                      enum:
+                        - Managed
+                        - Removed
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                  type: object
+                nim:
+                  description: Configures and enables NVIDIA NIM integration
+                  properties:
+                    airGapped:
+                      default: false
+                      description: |-
+                        When true, NIM integration assumes an air-gapped cluster. External API calls
+                        and the NIM model list ConfigMap creation are skipped, while status conditions
+                        are marked successful with an air-gapped message.
+                      type: boolean
+                    managementState:
+                      default: Managed
+                      enum:
+                        - Managed
+                        - Removed
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                  type: object
+                rawDeploymentServiceConfig:
+                  default: Headless
+                  description: |-
+                    Configures the type of service that is created for InferenceServices using RawDeployment.
+                    The values for RawDeploymentServiceConfig can be "Headless" (default value) or "Headed".
+                    Headless: to set "ServiceClusterIPNone = true" in the 'inferenceservice-config' configmap for Kserve.
+                    Headed: to set "ServiceClusterIPNone = false" in the 'inferenceservice-config' configmap for Kserve.
+                  enum:
+                    - Headless
+                    - Headed
+                  type: string
+              type: object
+            status:
+              description: KserveStatus defines the observed state of Kserve
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                releases:
+                  items:
+                    description: ComponentRelease represents the detailed status of a component release.
+                    properties:
+                      name:
+                        type: string
+                      repoUrl:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: Kserve name must be default-kserve
+              rule: self.metadata.name == 'default-kserve'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-kueues-components-platform-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-kueues-components-platform-opendatahub-io.yaml
@@ -1,0 +1,165 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: kueues.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: Kueue
+    listKind: KueueList
+    plural: kueues
+    singular: kueue
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Kueue is the Schema for the kueues API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KueueSpec defines the desired state of Kueue
+              properties:
+                defaultClusterQueueName:
+                  default: default
+                  description: Configures the automatically created cluster queue name.
+                  type: string
+                defaultLocalQueueName:
+                  default: default
+                  description: Configures the automatically created, in the managed namespaces, local queue name.
+                  type: string
+                managementState:
+                  description: |-
+                    Set to one of the following values:
+
+                    - "Managed"   : present for backwards compatibility with OLM upgrades, but not supported at runtime.
+                                    The operator will reject this value. Use "Unmanaged" or "Removed" instead.
+
+                    - "Unmanaged" : the operator will not deploy or manage the component's lifecycle, but may create supporting configuration resources.
+
+                    - "Removed"   : the operator is actively managing the component and will not install it,
+                                    or if it is installed, the operator will try to remove it
+                  enum:
+                    - Managed
+                    - Unmanaged
+                    - Removed
+                  pattern: ^(Managed|Unmanaged|Force|Removed)$
+                  type: string
+              type: object
+            status:
+              description: KueueStatus defines the observed state of Kueue
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                releases:
+                  items:
+                    description: ComponentRelease represents the detailed status of a component release.
+                    properties:
+                      name:
+                        type: string
+                      repoUrl:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: Kueue name must be default-kueue
+              rule: self.metadata.name == 'default-kueue'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-llamastackoperators-components-platform-opendatahu.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-llamastackoperators-components-platform-opendatahu.yaml
@@ -1,0 +1,139 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: llamastackoperators.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: LlamaStackOperator
+    listKind: LlamaStackOperatorList
+    plural: llamastackoperators
+    singular: llamastackoperator
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: LlamaStackOperator is the Schema for the LlamaStackOperator API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: LlamaStackOperatorSpec defines the desired state of LlamaStackOperator
+              type: object
+            status:
+              description: LlamaStackOperatorStatus defines the observed state of LlamaStackOperator
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                releases:
+                  items:
+                    description: ComponentRelease represents the detailed status of a component release.
+                    properties:
+                      name:
+                        type: string
+                      repoUrl:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: LlamaStackOperator name must be default-llamastackoperator
+              rule: self.metadata.name == 'default-llamastackoperator'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-mlflowoperators-components-platform-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-mlflowoperators-components-platform-opendatahub-io.yaml
@@ -1,0 +1,138 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: mlflowoperators.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: MLflowOperator
+    listKind: MLflowOperatorList
+    plural: mlflowoperators
+    singular: mlflowoperator
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: MLflowOperator is the Schema for the MLflowOperators API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+            status:
+              description: MLflowOperatorStatus defines the observed state of MLflowOperator
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                releases:
+                  items:
+                    description: ComponentRelease represents the detailed status of a component release.
+                    properties:
+                      name:
+                        type: string
+                      repoUrl:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: MLflowOperator name must be default-mlflowoperator
+              rule: self.metadata.name == 'default-mlflowoperator'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-modelcontrollers-components-platform-opendatahub-i.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-modelcontrollers-components-platform-opendatahub-i.yaml
@@ -1,0 +1,158 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: modelcontrollers.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: ModelController
+    listKind: ModelControllerList
+    plural: modelcontrollers
+    singular: modelcontroller
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+        - description: devFlag's URI used to download
+          jsonPath: .status.URI
+          name: URI
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ModelController is the Schema for the modelcontroller API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ModelControllerSpec defines the desired state of ModelController
+              properties:
+                kserve:
+                  description: a mini version of the DSCKserve only keeps management and NIM spec
+                  properties:
+                    managementState:
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                    nim:
+                      description: nimSpec enables NVIDIA NIM integration
+                      properties:
+                        airGapped:
+                          default: false
+                          description: |-
+                            When true, NIM integration assumes an air-gapped cluster. External API calls
+                            and the NIM model list ConfigMap creation are skipped, while status conditions
+                            are marked successful with an air-gapped message.
+                          type: boolean
+                        managementState:
+                          default: Managed
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                  type: object
+                modelRegistry:
+                  properties:
+                    managementState:
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                  type: object
+              type: object
+            status:
+              description: ModelControllerStatus defines the observed state of ModelController
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: ModelController name must be default-modelcontroller
+              rule: self.metadata.name == 'default-modelcontroller'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-modelregistries-components-platform-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-modelregistries-components-platform-opendatahub-io.yaml
@@ -1,0 +1,161 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: modelregistries.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: ModelRegistry
+    listKind: ModelRegistryList
+    plural: modelregistries
+    singular: modelregistry
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ModelRegistry is the Schema for the modelregistries API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ModelRegistrySpec defines the desired state of ModelRegistry (ModelRegistry CR only).
+              properties:
+                gateway:
+                  description: Gateway configuration for model registry ingress (synced from GatewayConfig by the DSC controller when creating the ModelRegistry CR).
+                  properties:
+                    domain:
+                      description: |-
+                        Domain is the fully qualified domain name for the gateway.
+                        Example: "rhods-dashboard.apps.example.com"
+                      maxLength: 253
+                      pattern: ^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$
+                      type: string
+                  required:
+                    - domain
+                  type: object
+                registriesNamespace:
+                  default: odh-model-registries
+                  description: Namespace for model registries to be installed, configurable only once when model registry is enabled, defaults to "odh-model-registries"
+                  maxLength: 63
+                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                  type: string
+              type: object
+            status:
+              description: ModelRegistryStatus defines the observed state of ModelRegistry
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                registriesNamespace:
+                  type: string
+                releases:
+                  items:
+                    description: ComponentRelease represents the detailed status of a component release.
+                    properties:
+                      name:
+                        type: string
+                      repoUrl:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: ModelRegistry name must be default-modelregistry
+              rule: self.metadata.name == 'default-modelregistry'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-modelsasservices-components-platform-opendatahub-i.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-modelsasservices-components-platform-opendatahub-i.yaml
@@ -1,0 +1,141 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: modelsasservices.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: ModelsAsService
+    listKind: ModelsAsServiceList
+    plural: modelsasservices
+    singular: modelsasservice
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ModelsAsService is the Schema for the modelsasservice API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ModelsAsServiceSpec defines the desired state of ModelsAsService
+              properties:
+                gatewayRef:
+                  description: |-
+                    GatewayRef specifies which Gateway (Gateway API) to use for exposing model endpoints.
+                    If omitted, defaults to openshift-ingress/maas-default-gateway.
+                  properties:
+                    name:
+                      default: maas-default-gateway
+                      description: Name is the name of the Gateway resource.
+                      maxLength: 63
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                      type: string
+                    namespace:
+                      default: openshift-ingress
+                      description: Namespace is the namespace where the Gateway resource is located.
+                      maxLength: 63
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                      type: string
+                  type: object
+              type: object
+            status:
+              description: ModelsAsServiceStatus defines the observed state of ModelsAsService
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: ModelsAsService name must be default-modelsasservice
+              rule: self.metadata.name == 'default-modelsasservice'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-monitorings-services-platform-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-monitorings-services-platform-opendatahub-io.yaml
@@ -1,0 +1,278 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: monitorings.services.platform.opendatahub.io
+spec:
+  group: services.platform.opendatahub.io
+  names:
+    kind: Monitoring
+    listKind: MonitoringList
+    plural: monitorings
+    singular: monitoring
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+        - description: URL
+          jsonPath: .status.url
+          name: URL
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Monitoring is the Schema for the monitorings API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: MonitoringSpec defines the desired state of Monitoring
+              properties:
+                alerting:
+                  description: Alerting configuration for Prometheus
+                  type: object
+                collectorReplicas:
+                  description: |-
+                    CollectorReplicas specifies the number of replicas in opentelemetry-collector. If not set, it defaults
+                    to 1 on single-node clusters and 2 on multi-node clusters.
+                  format: int32
+                  type: integer
+                metrics:
+                  description: metrics collection
+                  properties:
+                    exporters:
+                      additionalProperties:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      description: |-
+                        Exporters defines custom metrics exporters for sending metrics to external observability tools.
+                        Each key represents the exporter name, and the value contains the exporter configuration.
+                        The configuration follows the OpenTelemetry Collector exporter format.
+                        Reserved names 'prometheus' and 'otlp/tempo' cannot be used as they conflict with built-in exporters.
+                        Maximum 10 exporters allowed, each config must be less than 10KB (enforced at reconciliation time).
+                      type: object
+                      x-kubernetes-validations:
+                        - message: exporter name 'prometheus' is reserved and cannot be used
+                          rule: '!(''prometheus'' in self)'
+                        - message: exporter name 'otlp/tempo' is reserved and cannot be used
+                          rule: '!(''otlp/tempo'' in self)'
+                        - message: maximum 10 exporters allowed
+                          rule: size(self) <= 10
+                    replicas:
+                      description: |-
+                        Replicas specifies the number of replicas in monitoringstack. If not set, it defaults
+                        to 1 on single-node clusters and 2 on multi-node clusters.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    storage:
+                      description: MetricsStorage defines the storage configuration for the monitoring service
+                      properties:
+                        retention:
+                          default: 90d
+                          description: Retention specifies how long metrics data should be retained (e.g., "1d", "2w")
+                          type: string
+                        size:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          default: 5Gi
+                          description: Size specifies the storage size for the MonitoringStack (e.g, "5Gi", "10Mi")
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
+                  x-kubernetes-validations:
+                    - message: Non-zero replicas require metrics.storage to be configured
+                      rule: has(self.storage) || !has(self.replicas) || self.replicas == 0
+                namespace:
+                  default: opendatahub
+                  description: |-
+                    monitoring spec exposed to DSCI api
+                    Namespace for monitoring if it is enabled
+                  maxLength: 63
+                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: MonitoringNamespace is immutable
+                      rule: self == oldSelf
+                traces:
+                  description: Tracing configuration for OpenTelemetry instrumentation
+                  properties:
+                    exporters:
+                      additionalProperties:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      description: |-
+                        Exporters defines custom trace exporters for sending traces to external observability tools.
+                        Each key represents the exporter name, and the value contains the exporter configuration.
+                        The configuration follows the OpenTelemetry Collector exporter format.
+                      type: object
+                    sampleRatio:
+                      default: "0.1"
+                      description: |-
+                        SampleRatio determines the sampling rate for traces
+                        Value should be between 0.0 (no sampling) and 1.0 (sample all traces)
+                      pattern: ^(0(\.[0-9]+)?|1(\.0+)?)$
+                      type: string
+                    storage:
+                      description: TracesStorage defines the storage configuration for tracing
+                      properties:
+                        backend:
+                          default: pv
+                          description: |-
+                            Backend defines the storage backend type.
+                            Valid values are "pv", "s3", and "gcs".
+                          enum:
+                            - pv
+                            - s3
+                            - gcs
+                          type: string
+                        retention:
+                          default: 2160h
+                          description: Retention specifies how long trace data should be retained globally (e.g., "60m", "10h")
+                          type: string
+                        secret:
+                          description: |-
+                            Secret specifies the secret name for storage credentials.
+                            This field is required when the backend is not "pv".
+                          type: string
+                        size:
+                          description: |-
+                            Size specifies the size of the storage.
+                            This field is optional.
+                          type: string
+                      required:
+                        - backend
+                      type: object
+                      x-kubernetes-validations:
+                        - message: When backend is s3 or gcs, the 'secret' field must be specified and non-empty
+                          rule: 'self.backend != ''pv'' ? (has(self.secret) && self.secret != "") : true'
+                        - message: Size is supported when backend is pv only
+                          rule: 'self.backend != ''pv'' ? !has(self.size) : true'
+                    tls:
+                      description: TLS configuration for Tempo gRPC connections
+                      properties:
+                        caConfigMap:
+                          description: |-
+                            CAConfigMap specifies the name of the ConfigMap containing the CA certificate
+                            Required for mutual TLS authentication
+                          type: string
+                        certificateSecret:
+                          description: |-
+                            CertificateSecret specifies the name of the secret containing TLS certificates
+                            If not specified, OpenShift service serving certificates will be used
+                          type: string
+                        enabled:
+                          description: |-
+                            Enabled enables TLS for Tempo OTLP ingestion (gRPC/HTTP) and query APIs (HTTP)
+                            TLS is disabled by default to maintain backward compatibility
+                          type: boolean
+                      type: object
+                  required:
+                    - storage
+                  type: object
+              type: object
+              x-kubernetes-validations:
+                - message: Alerting configuration requires metrics.storage to be configured
+                  rule: 'has(self.alerting) ? has(self.metrics.storage)  : true'
+                - message: CollectorReplicas can only be set when metrics.storage or traces are configured, and must be > 0
+                  rule: '!has(self.collectorReplicas) || (self.collectorReplicas > 0 && (self.metrics.storage != null || self.traces != null))'
+            status:
+              description: MonitoringStatus defines the observed state of Monitoring
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                url:
+                  type: string
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: Monitoring name must be default-monitoring
+              rule: self.metadata.name == 'default-monitoring'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-rays-components-platform-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-rays-components-platform-opendatahub-io.yaml
@@ -1,0 +1,139 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: rays.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: Ray
+    listKind: RayList
+    plural: rays
+    singular: ray
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Ray is the Schema for the rays API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: RaySpec defines the desired state of Ray
+              type: object
+            status:
+              description: RayStatus defines the observed state of Ray
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                releases:
+                  items:
+                    description: ComponentRelease represents the detailed status of a component release.
+                    properties:
+                      name:
+                        type: string
+                      repoUrl:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: Ray name must be default-ray
+              rule: self.metadata.name == 'default-ray'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-sparkoperators-components-platform-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-sparkoperators-components-platform-opendatahub-io.yaml
@@ -1,0 +1,139 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: sparkoperators.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: SparkOperator
+    listKind: SparkOperatorList
+    plural: sparkoperators
+    singular: sparkoperator
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: SparkOperator is the Schema for the sparkoperators API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SparkOperatorSpec defines the desired state of SparkOperator
+              type: object
+            status:
+              description: SparkOperatorStatus defines the observed state
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                releases:
+                  items:
+                    description: ComponentRelease represents the detailed status of a component release.
+                    properties:
+                      name:
+                        type: string
+                      repoUrl:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: SparkOperator name must be default-sparkoperator
+              rule: self.metadata.name == 'default-sparkoperator'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-trainers-components-platform-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-trainers-components-platform-opendatahub-io.yaml
@@ -1,0 +1,139 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: trainers.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: Trainer
+    listKind: TrainerList
+    plural: trainers
+    singular: trainer
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Trainer is the Schema for the trainers API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TrainerSpec defines the desired state of Trainer
+              type: object
+            status:
+              description: TrainerStatus defines the observed state of Trainer
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                releases:
+                  items:
+                    description: ComponentRelease represents the detailed status of a component release.
+                    properties:
+                      name:
+                        type: string
+                      repoUrl:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: Trainer name must be default-trainer
+              rule: self.metadata.name == 'default-trainer'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-trainingoperators-components-platform-opendatahub-.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-trainingoperators-components-platform-opendatahub-.yaml
@@ -1,0 +1,139 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: trainingoperators.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: TrainingOperator
+    listKind: TrainingOperatorList
+    plural: trainingoperators
+    singular: trainingoperator
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: TrainingOperator is the Schema for the trainingoperators API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TrainingOperatorSpec defines the desired state of TrainingOperator
+              type: object
+            status:
+              description: TrainingOperatorStatus defines the observed state of TrainingOperator
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                releases:
+                  items:
+                    description: ComponentRelease represents the detailed status of a component release.
+                    properties:
+                      name:
+                        type: string
+                      repoUrl:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: TrainingOperator name must be default-trainingoperator
+              rule: self.metadata.name == 'default-trainingoperator'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-trustyais-components-platform-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-trustyais-components-platform-opendatahub-io.yaml
@@ -1,0 +1,164 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: trustyais.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: TrustyAI
+    listKind: TrustyAIList
+    plural: trustyais
+    singular: trustyai
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: TrustyAI is the Schema for the trustyais API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TrustyAISpec defines the desired state of TrustyAI
+              properties:
+                eval:
+                  description: Eval configuration for TrustyAI evaluations
+                  properties:
+                    lmeval:
+                      description: LMEval configuration for model evaluations
+                      properties:
+                        permitCodeExecution:
+                          default: deny
+                          description: PermitCodeExecution controls whether code execution is allowed during evaluations
+                          enum:
+                            - allow
+                            - deny
+                          type: string
+                        permitOnline:
+                          default: deny
+                          description: PermitOnline controls whether online access is allowed during evaluations
+                          enum:
+                            - allow
+                            - deny
+                          type: string
+                      type: object
+                  required:
+                    - lmeval
+                  type: object
+              type: object
+            status:
+              description: TrustyAIStatus defines the observed state of TrustyAI
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                releases:
+                  items:
+                    description: ComponentRelease represents the detailed status of a component release.
+                    properties:
+                      name:
+                        type: string
+                      repoUrl:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: TrustyAI name must be default-trustyai
+              rule: self.metadata.name == 'default-trustyai'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/crds/customresourcedefinition-workbenches-components-platform-opendatahub-io.yaml
+++ b/charts/rhoai-operator/crds/customresourcedefinition-workbenches-components-platform-opendatahub-io.yaml
@@ -1,0 +1,151 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: workbenches.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: Workbenches
+    listKind: WorkbenchesList
+    plural: workbenches
+    singular: workbenches
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Workbenches is the Schema for the workbenches API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: WorkbenchesSpec defines the desired state of Workbenches
+              properties:
+                workbenchNamespace:
+                  default: opendatahub
+                  description: Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to "opendatahub"
+                  maxLength: 63
+                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: WorkbenchNamespace is immutable
+                      rule: self == oldSelf
+              type: object
+            status:
+              description: WorkbenchesStatus defines the observed state of Workbenches
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                releases:
+                  items:
+                    description: ComponentRelease represents the detailed status of a component release.
+                    properties:
+                      name:
+                        type: string
+                      repoUrl:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                workbenchNamespace:
+                  type: string
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: Workbenches name must be default-workbenches
+              rule: self.metadata.name == 'default-workbenches'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/rhoai-operator/scripts/update-bundle.sh
+++ b/charts/rhoai-operator/scripts/update-bundle.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Update Helm chart with new bundle version
+# Usage: ./update-bundle.sh [version]
+# Examples:
+#   ./update-bundle.sh v3.4.0-ea.1
+#   ./update-bundle.sh v3.3.0
+
+set -euo pipefail
+
+VERSION="${1:-v3.4.0-ea.1}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Bundle image from quay.io (public, no auth required)
+BUNDLE_IMAGE="quay.io/opendatahub/opendatahub-operator-bundle:${VERSION}"
+
+echo "============================================"
+echo "  Updating RHOAI Operator Helm Chart"
+echo "============================================"
+echo "Version: $VERSION"
+echo "Bundle: $BUNDLE_IMAGE"
+echo ""
+
+# Create temp directory
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Extract manifests using olm-extractor
+echo "[1/3] Extracting manifests..."
+podman run --rm --pull=always \
+  quay.io/lburgazzoli/olm-extractor:main \
+  run "$BUNDLE_IMAGE" \
+  -n opendatahub-operator \
+  2>/dev/null | grep -v "^time=" > "$TMP_DIR/manifests.yaml"
+
+# Validate extraction produced output
+if [ ! -s "$TMP_DIR/manifests.yaml" ]; then
+  echo "ERROR: Extraction produced empty manifests. Check bundle image."
+  exit 1
+fi
+
+echo "Extracted $(wc -l < "$TMP_DIR/manifests.yaml") lines"
+
+# Clean: remove all CRDs and templates (only after successful extraction)
+echo "[2/3] Cleaning old manifests..."
+find "$CHART_DIR/crds" -name "*.yaml" -delete 2>/dev/null || true
+find "$CHART_DIR/templates" -name "*.yaml" \
+  ! -name "namespace.yaml" \
+  ! -name "issuer-opendatahub-operator-controller-manager-selfsigned.yaml" \
+  -delete 2>/dev/null || true
+
+# Split manifests, templatize namespace references
+echo "[3/3] Splitting into CRDs and templates..."
+
+export TMP_DIR CHART_DIR
+python3 << 'PYEOF'
+import yaml
+import os
+import sys
+
+tmp_dir = os.environ.get('TMP_DIR', '/tmp')
+chart_dir = os.environ.get('CHART_DIR', '.')
+
+input_file = f'{tmp_dir}/manifests.yaml'
+crds_dir = f'{chart_dir}/crds'
+templates_dir = f'{chart_dir}/templates'
+
+os.makedirs(crds_dir, exist_ok=True)
+os.makedirs(templates_dir, exist_ok=True)
+
+with open(input_file, 'r') as f:
+    content = f.read()
+
+docs = content.split('\n---\n')
+crd_count = 0
+other_count = 0
+
+# Skip Issuer — preserved as custom template (olm-extractor strips selfSigned: {})
+skip_resources = [
+    ('Issuer', 'opendatahub-operator-controller-manager-selfsigned'),
+]
+
+for doc in docs:
+    if not doc.strip():
+        continue
+    try:
+        obj = yaml.safe_load(doc)
+        if not obj:
+            continue
+        kind = obj.get('kind', 'unknown')
+        name = obj.get('metadata', {}).get('name', 'unknown')
+
+        # Skip preserved custom templates
+        if (kind, name) in skip_resources:
+            continue
+
+        filename = f"{kind.lower()}-{name.replace('.', '-')[:50]}.yaml"
+
+        if kind == 'CustomResourceDefinition':
+            filepath = os.path.join(crds_dir, filename)
+            crd_count += 1
+            with open(filepath, 'w') as out:
+                out.write(doc.strip() + '\n')
+        elif kind == 'Namespace':
+            continue
+        else:
+            filepath = os.path.join(templates_dir, filename)
+            other_count += 1
+            # Templatize namespace references
+            content = doc.strip()
+            content = content.replace('namespace: opendatahub-operator', 'namespace: {{ .Values.namespace }}')
+            # Templatize cert-manager CA injection annotation
+            content = content.replace('inject-ca-from: opendatahub-operator/', 'inject-ca-from: "{{ .Values.namespace }}/')\
+                      .replace('service-cert\n', 'service-cert"\n')
+            # Templatize certificate dnsNames
+            content = content.replace('.opendatahub-operator.svc', '.{{ .Values.namespace }}.svc')
+
+            # Fix ServiceAccount missing namespace (olm-extractor bug)
+            if kind == 'ServiceAccount':
+                obj_check = yaml.safe_load(content)
+                if 'namespace' not in obj_check.get('metadata', {}):
+                    content = content.replace(
+                        f'  name: {name}',
+                        f'  name: {name}\n  namespace: {{{{ .Values.namespace }}}}'
+                    )
+
+            with open(filepath, 'w') as out:
+                out.write(content + '\n')
+
+    except Exception as e:
+        print(f"Error processing manifest: {e}", file=sys.stderr)
+        sys.exit(1)
+
+print(f"Created {crd_count} CRDs")
+print(f"Created {other_count} templates")
+PYEOF
+
+# Update bundle.version in values.yaml
+sed -i '/^bundle:/,/^[a-z]/{s/  version: ".*"/  version: "'"$VERSION"'"/}' "$CHART_DIR/values.yaml"
+
+echo ""
+echo "============================================"
+echo "  Update Complete!"
+echo "============================================"
+echo ""
+echo "Chart updated at: $CHART_DIR"
+echo "New version: $VERSION"
+echo ""
+echo "Next steps:"
+echo "  1. Review extracted manifests"
+echo "  2. Test with: helm template rhoai-operator $CHART_DIR"

--- a/charts/rhoai-operator/templates/certificate-opendatahub-operator-controller-manager-service-ce.yaml
+++ b/charts/rhoai-operator/templates/certificate-opendatahub-operator-controller-manager-service-ce.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: opendatahub-operator-controller-manager-service-cert
+  namespace: {{ .Values.namespace }}
+spec:
+  dnsNames:
+    - opendatahub-operator-controller-manager-service.{{ .Values.namespace }}.svc
+    - opendatahub-operator-controller-manager-service.{{ .Values.namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: opendatahub-operator-controller-manager-selfsigned
+  secretName: opendatahub-operator-controller-webhook-cert

--- a/charts/rhoai-operator/templates/clusterrole-opendatahub-operator-controller-manager-clusterrol.yaml
+++ b/charts/rhoai-operator/templates/clusterrole-opendatahub-operator-controller-manager-clusterrol.yaml
@@ -1,0 +1,1326 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opendatahub-operator-controller-manager-clusterrole
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - clusterversions
+      - nodes
+      - rhmis
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - deployments
+      - events
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - secrets
+      - secrets/finalizers
+      - serviceaccounts
+      - services
+      - services/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps/status
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces/finalizers
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups:
+      - '*'
+    resources:
+      - deployments
+      - services
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - '*'
+      - apps
+      - extensions
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
+      - validatingwebhookconfigurations
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - deployments/finalizers
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflows
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - autoscaling.openshift.io
+      - machine.openshift.io
+    resources:
+      - machineautoscalers
+      - machinesets
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+      - jobs/status
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - build.openshift.io
+    resources:
+      - buildconfigs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - build.openshift.io
+    resources:
+      - buildconfigs/instantiate
+      - builds
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+      - issuers
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - codeflares
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - codeflares/status
+    verbs:
+      - get
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - dashboards
+      - datasciencepipelines
+      - feastoperators
+      - kserves
+      - kueues
+      - llamastackoperators
+      - mlflowoperators
+      - modelcontrollers
+      - modelmeshservings
+      - modelregistries
+      - modelsasservices
+      - rays
+      - sparkoperators
+      - trainers
+      - trainingoperators
+      - trustyais
+      - workbenches
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - dashboards/finalizers
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - use
+      - watch
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - dashboards/status
+      - datasciencepipelines/status
+      - feastoperators/status
+      - kserves/status
+      - kueues/status
+      - llamastackoperators/status
+      - mlflowoperators/status
+      - modelcontrollers/status
+      - modelmeshservings/status
+      - modelregistries/status
+      - modelsasservices/status
+      - rays/status
+      - sparkoperators/status
+      - trainers/status
+      - trainingoperators/status
+      - trustyais/status
+      - workbenches/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - datasciencepipelines/finalizers
+      - feastoperators/finalizers
+      - kserves/finalizers
+      - kueues/finalizers
+      - llamastackoperators/finalizers
+      - mlflowoperators/finalizers
+      - modelcontrollers/finalizers
+      - modelmeshservings/finalizers
+      - modelregistries/finalizers
+      - modelsasservices/finalizers
+      - rays/finalizers
+      - sparkoperators/finalizers
+      - trainers/finalizers
+      - trainingoperators/finalizers
+      - trustyais/finalizers
+      - workbenches/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - authentications
+      - clusterversions
+      - infrastructures
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+  - apiGroups:
+      - console.openshift.io
+    resources:
+      - consolelinks
+      - odhquickstarts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - controller-runtime.sigs.k8s.io
+    resources:
+      - controllermanagerconfigs
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - dashboard.opendatahub.io
+    resources:
+      - acceleratorprofiles
+      - odhapplications
+      - odhdocuments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - dashboard.opendatahub.io
+    resources:
+      - hardwareprofiles
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - datasciencecluster.opendatahub.io
+    resources:
+      - datascienceclusters
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datasciencecluster.opendatahub.io
+    resources:
+      - datascienceclusters/finalizers
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datasciencecluster.opendatahub.io
+    resources:
+      - datascienceclusters/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datasciencepipelinesapplications.opendatahub.io
+    resources:
+      - datasciencepipelinesapplications
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datasciencepipelinesapplications.opendatahub.io
+    resources:
+      - datasciencepipelinesapplications/finalizers
+      - datasciencepipelinesapplications/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - dscinitialization.opendatahub.io
+    resources:
+      - dscinitializations
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - dscinitialization.opendatahub.io
+    resources:
+      - dscinitializations/finalizers
+      - dscinitializations/status
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - extensions.kuadrant.io
+    resources:
+      - telemetrypolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - features.opendatahub.io
+    resources:
+      - featuretrackers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - features.opendatahub.io
+    resources:
+      - featuretrackers/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - features.opendatahub.io
+    resources:
+      - featuretrackers/status
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - image.openshift.io
+    resources:
+      - imagestreams
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - image.openshift.io
+    resources:
+      - imagestreamtags
+      - registry/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - inference.networking.k8s.io
+    resources:
+      - inferencepools
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - inference.networking.x-k8s.io
+    resources:
+      - inferencemodels
+      - inferencepools
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - hardwareprofiles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - hardwareprofiles/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - hardwareprofiles/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - integreatly.org
+    resources:
+      - rhmis
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - keda.sh
+    resources:
+      - triggerauthentications
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kuadrant.io
+    resources:
+      - authpolicies
+      - ratelimitpolicies
+      - telemetrypolicies
+      - tokenratelimitpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kuadrant.io
+    resources:
+      - kuadrants
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - notebooks
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kueue.openshift.io
+    resources:
+      - kueues
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kueue.openshift.io
+    resources:
+      - kueues/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - clusterqueues
+      - localqueues
+      - resourceflavors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - clusterqueues/status
+      - localqueues/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - machinelearning.seldon.io
+    resources:
+      - seldondeployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - mlflow.opendatahub.io
+    resources:
+      - mlflows
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - mlflow.opendatahub.io
+    resources:
+      - mlflows/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - mlflow.opendatahub.io
+    resources:
+      - mlflows/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - modelregistry.opendatahub.io
+    resources:
+      - modelregistries
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - modelregistry.opendatahub.io
+    resources:
+      - modelregistries/finalizers
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - modelregistry.opendatahub.io
+    resources:
+      - modelregistries/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - alertmanagerconfigs
+      - alertmanagers
+      - alertmanagers/finalizers
+      - alertmanagers/status
+      - probes
+      - prometheuses
+      - prometheuses/finalizers
+      - prometheuses/status
+      - thanosrulers
+      - thanosrulers/finalizers
+      - thanosrulers/status
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - patch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - podmonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+      - servicemonitors
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.rhobs
+    resources:
+      - monitoringstacks
+      - prometheusrules
+      - servicemonitors
+      - thanosqueriers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.rhobs
+    resources:
+      - monitoringstacks/finalizers
+      - prometheusrules/finalizers
+      - servicemonitors/finalizers
+      - thanosqueriers/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - monitoring.rhobs
+    resources:
+      - monitoringstacks/status
+      - prometheusrules/status
+      - servicemonitors/status
+      - thanosqueriers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - destinationrules
+      - envoyfilters
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - oauth.openshift.io
+    resources:
+      - oauthclients
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opendatahub.io
+    resources:
+      - odhdashboardconfigs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - instrumentations
+      - opentelemetrycollectors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - instrumentations/finalizers
+      - opentelemetrycollectors/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - instrumentations/status
+      - opentelemetrycollectors/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - consoles
+      - ingresscontrollers
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - jobsetoperators
+      - leaderworkersetoperators
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - catalogsources
+      - operatorconditions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+    verbs:
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - subscriptions
+    verbs:
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - perses.dev
+    resources:
+      - perses
+      - persesdashboards
+      - persesdatasources
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - perses.dev
+    resources:
+      - perses/finalizers
+      - persesdashboards/finalizers
+      - persesdatasources/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - perses.dev
+    resources:
+      - perses/status
+      - persesdashboards/status
+      - persesdatasources/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ray.io
+    resources:
+      - rayclusters
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+  - apiGroups:
+      - ray.io
+    resources:
+      - rayjobs
+      - rayservices
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+      - roles
+    verbs:
+      - '*'
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routers/federate
+      - routers/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes/custom-host
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - use
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - anyuid
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - use
+      - watch
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - restricted
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - use
+      - watch
+  - apiGroups:
+      - services.platform.opendatahub.io
+    resources:
+      - auths
+      - gatewayconfigs
+      - monitorings
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - services.platform.opendatahub.io
+    resources:
+      - auths/finalizers
+      - gatewayconfigs/finalizers
+      - monitorings/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - services.platform.opendatahub.io
+    resources:
+      - auths/status
+      - gatewayconfigs/status
+      - monitorings/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterservingruntimes
+      - clusterservingruntimes/finalizers
+      - inferencegraphs
+      - inferenceservices
+      - inferenceservices/finalizers
+      - llminferenceserviceconfigs
+      - predictors
+      - servingruntimes
+      - servingruntimes/finalizers
+      - trainedmodels
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterservingruntimes/status
+      - inferencegraphs/status
+      - inferenceservices/status
+      - predictors/status
+      - trainedmodels/status
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - llminferenceserviceconfigs/status
+      - predictors/finalizers
+      - servingruntimes/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - llminferenceservices
+      - llminferenceservices/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshots
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - template.openshift.io
+    resources:
+      - templates
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - tempo.grafana.com
+    resources:
+      - tempomonolithics
+      - tempostacks
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - trainer.kubeflow.org
+    resources:
+      - clustertrainingruntimes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - user.openshift.io
+    resources:
+      - groups
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - user.openshift.io
+    resources:
+      - users
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/charts/rhoai-operator/templates/clusterrole-opendatahub-operator-metrics-reader.yaml
+++ b/charts/rhoai-operator/templates/clusterrole-opendatahub-operator-metrics-reader.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opendatahub-operator-metrics-reader
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get

--- a/charts/rhoai-operator/templates/clusterrole-prometheus-k8s-viewer.yaml
+++ b/charts/rhoai-operator/templates/clusterrole-prometheus-k8s-viewer.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-k8s-viewer
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - endpoints
+    verbs:
+      - get
+      - watch
+      - list

--- a/charts/rhoai-operator/templates/clusterrolebinding-opendatahub-operator-controller-manager-clusterrol.yaml
+++ b/charts/rhoai-operator/templates/clusterrolebinding-opendatahub-operator-controller-manager-clusterrol.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: opendatahub-operator-controller-manager-clusterrolebinding
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: opendatahub-operator-controller-manager-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: opendatahub-operator-controller-manager
+    namespace: {{ .Values.namespace }}

--- a/charts/rhoai-operator/templates/clusterrolebinding-prometheus-k8s-viewer.yaml
+++ b/charts/rhoai-operator/templates/clusterrolebinding-prometheus-k8s-viewer.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-k8s-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-k8s-viewer
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/charts/rhoai-operator/templates/deployment-opendatahub-operator-controller-manager.yaml
+++ b/charts/rhoai-operator/templates/deployment-opendatahub-operator-controller-manager.yaml
@@ -1,0 +1,110 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+    name: opendatahub-operator
+  name: opendatahub-operator-controller-manager
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      name: opendatahub-operator
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+        name: opendatahub-operator
+      namespace: {{ .Values.namespace }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: name
+                      operator: In
+                      values:
+                        - opendatahub-operator
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      containers:
+        - args:
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=0.0.0.0:8080
+            - --leader-elect
+          command:
+            - /manager
+          env:
+            - name: DISABLE_DSC_CONFIG
+              value: "true"
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DEFAULT_MANIFESTS_PATH
+              value: /opt/manifests
+            - name: ODH_PLATFORM_TYPE
+              value: OpenDataHub
+          image: quay.io/opendatahub/opendatahub-operator:latest
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 4Gi
+            requests:
+              cpu: 100m
+              memory: 780Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: opendatahub-operator-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: opendatahub-operator-controller-webhook-cert

--- a/charts/rhoai-operator/templates/issuer-opendatahub-operator-controller-manager-selfsigned.yaml
+++ b/charts/rhoai-operator/templates/issuer-opendatahub-operator-controller-manager-selfsigned.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: opendatahub-operator-controller-manager-selfsigned
+  namespace: {{ .Values.namespace }}
+spec:
+  selfSigned: {}

--- a/charts/rhoai-operator/templates/mutatingwebhookconfiguration-connection-isvc-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/mutatingwebhookconfiguration-connection-isvc-opendatahub-io.yaml
@@ -1,0 +1,28 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: connection-isvc.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /platform-connection-isvc
+        port: 443
+    failurePolicy: Fail
+    name: connection-isvc.opendatahub.io
+    rules:
+      - apiGroups:
+          - serving.kserve.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - inferenceservices
+    sideEffects: NoneOnDryRun

--- a/charts/rhoai-operator/templates/mutatingwebhookconfiguration-connection-llmisvc-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/mutatingwebhookconfiguration-connection-llmisvc-opendatahub-io.yaml
@@ -1,0 +1,28 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: connection-llmisvc.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /platform-connection-llmisvc
+        port: 443
+    failurePolicy: Fail
+    name: connection-llmisvc.opendatahub.io
+    rules:
+      - apiGroups:
+          - serving.kserve.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - llminferenceservices
+    sideEffects: NoneOnDryRun

--- a/charts/rhoai-operator/templates/mutatingwebhookconfiguration-connection-notebook-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/mutatingwebhookconfiguration-connection-notebook-opendatahub-io.yaml
@@ -1,0 +1,28 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: connection-notebook.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /platform-connection-notebook
+        port: 443
+    failurePolicy: Fail
+    name: connection-notebook.opendatahub.io
+    rules:
+      - apiGroups:
+          - kubeflow.org
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - notebooks
+    sideEffects: None

--- a/charts/rhoai-operator/templates/mutatingwebhookconfiguration-datasciencecluster-v1-defaulter-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/mutatingwebhookconfiguration-datasciencecluster-v1-defaulter-opendatahub-io.yaml
@@ -1,0 +1,29 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: datasciencecluster-v1-defaulter.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /mutate-datasciencecluster-v1
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Exact
+    name: datasciencecluster-v1-defaulter.opendatahub.io
+    rules:
+      - apiGroups:
+          - datasciencecluster.opendatahub.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - datascienceclusters
+    sideEffects: None

--- a/charts/rhoai-operator/templates/mutatingwebhookconfiguration-datasciencecluster-v2-defaulter-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/mutatingwebhookconfiguration-datasciencecluster-v2-defaulter-opendatahub-io.yaml
@@ -1,0 +1,29 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: datasciencecluster-v2-defaulter.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /mutate-datasciencecluster-v2
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Exact
+    name: datasciencecluster-v2-defaulter.opendatahub.io
+    rules:
+      - apiGroups:
+          - datasciencecluster.opendatahub.io
+        apiVersions:
+          - v2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - datascienceclusters
+    sideEffects: None

--- a/charts/rhoai-operator/templates/mutatingwebhookconfiguration-hardwareprofile-isvc-injector-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/mutatingwebhookconfiguration-hardwareprofile-isvc-injector-opendatahub-io.yaml
@@ -1,0 +1,28 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: hardwareprofile-isvc-injector.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /mutate-hardware-profile
+        port: 443
+    failurePolicy: Fail
+    name: hardwareprofile-isvc-injector.opendatahub.io
+    rules:
+      - apiGroups:
+          - serving.kserve.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - inferenceservices
+    sideEffects: None

--- a/charts/rhoai-operator/templates/mutatingwebhookconfiguration-hardwareprofile-llmisvc-injector-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/mutatingwebhookconfiguration-hardwareprofile-llmisvc-injector-opendatahub-io.yaml
@@ -1,0 +1,28 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: hardwareprofile-llmisvc-injector.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /mutate-hardware-profile
+        port: 443
+    failurePolicy: Fail
+    name: hardwareprofile-llmisvc-injector.opendatahub.io
+    rules:
+      - apiGroups:
+          - serving.kserve.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - llminferenceservices
+    sideEffects: None

--- a/charts/rhoai-operator/templates/mutatingwebhookconfiguration-hardwareprofile-notebook-injector-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/mutatingwebhookconfiguration-hardwareprofile-notebook-injector-opendatahub-io.yaml
@@ -1,0 +1,28 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: hardwareprofile-notebook-injector.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /mutate-hardware-profile
+        port: 443
+    failurePolicy: Fail
+    name: hardwareprofile-notebook-injector.opendatahub.io
+    rules:
+      - apiGroups:
+          - kubeflow.org
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - notebooks
+    sideEffects: None

--- a/charts/rhoai-operator/templates/namespace.yaml
+++ b/charts/rhoai-operator/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}

--- a/charts/rhoai-operator/templates/service-opendatahub-operator-controller-manager-metrics-se.yaml
+++ b/charts/rhoai-operator/templates/service-opendatahub-operator-controller-manager-metrics-se.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: opendatahub-operator-controller-manager-metrics-service
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    control-plane: controller-manager

--- a/charts/rhoai-operator/templates/service-opendatahub-operator-controller-manager-service.yaml
+++ b/charts/rhoai-operator/templates/service-opendatahub-operator-controller-manager-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: opendatahub-operator-controller-manager-service
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 443
+  selector:
+    app.kubernetes.io/name: opendatahub-operator-controller-manager-service

--- a/charts/rhoai-operator/templates/service-opendatahub-operator-controller-manager-webhook-se.yaml
+++ b/charts/rhoai-operator/templates/service-opendatahub-operator-controller-manager-webhook-se.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: opendatahub-operator-controller-manager-webhook-service
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    name: opendatahub-operator-controller-manager

--- a/charts/rhoai-operator/templates/serviceaccount-opendatahub-operator-controller-manager.yaml
+++ b/charts/rhoai-operator/templates/serviceaccount-opendatahub-operator-controller-manager.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opendatahub-operator-controller-manager
+  namespace: {{ .Values.namespace }}

--- a/charts/rhoai-operator/templates/validatingwebhookconfiguration-dashboard-acceleratorprofile-validator-opendatahub.yaml
+++ b/charts/rhoai-operator/templates/validatingwebhookconfiguration-dashboard-acceleratorprofile-validator-opendatahub.yaml
@@ -1,0 +1,28 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: dashboard-acceleratorprofile-validator.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /validate-dashboard-acceleratorprofile
+        port: 443
+    failurePolicy: Fail
+    name: dashboard-acceleratorprofile-validator.opendatahub.io
+    rules:
+      - apiGroups:
+          - dashboard.opendatahub.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - acceleratorprofiles
+    sideEffects: None

--- a/charts/rhoai-operator/templates/validatingwebhookconfiguration-dashboard-hardwareprofile-validator-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/validatingwebhookconfiguration-dashboard-hardwareprofile-validator-opendatahub-io.yaml
@@ -1,0 +1,28 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: dashboard-hardwareprofile-validator.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /validate-dashboard-hardwareprofile
+        port: 443
+    failurePolicy: Fail
+    name: dashboard-hardwareprofile-validator.opendatahub.io
+    rules:
+      - apiGroups:
+          - dashboard.opendatahub.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - hardwareprofiles
+    sideEffects: None

--- a/charts/rhoai-operator/templates/validatingwebhookconfiguration-datasciencecluster-v1-validator-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/validatingwebhookconfiguration-datasciencecluster-v1-validator-opendatahub-io.yaml
@@ -1,0 +1,29 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: datasciencecluster-v1-validator.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /validate-datasciencecluster-v1
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Exact
+    name: datasciencecluster-v1-validator.opendatahub.io
+    rules:
+      - apiGroups:
+          - datasciencecluster.opendatahub.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - datascienceclusters
+    sideEffects: None

--- a/charts/rhoai-operator/templates/validatingwebhookconfiguration-datasciencecluster-v2-validator-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/validatingwebhookconfiguration-datasciencecluster-v2-validator-opendatahub-io.yaml
@@ -1,0 +1,28 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: datasciencecluster-v2-validator.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /validate-datasciencecluster-v2
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Exact
+    name: datasciencecluster-v2-validator.opendatahub.io
+    rules:
+      - apiGroups:
+          - datasciencecluster.opendatahub.io
+        apiVersions:
+          - v2
+        operations:
+          - CREATE
+        resources:
+          - datascienceclusters
+    sideEffects: None

--- a/charts/rhoai-operator/templates/validatingwebhookconfiguration-dscinitialization-v1-validator-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/validatingwebhookconfiguration-dscinitialization-v1-validator-opendatahub-io.yaml
@@ -1,0 +1,29 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: dscinitialization-v1-validator.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /validate-dscinitialization-v1
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Exact
+    name: dscinitialization-v1-validator.opendatahub.io
+    rules:
+      - apiGroups:
+          - dscinitialization.opendatahub.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - DELETE
+        resources:
+          - dscinitializations
+    sideEffects: None

--- a/charts/rhoai-operator/templates/validatingwebhookconfiguration-dscinitialization-v2-validator-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/validatingwebhookconfiguration-dscinitialization-v2-validator-opendatahub-io.yaml
@@ -1,0 +1,29 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: dscinitialization-v2-validator.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /validate-dscinitialization-v2
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Exact
+    name: dscinitialization-v2-validator.opendatahub.io
+    rules:
+      - apiGroups:
+          - dscinitialization.opendatahub.io
+        apiVersions:
+          - v2
+        operations:
+          - CREATE
+          - DELETE
+        resources:
+          - dscinitializations
+    sideEffects: None

--- a/charts/rhoai-operator/templates/validatingwebhookconfiguration-kserve-isvc-kueuelabels-validator-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/validatingwebhookconfiguration-kserve-isvc-kueuelabels-validator-opendatahub-io.yaml
@@ -1,0 +1,28 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: kserve-isvc-kueuelabels-validator.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /validate-kueue
+        port: 443
+    failurePolicy: Fail
+    name: kserve-isvc-kueuelabels-validator.opendatahub.io
+    rules:
+      - apiGroups:
+          - serving.kserve.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - inferenceservices
+    sideEffects: None

--- a/charts/rhoai-operator/templates/validatingwebhookconfiguration-kserve-llmisvc-kueuelabels-validator-opendatahub-i.yaml
+++ b/charts/rhoai-operator/templates/validatingwebhookconfiguration-kserve-llmisvc-kueuelabels-validator-opendatahub-i.yaml
@@ -1,0 +1,28 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: kserve-llmisvc-kueuelabels-validator.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /validate-kueue
+        port: 443
+    failurePolicy: Fail
+    name: kserve-llmisvc-kueuelabels-validator.opendatahub.io
+    rules:
+      - apiGroups:
+          - serving.kserve.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - llminferenceservices
+    sideEffects: None

--- a/charts/rhoai-operator/templates/validatingwebhookconfiguration-kubeflow-kueuelabels-validator-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/validatingwebhookconfiguration-kubeflow-kueuelabels-validator-opendatahub-io.yaml
@@ -1,0 +1,29 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: kubeflow-kueuelabels-validator.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /validate-kueue
+        port: 443
+    failurePolicy: Fail
+    name: kubeflow-kueuelabels-validator.opendatahub.io
+    rules:
+      - apiGroups:
+          - kubeflow.org
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - pytorchjobs
+          - notebooks
+    sideEffects: None

--- a/charts/rhoai-operator/templates/validatingwebhookconfiguration-ray-kueuelabels-validator-opendatahub-io.yaml
+++ b/charts/rhoai-operator/templates/validatingwebhookconfiguration-ray-kueuelabels-validator-opendatahub-io.yaml
@@ -1,0 +1,30 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Values.namespace }}/opendatahub-operator-controller-manager-service-cert"
+  name: ray-kueuelabels-validator.opendatahub.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: opendatahub-operator-controller-manager-service
+        namespace: {{ .Values.namespace }}
+        path: /validate-kueue
+        port: 443
+    failurePolicy: Fail
+    name: ray-kueuelabels-validator.opendatahub.io
+    rules:
+      - apiGroups:
+          - ray.io
+        apiVersions:
+          - v1
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - rayjobs
+          - rayclusters
+    sideEffects: None

--- a/charts/rhoai-operator/values.yaml
+++ b/charts/rhoai-operator/values.yaml
@@ -1,0 +1,5 @@
+# RHOAI Operator Helm Chart
+namespace: opendatahub-operator
+
+bundle:
+  version: "v3.4.0-ea.1"


### PR DESCRIPTION
 Summary:
 Add Helm chart for deploying the OpenDataHub/RHOAI operator on xKS clusters without OLM
 Add Konflux Tekton pipeline to build and publish the chart as an OCI artifact

1.  RHOAI operator Helm chart
    Chart extracted from quay.io/opendatahub/opendatahub-operator-bundle:v3.4.0-ea.1 using olm-extractor
    Namespace configurable via values.yaml (default: opendatahub-operator)
    Includes update-bundle.sh script for upgrading to newer versions
 
 2. Knoflux build pipeline 
    .tekton/rhoai-operator-helm-push.yaml   triggers on push to main
    Uses build-helm-chart-oci-ta:0.3 task to package and push to OCI registry
    Publishes to quay.io/redhat-user-workloads/open-data-hub-tenant/opendatahub-poc/rhoai-operator-helm

  
Custom Templates (preserved across bundle updates)
  - namespace.yaml — creates operator namespace
  - issuer-opendatahub-operator-controller-manager-selfsigned.yaml — manually maintained because olm-extractor strips selfSigned: {} (empty map bug)

Known Issue
The operator currently crashes on startup on vanilla Kubernetes because it calls OLM APIs (operators.coreos.com/v1alpha1) and OpenShift APIs that don't exist. This requires a code change in the opendatahub-operator — tracked separately. The chart itself installs correctly.

  Test Plan
  - helm template renders correctly
  - helm lint passes
  - Chart installs on AKS, pods start
  - Operator runs successfully (blocked on upstream operator fix)
  -  Konflux pipeline builds and pushes OCI artifact (requires namespace onboarding)


Testing Knoflux : 
# 1. Lint the chart
  helm lint charts/rhoai-operator/

  # 2. Template it (verify it renders)
  helm template rhoai-operator charts/rhoai-operator/

  # 3. Package it (what the task does internally)
  helm package charts/rhoai-operator/

  # 4. (Optional) Push to your own registry to test OCI flow
  helm push rhoai-operator-1.0.0.tgz oci://quay.io/aneeshkp/

  # 5. (Optional) Pull it back to verify
  helm pull oci://quay.io/aneeshkp/rhoai-operator --version 1.0.0

  Steps 1-3 validate everything the pipeline would do. The actual Konflux pipeline just wraps these commands with git clone, trusted artifacts, and security scanning on top.

  For the Tekton YAML itself, you can validate the syntax:

  # Check if the YAML is valid
  kubectl apply --dry-run=client -f .tekton/rhoai-operator-helm-push.yaml

  This will fail (missing Konflux CRDs locally) but will catch YAML syntax errors.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm chart to deploy the RHOAI Operator on vanilla Kubernetes, including deployment, services, namespace, certs, webhooks, and RBAC.
  * New cluster CustomResources for 20+ platform components (KServe, Kueue, Monitoring, Ray, TrustyAI, ModelRegistry, and more) with schemas, status, and kubectl printer columns.
  * Admission webhooks for validation and mutation across multiple resources.

* **Chores**
  * CI/task automation and a script to update chart bundle versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->