### PR TITLE
feat: add support for pin a speicific version of operator to be installed

### DIFF
--- a/charts/cert-manager-operator/api-docs.md
+++ b/charts/cert-manager-operator/api-docs.md
@@ -1,0 +1,20 @@
+# cert-manager-operator
+
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15.5](https://img.shields.io/badge/AppVersion-1.15.5-informational?style=flat-square)
+
+Red Hat cert-manager Operator for vanilla Kubernetes (without OLM)
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Red Hat |  |  |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| bundle.version | string | `"v1.15.2"` |  |
+| operandNamespace | string | `"cert-manager"` |  |
+| operatorNamespace | string | `"cert-manager-operator"` |  |
+

--- a/charts/lws-operator/api-docs.md
+++ b/charts/lws-operator/api-docs.md
@@ -1,0 +1,23 @@
+# lws-operator
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+
+Red Hat Leader Worker Set Operator for Kubernetes
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Red Hat |  |  |
+
+## Source Code
+
+* <https://github.com/kubernetes-sigs/lws>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| bundle.version | string | `"1.0"` |  |
+| namespace | string | `"openshift-lws-operator"` |  |
+

--- a/charts/odh-rhoai/README.md
+++ b/charts/odh-rhoai/README.md
@@ -271,6 +271,30 @@ Then run the TLS preparation script after the Kuadrant operator has created the 
 ./scripts/prepare-authorino-tls.sh
 ```
 
+### Example: Pin operator to specific version
+
+By default, operators install the latest version available in their channel. To pin an operator to a specific version:
+
+```yaml
+# values.yaml
+dependencies:
+  rhcl:
+    enabled: auto
+    olm:
+      channel: stable
+      version: v1.2.1  # Pin to specific version
+```
+
+**How it works:**
+- **Without `version`**: OLM installs the latest operator version from the channel
+- **With `version`**: OLM installs the specified version (`startingCSV: rhcl-operator.v1.2.1`)
+- The version must exist in the specified channel or the subscription will fail
+
+**Use cases:**
+- Testing with a known-good version
+- Ensuring consistent deployments across environments
+- Avoiding automatic upgrades to newer versions
+
 ## Values Reference
 
 ### Global Settings

--- a/charts/odh-rhoai/README.md
+++ b/charts/odh-rhoai/README.md
@@ -286,14 +286,30 @@ dependencies:
 ```
 
 **How it works:**
-- **Without `version`**: OLM installs the latest operator version from the channel
-- **With `version`**: OLM installs the specified version (`startingCSV: rhcl-operator.v1.2.1`)
+- **Without `version`**: OLM installs the latest operator version from the channel and upgrades automatically
+- **With `version`**: OLM installs the specified version (`startingCSV: rhcl-operator.v1.2.1`) and **automatically sets `installPlanApproval: Manual`** to prevent automatic upgrades
 - The version must exist in the specified channel or the subscription will fail
+
+**Install Plan Approval Logic:**
+1. **Only `installPlanApproval` set**: Uses the specified approval mode
+2. **Only `version` set**: Auto-sets `installPlanApproval: Manual` to lock the version
+3. **Both `version` and `installPlanApproval` set**: Uses both (useful for minimum version scenarios)
+4. **Neither set**: Explicitly sets `installPlanApproval: Automatic`
+
+**Example - Override to allow upgrades despite version pinning:**
+```yaml
+dependencies:
+  rhcl:
+    olm:
+      version: v1.2.1  # Minimum version
+      installPlanApproval: Automatic  # Still allow auto-upgrades
+```
 
 **Use cases:**
 - Testing with a known-good version
 - Ensuring consistent deployments across environments
-- Avoiding automatic upgrades to newer versions
+- Preventing automatic upgrades to newer versions
+- Setting a minimum version while still allowing upgrades
 
 ## Values Reference
 

--- a/charts/odh-rhoai/templates/definitions/_operator.tpl
+++ b/charts/odh-rhoai/templates/definitions/_operator.tpl
@@ -49,6 +49,7 @@ Arguments (passed as dict):
   - name: subscription/operator name
   - namespace: namespace name
   - channel: subscription channel
+  - version: operator version (optional, for version pinning) input: v$version (e.g., "v1.0.5") to form startingCSV: $name.$version
   - source: catalog source (optional, uses global default)
   - sourceNamespace: catalog source namespace (optional, uses global default)
   - installPlanApproval: install plan approval (optional, uses global default)
@@ -72,6 +73,9 @@ spec:
   name: {{ .name }}
   source: {{ $source }}
   sourceNamespace: {{ $sourceNamespace }}
+  {{- with .version }}
+  startingCSV: {{ $.name }}.{{ . }}
+  {{- end }}
   {{- with .config }}
   config:
     {{- toYaml . | nindent 4 }}
@@ -84,6 +88,7 @@ Arguments (passed as dict):
   - name: operator name
   - namespace: namespace name
   - channel: subscription channel
+  - version: operator version (optional, for version pinning) input: v$version (e.g., "v1.0.5") to form startingCSV: $name.$version
   - source: catalog source (optional)
   - sourceNamespace: catalog source namespace (optional)
   - installPlanApproval: install plan approval (optional)

--- a/charts/odh-rhoai/templates/definitions/_operator.tpl
+++ b/charts/odh-rhoai/templates/definitions/_operator.tpl
@@ -49,17 +49,26 @@ Arguments (passed as dict):
   - name: subscription/operator name
   - namespace: namespace name
   - channel: subscription channel
-  - version: operator version (optional, for version pinning) input: v$version (e.g., "v1.0.5") to form startingCSV: $name.$version
   - source: catalog source (optional, uses global default)
   - sourceNamespace: catalog source namespace (optional, uses global default)
-  - installPlanApproval: install plan approval (optional, uses global default)
+  - version: operator version (optional, for version pinning) input: v$version (e.g., "v1.0.5") to form startingCSV: $name.$version
+  - installPlanApproval: install plan approval (optional)
+      Logic: 1) if only installPlanApproval set: use it
+             2) if only version set: auto-set installPlanApproval to "Manual" to prevent upgrade
+             3) if both version and installPlanApproval set: use both, this is for a minimum version case
+             4) if neither set: explicitly set to "Automatic"
   - config: configuration for the subscription (optional)
   - root: root context ($)
 */}}
 {{- define "rhoai-dependencies.operator.subscription" -}}
 {{- $source := default .root.Values.olm.source .source -}}
 {{- $sourceNamespace := default .root.Values.olm.sourceNamespace .sourceNamespace -}}
