### PR TITLE
Revert "fix: RHCL operator should be installed in openshift-operators"

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The repository is designed to be applied in **layers**, providing flexibility in
 | **Job Set Operator**               | Job management as a unit                    | `openshift-jobset-operator` | Trainer                      | |
 | **Custom Metrics Autoscaler** | Event-driven autoscaler based on KEDA | `openshift-keda` | Model Serving | |
 | **Tempo Operator** | Distributed tracing backend | `openshift-tempo-operator` | Tracing infrastructure | |
-| **Red Hat Connectivity Link** | Multicloud application connectivity and API management | `openshift-operators` | Model Serving (KServe) | Leader Worker Set, Cert-Manager |
+| **Red Hat Connectivity Link** | Multicloud application connectivity and API management | `kuadrant-system` | Model Serving (KServe) | Leader Worker Set, Cert-Manager |
 | **MariaDB Operator** | MariaDB for OpenShift | `mariadb-operator` | TrustyAI (optional, only if using database mode) | |
 | **Node Feature Discovery** | Detects hardware features and capabilities of nodes | `openshift-nfd` | LlamaStack Operator | |
 | **NVIDIA GPU Operator** | Enables GPU-accelerated workloads on NVIDIA hardware | `nvidia-gpu-operator` | Model Serving, LlamaStack Operator | Node Feature Discovery |

--- a/charts/odh-rhoai/api-docs.md
+++ b/charts/odh-rhoai/api-docs.md
@@ -102,9 +102,8 @@ A Helm chart for installing ODH/RHOAI dependencies and component configurations
 | dependencies.opentelemetry | object | `{"dependencies":{},"enabled":"auto","olm":{"channel":"stable","name":"opentelemetry-product","namespace":"openshift-opentelemetry-operator"}}` | OpenTelemetry operator |
 | dependencies.opentelemetry.dependencies | object | `{}` | Dependencies required by opentelemetry |
 | dependencies.opentelemetry.enabled | string | `"auto"` | Enable opentelemetry: auto (if needed), true (always), false (never) |
-| dependencies.rhcl | object | `{"config":{"authorinoSpec":{"clusterWide":true,"listener":{"tls":{"certSecretRef":{"name":"authorino-server-cert"},"enabled":true}},"oidcServer":{"tls":{"enabled":false}},"replicas":1},"namespace":"kuadrant-system","spec":{},"tlsEnabled":false},"dependencies":{"certManager":true,"leaderWorkerSet":true},"enabled":"auto","olm":{"channel":"stable","name":"rhcl-operator","namespace":"kuadrant-system"}}` | RHCL (Kuadrant) operator |
+| dependencies.rhcl | object | `{"config":{"authorinoSpec":{"clusterWide":true,"listener":{"tls":{"certSecretRef":{"name":"authorino-server-cert"},"enabled":true}},"oidcServer":{"tls":{"enabled":false}},"replicas":1},"spec":{},"tlsEnabled":false},"dependencies":{"certManager":true,"leaderWorkerSet":true},"enabled":"auto","olm":{"channel":"stable","name":"rhcl-operator","namespace":"kuadrant-system"}}` | RHCL (Kuadrant) operator |
 | dependencies.rhcl.config.authorinoSpec | object | `{"clusterWide":true,"listener":{"tls":{"certSecretRef":{"name":"authorino-server-cert"},"enabled":true}},"oidcServer":{"tls":{"enabled":false}},"replicas":1}` | Authorino CR spec (only created if tlsEnabled: true) |
-| dependencies.rhcl.config.namespace | string | `"kuadrant-system"` | Namespace where Kuadrant CR and operands are deployed |
 | dependencies.rhcl.config.spec | object | `{}` | Kuadrant CR spec (user can add any fields) |
 | dependencies.rhcl.config.tlsEnabled | bool | `false` | Enable Authorino TLS configuration |
 | dependencies.rhcl.dependencies | object | `{"certManager":true,"leaderWorkerSet":true}` | Dependencies required by rhcl |

--- a/charts/odh-rhoai/templates/dependencies/rhcl/config.yaml
+++ b/charts/odh-rhoai/templates/dependencies/rhcl/config.yaml
@@ -6,7 +6,7 @@ apiVersion: kuadrant.io/v1beta1
 kind: Kuadrant
 metadata:
   name: kuadrant
-  namespace: {{ $dep.config.namespace }}
+  namespace: {{ $dep.olm.namespace }}
   labels:
     {{- include "rhoai-dependencies.labels" . | nindent 4 }}
 {{- with $dep.config.spec }}

--- a/charts/odh-rhoai/templates/dependencies/rhcl/namespace.yaml
+++ b/charts/odh-rhoai/templates/dependencies/rhcl/namespace.yaml
@@ -1,7 +1,0 @@
-{{- $dep := .Values.dependencies.rhcl -}}
-{{- $shouldInstall := include "rhoai-dependencies.shouldInstall" (dict "dependencyName" "rhcl" "dependency" $dep "dependencies" .Values.dependencies "components" .Values.components "services" .Values.services) -}}
-{{- if eq $shouldInstall "true" }}
-{{- if eq (include "rhoai-dependencies.isOlmMode" $) "true" }}
-{{ include "rhoai-dependencies.operator.namespace" (dict "namespace" $dep.config.namespace "root" $) }}
-{{- end }}
-{{- end }}

