### PR TITLE
feat(RHOAIENG-51772): add custom resources to lws and sail-operator

### DIFF
--- a/charts/lws-operator/scripts/update-bundle.sh
+++ b/charts/lws-operator/scripts/update-bundle.sh
@@ -60,6 +60,7 @@ echo "[2/3] Cleaning old manifests..."
 find "$CHART_DIR/crds" -name "*.yaml" -delete 2>/dev/null || true
 find "$CHART_DIR/templates" -name "*.yaml" \
   ! -name "namespace.yaml" \
+  ! -name "kube-system-role-binding.yaml" \
   -delete 2>/dev/null || true
 
 # Split manifests, templatize namespace references

--- a/charts/lws-operator/templates/kube-system-role-binding.yaml
+++ b/charts/lws-operator/templates/kube-system-role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-lws-operator-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: openshift-lws-operator
+    namespace: {{ .Values.namespace }}

--- a/charts/sail-operator/scripts/update-bundle.sh
+++ b/charts/sail-operator/scripts/update-bundle.sh
@@ -61,6 +61,7 @@ echo "[2/3] Cleaning old manifests..."
 find "$CHART_DIR/crds" -name "*.yaml" -delete 2>/dev/null || true
 find "$CHART_DIR/templates" -name "*.yaml" \
   ! -name "namespace.yaml" \
+  ! -name "istio.yaml" \
   -delete 2>/dev/null || true
 
 # Split manifests (no templatization)

--- a/charts/sail-operator/templates/istio.yaml
+++ b/charts/sail-operator/templates/istio.yaml
@@ -1,0 +1,20 @@
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: default
+  namespace: {{ .Values.namespace }}
+spec:
+  namespace: {{ .Values.namespace }}
+  version: v1.27-latest
+  values:
+    pilot:
+      env:
+        PILOT_ENABLE_GATEWAY_API: "true"
+        PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER: "true"
+        PILOT_ENABLE_GATEWAY_API_STATUS: "true"
+        ENABLE_GATEWAY_API_INFERENCE_EXTENSION: "true"
+    meshConfig:
+      accessLogFile: /dev/stdout
+      defaultConfig:
+        proxyMetadata:
+          ENABLE_GATEWAY_API_INFERENCE_EXTENSION: "true"


### PR DESCRIPTION
## Description

- Add a `kube-system` RoleBinding for the lws-operator ServiceAccount to read the `extension-apiserver-authentication-reader` Role, which is required for the operator's webhook/aggregated API server to authenticate requests.
- Add an Istio custom resource to the sail-operator chart with Gateway API support and inference extension enabled.
- Update both operators `update-bundle.sh` scripts to preserve these manually-managed templates during bundle regeneration.

Jira task: https://issues.redhat.com/browse/RHOAIENG-51772

## Has it been tested?

- [ ] Installed on a real cluster to verify the changes

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RBAC role binding added to allow the lws-operator to read extension API server authentication resources in the kube-system namespace.
  * Istio custom resource support added for the sail-operator, enabling gateway API features, gateway inference, and access logging for the service mesh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->