-{{- $installPlanApproval := default .root.Values.olm.installPlanApproval .installPlanApproval -}}
+{{- $installPlanApproval := "Automatic" -}}
+{{- if .installPlanApproval -}}
+{{- $installPlanApproval = .installPlanApproval -}}
+{{- else if .version -}}
+{{- $installPlanApproval = "Manual" -}}
+{{- end -}}
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -88,10 +97,14 @@ Arguments (passed as dict):
   - name: operator name
   - namespace: namespace name
   - channel: subscription channel
-  - version: operator version (optional, for version pinning) input: v$version (e.g., "v1.0.5") to form startingCSV: $name.$version
   - source: catalog source (optional)
   - sourceNamespace: catalog source namespace (optional)
+  - version: operator version (optional, for version pinning) input: v$version (e.g., "v1.0.5") to form startingCSV: $name.$version
   - installPlanApproval: install plan approval (optional)
+      Logic: 1) if only installPlanApproval set: use it
+             2) if only version set: auto-set installPlanApproval to "Manual" to prevent upgrade
+             3) if both version and installPlanApproval set: use both, this is for a minimum version case
+             4) if neither set: explicitly set to "Automatic"
   - targetNamespaces: list of target namespaces for OperatorGroup (optional)
   - root: root context ($)
 */}}