--- a/charts/odh-rhoai/test/snapshots/all-components-managed.snap.yaml
+++ b/charts/odh-rhoai/test/snapshots/all-components-managed.snap.yaml
@@ -80,15 +80,6 @@ metadata:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: odh-rhoai-chart/templates/dependencies/rhcl/namespace.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kuadrant-system
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
----
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: v1
 kind: Namespace

--- a/charts/odh-rhoai/test/snapshots/default.snap.yaml
+++ b/charts/odh-rhoai/test/snapshots/default.snap.yaml
@@ -62,15 +62,6 @@ metadata:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: odh-rhoai-chart/templates/dependencies/rhcl/namespace.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kuadrant-system
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
----
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: v1
 kind: Namespace

--- a/charts/odh-rhoai/test/snapshots/skip-crd-check-odh.snap.yaml
+++ b/charts/odh-rhoai/test/snapshots/skip-crd-check-odh.snap.yaml
@@ -62,15 +62,6 @@ metadata:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: odh-rhoai-chart/templates/dependencies/rhcl/namespace.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kuadrant-system
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
----
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: v1
 kind: Namespace

--- a/charts/odh-rhoai/test/snapshots/skip-crd-check-rhoai.snap.yaml
+++ b/charts/odh-rhoai/test/snapshots/skip-crd-check-rhoai.snap.yaml
@@ -62,15 +62,6 @@ metadata:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: odh-rhoai-chart/templates/dependencies/rhcl/namespace.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kuadrant-system
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
----
 # Source: odh-rhoai-chart/templates/dependencies/rhcl/operator.yaml
 apiVersion: v1
 kind: Namespace

--- a/charts/odh-rhoai/values.schema.json
+++ b/charts/odh-rhoai/values.schema.json
@@ -671,11 +671,6 @@
           "type": "object",
           "description": "RHCL configuration",
           "properties": {
-            "namespace": {
-              "type": "string",
-              "default": "kuadrant-system",
-              "description": "Namespace where Kuadrant CR and operands are deployed"
-            },
             "tlsEnabled": {
               "type": "boolean",
               "default": false,

--- a/charts/odh-rhoai/values.yaml
+++ b/charts/odh-rhoai/values.yaml
@@ -369,8 +369,6 @@ dependencies:
       # -- (optional) Version to pin operator to (e.g., "v0.8.0"). If omitted, installs latest from channel.
       # version: v0.8.0
     config:
-      # -- Namespace where Kuadrant CR and operands are deployed
-      namespace: kuadrant-system
       # -- Enable Authorino TLS configuration
       tlsEnabled: false
       # -- Kuadrant CR spec (user can add any fields)

--- a/components/operators/rhcl-operator/kustomization.yaml
+++ b/components/operators/rhcl-operator/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Component
 
 resources:
   - namespace.yaml
+  - operatorgroup.yaml
   - subscription.yaml

--- a/components/operators/rhcl-operator/operatorgroup.yaml
+++ b/components/operators/rhcl-operator/operatorgroup.yaml
@@ -1,0 +1,7 @@
+kind: OperatorGroup
+apiVersion: operators.coreos.com/v1
+metadata:
+  name: kuadrant
+  namespace: kuadrant-system
+spec:
+  upgradeStrategy: Default

--- a/components/operators/rhcl-operator/subscription.yaml
+++ b/components/operators/rhcl-operator/subscription.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: rhcl-operator
-  namespace: openshift-operators
+  namespace: kuadrant-system
 spec:
   channel: stable
   installPlanApproval: Automatic

--- a/scripts/verify-dependencies.sh
+++ b/scripts/verify-dependencies.sh
@@ -29,7 +29,7 @@ declare -A OPERATORS=(
     [job-set]="openshift-jobset-operator name=jobset-operator"
     [tempo-product]="openshift-tempo-operator app.kubernetes.io/name=tempo-operator"
     [openshift-custom-metrics-autoscaler-operator]="openshift-keda name=custom-metrics-autoscaler-operator"
-    [rhcl-operator]="openshift-operators app=kuadrant"
+    [rhcl-operator]="kuadrant-system app=kuadrant"
     [nfd]="openshift-nfd control-plane=controller-manager"
     [gpu-operator-certified]="nvidia-gpu-operator app=gpu-operator"
 


### PR DESCRIPTION
Reverts opendatahub-io/odh-gitops#40


As per offline discuss, we will not have this change in 3.4EA2 till we know what to do.
the main issue here is when using openshift-operators namespace, if any other operator (e.g ossm) is installed there and subscription set to Manual, then RHCL will take Manual as plan as well. 
We can take another look later for investigation.


cc @davidebianchi 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Red Hat Connectivity Link operator namespace configuration in reference documentation

* **Configuration Changes**
  * Kuadrant operator now deployed in the `kuadrant-system` namespace instead of `openshift-operators`
  * Simplified namespace management configuration; manual namespace creation is no longer required
  * Updated operator deployment configuration to reflect new namespace location

<!-- end of auto-generated comment: release notes by coderabbit.ai -->