--- a/charts/odh-rhoai/templates/dependencies/cert-manager/operator.yaml
+++ b/charts/odh-rhoai/templates/dependencies/cert-manager/operator.yaml
@@ -1,8 +1,20 @@
 {{- $dep := .Values.dependencies.certManager -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "certManager" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict
+  "dependencyName" "certManager"
+  "dependency" $dep
+  "dependencies" .Values.dependencies
+  "components" .Values.components
+  "services" .Values.services
+) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if eq (include "rhoai-dependencies.isOlmMode" $) "true" }}
-{{ include "rhoai-dependencies.operator.olm" (dict "name" $dep.olm.name "namespace" $dep.olm.namespace "channel" $dep.olm.channel "root" $) }}
+{{ include "rhoai-dependencies.operator.olm" (dict
+  "name" $dep.olm.name
+  "namespace" $dep.olm.namespace
+  "channel" $dep.olm.channel
+  "version" $dep.olm.version
+  "root" $
+) }}
 {{- end }}
 {{- end }}
 

--- a/charts/odh-rhoai/templates/dependencies/cluster-observability/operator.yaml
+++ b/charts/odh-rhoai/templates/dependencies/cluster-observability/operator.yaml
@@ -1,8 +1,20 @@
 {{- $dep := .Values.dependencies.clusterObservability -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "clusterObservability" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict
+  "dependencyName" "clusterObservability"
+  "dependency" $dep
+  "dependencies" .Values.dependencies
+  "components" .Values.components
+  "services" .Values.services
+) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if eq (include "rhoai-dependencies.isOlmMode" $) "true" }}
-{{ include "rhoai-dependencies.operator.olm" (dict "name" $dep.olm.name "namespace" $dep.olm.namespace "channel" $dep.olm.channel "root" $) }}
+{{ include "rhoai-dependencies.operator.olm" (dict
+  "name" $dep.olm.name
+  "namespace" $dep.olm.namespace
+  "channel" $dep.olm.channel
+  "version" $dep.olm.version
+  "root" $
+) }}
 {{- end }}
 {{- end }}
 

--- a/charts/odh-rhoai/templates/dependencies/custom-metrics-autoscaler/operator.yaml
+++ b/charts/odh-rhoai/templates/dependencies/custom-metrics-autoscaler/operator.yaml
@@ -1,8 +1,20 @@
 {{- $dep := .Values.dependencies.customMetricsAutoscaler -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "customMetricsAutoscaler" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict
+  "dependencyName" "customMetricsAutoscaler"
+  "dependency" $dep
+  "dependencies" .Values.dependencies
+  "components" .Values.components
+  "services" .Values.services
+) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if eq (include "rhoai-dependencies.isOlmMode" $) "true" }}
-{{ include "rhoai-dependencies.operator.olm" (dict "name" $dep.olm.name "namespace" $dep.olm.namespace "channel" $dep.olm.channel "root" $) }}
+{{ include "rhoai-dependencies.operator.olm" (dict
+  "name" $dep.olm.name
+  "namespace" $dep.olm.namespace
+  "channel" $dep.olm.channel
+  "version" $dep.olm.version
+  "root" $
+) }}
 {{- end }}
 {{- end }}
 

--- a/charts/odh-rhoai/templates/dependencies/job-set/operator.yaml
+++ b/charts/odh-rhoai/templates/dependencies/job-set/operator.yaml
@@ -1,7 +1,20 @@
 {{- $dep := .Values.dependencies.jobSet -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "jobSet" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict
+  "dependencyName" "jobSet"
+  "dependency" $dep
+  "dependencies" .Values.dependencies
+  "components" .Values.components
+  "services" .Values.services
+) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if eq (include "rhoai-dependencies.isOlmMode" $) "true" }}
-{{ include "rhoai-dependencies.operator.olm" (dict "name" $dep.olm.name "namespace" $dep.olm.namespace "channel" $dep.olm.channel "targetNamespaces" $dep.olm.targetNamespaces "root" $) }}
+{{ include "rhoai-dependencies.operator.olm" (dict
+  "name" $dep.olm.name
+  "namespace" $dep.olm.namespace
+  "channel" $dep.olm.channel
+  "version" $dep.olm.version
+  "targetNamespaces" $dep.olm.targetNamespaces
+  "root" $
+) }}
 {{- end }}
 {{- end }}

--- a/charts/odh-rhoai/templates/dependencies/kueue/operator.yaml
+++ b/charts/odh-rhoai/templates/dependencies/kueue/operator.yaml
@@ -1,8 +1,20 @@
 {{- $dep := .Values.dependencies.kueue -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "kueue" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict
+  "dependencyName" "kueue"
+  "dependency" $dep
+  "dependencies" .Values.dependencies
+  "components" .Values.components
+  "services" .Values.services
+) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if eq (include "rhoai-dependencies.isOlmMode" $) "true" }}
-{{ include "rhoai-dependencies.operator.olm" (dict "name" $dep.olm.name "namespace" $dep.olm.namespace "channel" $dep.olm.channel "root" $) }}
+{{ include "rhoai-dependencies.operator.olm" (dict
+  "name" $dep.olm.name
+  "namespace" $dep.olm.namespace
+  "channel" $dep.olm.channel
+  "version" $dep.olm.version
+  "root" $
+) }}
 {{- end }}
 {{- end }}
 

--- a/charts/odh-rhoai/templates/dependencies/leader-worker-set/operator.yaml
+++ b/charts/odh-rhoai/templates/dependencies/leader-worker-set/operator.yaml
@@ -1,7 +1,20 @@
 {{- $dep := .Values.dependencies.leaderWorkerSet -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "leaderWorkerSet" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict
+  "dependencyName" "leaderWorkerSet"
+  "dependency" $dep
+  "dependencies" .Values.dependencies
+  "components" .Values.components
+  "services" .Values.services
+) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if eq (include "rhoai-dependencies.isOlmMode" $) "true" }}
-{{ include "rhoai-dependencies.operator.olm" (dict "name" $dep.olm.name "namespace" $dep.olm.namespace "channel" $dep.olm.channel "targetNamespaces" $dep.olm.targetNamespaces "root" $) }}
+{{ include "rhoai-dependencies.operator.olm" (dict
+  "name" $dep.olm.name
+  "namespace" $dep.olm.namespace
+  "channel" $dep.olm.channel
+  "version" $dep.olm.version
+  "targetNamespaces" $dep.olm.targetNamespaces
+  "root" $
+) }}
 {{- end }}
 {{- end }}

--- a/charts/odh-rhoai/templates/dependencies/nfd/operator.yaml
+++ b/charts/odh-rhoai/templates/dependencies/nfd/operator.yaml
@@ -1,7 +1,21 @@
 {{- $dep := .Values.dependencies.nfd -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "nfd" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict
+  "dependencyName" "nfd"
+  "dependency" $dep
+  "dependencies" .Values.dependencies
+  "components" .Values.components
+  "services" .Values.services
+) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if eq (include "rhoai-dependencies.isOlmMode" $) "true" }}
-{{ include "rhoai-dependencies.operator.olm" (dict "name" $dep.olm.name "namespace" $dep.olm.namespace "channel" $dep.olm.channel "source" $dep.olm.source "targetNamespaces" $dep.olm.targetNamespaces "root" $) }}
+{{ include "rhoai-dependencies.operator.olm" (dict
+  "name" $dep.olm.name
+  "namespace" $dep.olm.namespace
+  "channel" $dep.olm.channel
+  "version" $dep.olm.version
+  "source" $dep.olm.source
+  "targetNamespaces" $dep.olm.targetNamespaces
+  "root" $
+) }}
 {{- end }}
 {{- end }}

--- a/charts/odh-rhoai/templates/dependencies/nvidia-gpu-operator/operator.yaml
+++ b/charts/odh-rhoai/templates/dependencies/nvidia-gpu-operator/operator.yaml
@@ -1,7 +1,21 @@
 {{- $dep := .Values.dependencies.nvidiaGPUOperator -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "nvidiaGPUOperator" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict
+  "dependencyName" "nvidiaGPUOperator"
+  "dependency" $dep
+  "dependencies" .Values.dependencies
+  "components" .Values.components
+  "services" .Values.services
+) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if eq (include "rhoai-dependencies.isOlmMode" $) "true" }}
-{{ include "rhoai-dependencies.operator.olm" (dict "name" $dep.olm.name "namespace" $dep.olm.namespace "channel" $dep.olm.channel "source" $dep.olm.source "targetNamespaces" $dep.olm.targetNamespaces "root" $) }}
+{{ include "rhoai-dependencies.operator.olm" (dict
+  "name" $dep.olm.name
+  "namespace" $dep.olm.namespace
+  "channel" $dep.olm.channel
+  "version" $dep.olm.version
+  "source" $dep.olm.source
+  "targetNamespaces" $dep.olm.targetNamespaces
+  "root" $
+) }}
 {{- end }}
 {{- end }}

--- a/charts/odh-rhoai/templates/dependencies/opentelemetry/operator.yaml
+++ b/charts/odh-rhoai/templates/dependencies/opentelemetry/operator.yaml
@@ -1,8 +1,20 @@
 {{- $dep := .Values.dependencies.opentelemetry -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "opentelemetry" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict
+  "dependencyName" "opentelemetry"
+  "dependency" $dep
+  "dependencies" .Values.dependencies
+  "components" .Values.components
+  "services" .Values.services
+) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if eq (include "rhoai-dependencies.isOlmMode" $) "true" }}
-{{ include "rhoai-dependencies.operator.olm" (dict "name" $dep.olm.name "namespace" $dep.olm.namespace "channel" $dep.olm.channel "root" $) }}
+{{ include "rhoai-dependencies.operator.olm" (dict
+  "name" $dep.olm.name
+  "namespace" $dep.olm.namespace
+  "channel" $dep.olm.channel
+  "version" $dep.olm.version
+  "root" $
+) }}
 {{- end }}
 {{- end }}
 

--- a/charts/odh-rhoai/templates/dependencies/rhcl/operator.yaml
+++ b/charts/odh-rhoai/templates/dependencies/rhcl/operator.yaml
@@ -1,7 +1,19 @@
 {{- $dep := .Values.dependencies.rhcl -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "rhcl" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict
+  "dependencyName" "rhcl"
+  "dependency" $dep
+  "dependencies" .Values.dependencies
+  "components" .Values.components
+  "services" .Values.services
+) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if eq (include "rhoai-dependencies.isOlmMode" $) "true" }}
-{{ include "rhoai-dependencies.operator.olm" (dict "name" $dep.olm.name "namespace" $dep.olm.namespace "channel" $dep.olm.channel "root" $) }}
+{{ include "rhoai-dependencies.operator.olm" (dict
+  "name" $dep.olm.name
+  "namespace" $dep.olm.namespace
+  "channel" $dep.olm.channel
+  "version" $dep.olm.version
+  "root" $
+) }}
 {{- end }}
 {{- end }}

--- a/charts/odh-rhoai/templates/dependencies/tempo/operator.yaml
+++ b/charts/odh-rhoai/templates/dependencies/tempo/operator.yaml
@@ -1,8 +1,20 @@
 {{- $dep := .Values.dependencies.tempo -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "tempo" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
+{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict
+  "dependencyName" "tempo"
+  "dependency" $dep
+  "dependencies" .Values.dependencies
+  "components" .Values.components
+  "services" .Values.services
+) -}}
 {{- if eq $shouldInstall "true" }}
 {{- if eq (include "rhoai-dependencies.isOlmMode" $) "true" }}
-{{ include "rhoai-dependencies.operator.olm" (dict "name" $dep.olm.name "namespace" $dep.olm.namespace "channel" $dep.olm.channel "root" $) }}
+{{ include "rhoai-dependencies.operator.olm" (dict
+  "name" $dep.olm.name
+  "namespace" $dep.olm.namespace
+  "channel" $dep.olm.channel
+  "version" $dep.olm.version
+  "root" $
+) }}
 {{- end }}
 {{- end }}
 

--- a/charts/odh-rhoai/values.schema.json
+++ b/charts/odh-rhoai/values.schema.json
@@ -330,6 +330,10 @@
             "type": "string"
           },
           "description": "Target namespaces for OperatorGroup (omit for AllNamespaces mode)"
+        },
+        "version": {
+          "type": "string",
+          "description": "Operator version for version pinning (e.g., v1.0.5). If omitted, installs latest from channel. Auto-constructs startingCSV: $name.$version"
         }
       },
       "required": ["channel", "name", "namespace"],

--- a/charts/odh-rhoai/values.yaml
+++ b/charts/odh-rhoai/values.yaml
@@ -366,6 +366,8 @@ dependencies:
       channel: stable
       name: rhcl-operator
       namespace: kuadrant-system
+      # -- (optional) Version to pin operator to (e.g., "v0.8.0"). If omitted, installs latest from channel.
+      # version: v0.8.0
     config:
       # -- Enable Authorino TLS configuration
       tlsEnabled: false

--- a/charts/sail-operator/api-docs.md
+++ b/charts/sail-operator/api-docs.md
@@ -1,0 +1,23 @@
+# sail-operator
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.1](https://img.shields.io/badge/AppVersion-3.2.1-informational?style=flat-square)
+
+Red Hat Sail Operator (OSSM 3.x) for Kubernetes
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Red Hat |  |  |
+
+## Source Code
+
+* <https://github.com/istio-ecosystem/sail-operator>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| bundle.version | string | `"3.2.1"` |  |
+| namespace | string | `"istio-system"` |  |
+


### PR DESCRIPTION


<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
- current implementation only support channel and install the latest version from that channel
- we need make it flex in certain cases dependent operator might release new version without us fully verifiy with compability
  - introduce a new "version" field
- run "make helm-docs" to generate missing docs
- format "dict" for too long lines

## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->
test default(without version)
```
>helm template test charts/odh-rhoai \
  --set skipCrdCheck=true \
  --set dependencies.rhcl.enabled=auto \
  --set dependencies.rhcl.dependencies.certManager=false \
  --set dependencies.rhcl.dependencies.leaderWorkerSet=false \
  --show-only templates/dependencies/rhcl/operator.yaml \
  2>&1 | grep -A 15 "kind: Subscription"
```
Output
```
kind: Subscription
metadata:
  name: rhcl-operator
  namespace: kuadrant-system
  labels:
    helm.sh/chart: odh-rhoai-chart-0.1.0
    app.kubernetes.io/managed-by: Helm
spec:
  channel: stable
  installPlanApproval: Automatic
  name: rhcl-operator
  source: redhat-operators
  sourceNamespace: openshift-marketplace
```
test(new behavior when set version)
```
>helm template test charts/odh-rhoai \
  --set skipCrdCheck=true \
  --set dependencies.rhcl.enabled=auto \
  --set dependencies.rhcl.dependencies.certManager=false \
  --set dependencies.rhcl.dependencies.leaderWorkerSet=false \
  --set dependencies.rhcl.olm.version=v1.2.0 \
  --show-only templates/dependencies/rhcl/operator.yaml \
  2>&1 | grep -A 15 "kind: Subscription"
```
output 
```
kind: Subscription
metadata:
  name: rhcl-operator
  namespace: kuadrant-system
  labels:
    helm.sh/chart: odh-rhoai-chart-0.1.0
    app.kubernetes.io/managed-by: Helm
spec:
  channel: stable
  installPlanApproval: Automatic
  name: rhcl-operator
  source: redhat-operators
  sourceNamespace: openshift-marketplace
  startingCSV: rhcl-operator.v1.2.0
```
- [ ] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator version pinning to lock installs to a specific operator release.
  * Configurable target namespaces for OperatorGroup scoping.

* **Documentation**
  * Added API docs for cert-manager-operator, lws-operator, and sail-operator.
  * Added README examples and guidance showing how to pin operators to specific versions and configure OLM behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->