### PR TITLE
update: rename rhods to rhaii for chart/rhaii-helm-chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ endif
 
 .PHONY: helm-verify
 helm-verify: ## Verify helm chart installation and DSC components
-	NAMESPACE=opendatahub-gitops OPERATOR_TYPE=$(OPERATOR_TYPE) ./scripts/verify-helm-chart.sh
+	NAMESPACE=rhaii-gitops OPERATOR_TYPE=$(OPERATOR_TYPE) ./scripts/verify-helm-chart.sh
 
 # Extra arguments to pass to helm commands (e.g., --set olm.source=custom-catalog)
 HELM_EXTRA_ARGS ?=
@@ -244,14 +244,14 @@ HELM_INSTALL_ARGS := -f $(HELM_INSTALL_VALUES_FILE) --set components.llamastacko
 .PHONY: helm-install-verify
 helm-install-verify: ## Install helm chart and verify installation
 	@echo "=== Step 1: Install operators ==="
-	helm upgrade --install odh ./$(CHART_PATH) -n opendatahub-gitops --create-namespace $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
+	helm upgrade --install rhaii ./$(CHART_PATH) -n rhaii-gitops --create-namespace $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
 	@echo ""
 	@echo "=== Step 2: Wait for CRDs (dependency) ==="
 	@./scripts/wait-for-crds.sh
 	@bash ./scripts/verify-dependencies.sh
 	@echo ""
 	@echo "=== Step 3: Enable DSC and DSCInitialization ==="
-	helm upgrade --install odh ./$(CHART_PATH) -n opendatahub-gitops $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
+	helm upgrade --install rhaii ./$(CHART_PATH) -n rhaii-gitops $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
 	@echo ""
 	@echo "=== Step 4: Verify operator and DSC installation, reducing dashboard replicas to 1 to reduce resource usage ==="
 	@echo "Waiting for odh-dashboard deployment to exist in namespace $(APPLICATIONS_NAMESPACE)..."
@@ -267,8 +267,7 @@ helm-install-verify: ## Install helm chart and verify installation
 	@$(MAKE) prepare-authorino-tls KUSTOMIZE_MODE=false
 	@echo ""
 	@echo "=== Step 6: Final helm upgrade with wait condition ==="
-	helm upgrade --install odh ./$(CHART_PATH) -n opendatahub-gitops --wait --timeout 10m $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
-
+	helm upgrade --install rhaii ./$(CHART_PATH) -n rhaii-gitops --wait --timeout 10m $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
 .PHONY: helm-uninstall
 helm-uninstall: ## Uninstall helm chart and all dependencies
 	./scripts/uninstall-helm-chart.sh

--- a/Makefile
+++ b/Makefile
@@ -244,13 +244,13 @@ HELM_INSTALL_ARGS := -f $(HELM_INSTALL_VALUES_FILE) --set components.llamastacko
 .PHONY: helm-install-verify
 helm-install-verify: ## Install helm chart and verify installation
 	@echo "=== Step 1: Install operators ==="
-	helm upgrade --install rhaii ./$(CHART_PATH) -n opendatahub-gitops --create-namespace $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
+	helm upgrade --install odh ./$(CHART_PATH) -n opendatahub-gitops --create-namespace $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
 	@echo "=== Step 2: Wait for CRDs (dependency) ==="
 	@./scripts/wait-for-crds.sh
 	@bash ./scripts/verify-dependencies.sh
 	@echo ""
 	@echo "=== Step 3: Enable DSC and DSCInitialization ==="
-	helm upgrade --install rhaii ./$(CHART_PATH) -n opendatahub-gitops $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
+	helm upgrade --install odh ./$(CHART_PATH) -n opendatahub-gitops $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
 	@echo ""
 	@echo "=== Step 4: Verify operator and DSC installation, reducing dashboard replicas to 1 to reduce resource usage ==="
 	@echo "Waiting for odh-dashboard deployment to exist in namespace $(APPLICATIONS_NAMESPACE)..."
@@ -266,7 +266,7 @@ helm-install-verify: ## Install helm chart and verify installation
 	@$(MAKE) prepare-authorino-tls KUSTOMIZE_MODE=false
 	@echo ""
 	@echo "=== Step 6: Final helm upgrade with wait condition ==="
-	helm upgrade --install rhaii ./$(CHART_PATH) -n opendatahub-gitops --wait --timeout 10m $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
+	helm upgrade --install odh ./$(CHART_PATH) -n opendatahub-gitops --wait --timeout 10m $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
 
 .PHONY: helm-uninstall
 helm-uninstall: ## Uninstall helm chart and all dependencies

--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ endif
 
 .PHONY: helm-verify
 helm-verify: ## Verify helm chart installation and DSC components
-	NAMESPACE=rhaii-gitops OPERATOR_TYPE=$(OPERATOR_TYPE) ./scripts/verify-helm-chart.sh
+	NAMESPACE=opendatahub-gitops OPERATOR_TYPE=$(OPERATOR_TYPE) ./scripts/verify-helm-chart.sh
 
 # Extra arguments to pass to helm commands (e.g., --set olm.source=custom-catalog)
 HELM_EXTRA_ARGS ?=
@@ -244,14 +244,13 @@ HELM_INSTALL_ARGS := -f $(HELM_INSTALL_VALUES_FILE) --set components.llamastacko
 .PHONY: helm-install-verify
 helm-install-verify: ## Install helm chart and verify installation
 	@echo "=== Step 1: Install operators ==="
-	helm upgrade --install rhaii ./$(CHART_PATH) -n rhaii-gitops --create-namespace $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
-	@echo ""
+	helm upgrade --install rhaii ./$(CHART_PATH) -n opendatahub-gitops --create-namespace $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
 	@echo "=== Step 2: Wait for CRDs (dependency) ==="
 	@./scripts/wait-for-crds.sh
 	@bash ./scripts/verify-dependencies.sh
 	@echo ""
 	@echo "=== Step 3: Enable DSC and DSCInitialization ==="
-	helm upgrade --install rhaii ./$(CHART_PATH) -n rhaii-gitops $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
+	helm upgrade --install rhaii ./$(CHART_PATH) -n opendatahub-gitops $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
 	@echo ""
 	@echo "=== Step 4: Verify operator and DSC installation, reducing dashboard replicas to 1 to reduce resource usage ==="
 	@echo "Waiting for odh-dashboard deployment to exist in namespace $(APPLICATIONS_NAMESPACE)..."
@@ -267,7 +266,8 @@ helm-install-verify: ## Install helm chart and verify installation
 	@$(MAKE) prepare-authorino-tls KUSTOMIZE_MODE=false
 	@echo ""
 	@echo "=== Step 6: Final helm upgrade with wait condition ==="
-	helm upgrade --install rhaii ./$(CHART_PATH) -n rhaii-gitops --wait --timeout 10m $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
+	helm upgrade --install rhaii ./$(CHART_PATH) -n opendatahub-gitops --wait --timeout 10m $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
+
 .PHONY: helm-uninstall
 helm-uninstall: ## Uninstall helm chart and all dependencies
 	./scripts/uninstall-helm-chart.sh

--- a/charts/README.md
+++ b/charts/README.md
@@ -249,11 +249,11 @@ helm lint charts/dependencies/gateway-api/
 make chart-snapshots
 ```
 
-### RHAI On XKS Helm Chart
+### RHAII Helm Chart
 
-The `rhai-on-xks-helm-chart` generates its templates from the [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator) repository using kustomize and [helmtemplate-generator](https://github.com/davidebianchi/helmtemplate-generator). It also generates cloud-specific (Azure, CoreWeave) cloudmanager templates.
+The `rhaii-helm-chart` generates its templates from the [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator) repository using kustomize and [helmtemplate-generator](https://github.com/davidebianchi/helmtemplate-generator). It also generates cloud-specific (Azure, CoreWeave) cloudmanager templates.
 
-**Prerequisites:** `go`, `kustomize`, and access to the ODH `opendatahub-operator` git repo.
+**Prerequisites:** `go`, `kustomize`, and access to the rhods-operator repo.
 
 **Update from the default branch (rhoai-3.4):**
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -253,18 +253,18 @@ make chart-snapshots
 
 The `rhaii-helm-chart` generates its templates from the [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator) repository using kustomize and [helmtemplate-generator](https://github.com/davidebianchi/helmtemplate-generator). It also generates cloud-specific (Azure, CoreWeave) cloudmanager templates.
 
-**Prerequisites:** `go`, `kustomize`, and SSH access to the opendatahub-operator repo.
+**Prerequisites:** `go`, `kustomize`, and access to the rhods-operator repo.
 
-**Update from the default branch (main):**
+**Update from the default branch (rhoai-3.4):**
 
 ```bash
-./charts/rhaii-helm-chart/scripts/update-bundle.sh v2.19.0
+./charts/rhaii-helm-chart/scripts/update-bundle.sh 3.4.0-ea.2
 ```
 
 **Update from a specific branch:**
 
 ```bash
-./charts/rhaii-helm-chart/scripts/update-bundle.sh v2.19.0 --branch feat/my-branch
+./charts/rhaii-helm-chart/scripts/update-bundle.sh 3.5.0 --branch rhoai-3.5
 ```
 
 **Update from a local opendatahub-operator checkout** (skips cloning):

--- a/charts/README.md
+++ b/charts/README.md
@@ -249,11 +249,11 @@ helm lint charts/dependencies/gateway-api/
 make chart-snapshots
 ```
 
-### RHAII Helm Chart
+### RHAI On XKS Helm Chart
 
-The `rhaii-helm-chart` generates its templates from the [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator) repository using kustomize and [helmtemplate-generator](https://github.com/davidebianchi/helmtemplate-generator). It also generates cloud-specific (Azure, CoreWeave) cloudmanager templates.
+The `rhai-on-xks-helm-chart` generates its templates from the [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator) repository using kustomize and [helmtemplate-generator](https://github.com/davidebianchi/helmtemplate-generator). It also generates cloud-specific (Azure, CoreWeave) cloudmanager templates.
 
-**Prerequisites:** `go`, `kustomize`, and access to the rhods-operator repo.
+**Prerequisites:** `go`, `kustomize`, and access to the ODH `opendatahub-operator` git repo.
 
 **Update from the default branch (rhoai-3.4):**
 

--- a/charts/rhaii-helm-chart/Chart.yaml
+++ b/charts/rhaii-helm-chart/Chart.yaml
@@ -3,4 +3,4 @@ name: rhaii-helm-chart
 description: Red Hat OpenShift AI Operator Helm chart (non-OLM installation)
 type: application
 version: 0.1.0
-appVersion: 3.4.0
+appVersion: 3.4.0-ea.2

--- a/charts/rhaii-helm-chart/Chart.yaml
+++ b/charts/rhaii-helm-chart/Chart.yaml
@@ -3,4 +3,4 @@ name: rhaii-helm-chart
 description: Red Hat OpenShift AI Operator Helm chart (non-OLM installation)
 type: application
 version: 0.1.0
-appVersion: "3.4.0-ea.2"
+appVersion: 3.4.0-ea.2

--- a/charts/rhaii-helm-chart/Chart.yaml
+++ b/charts/rhaii-helm-chart/Chart.yaml
@@ -3,4 +3,4 @@ name: rhaii-helm-chart
 description: Red Hat OpenShift AI Operator Helm chart (non-OLM installation)
 type: application
 version: 0.1.0
-appVersion: 3.4.0-ea.2
+appVersion: 3.4.0

--- a/charts/rhaii-helm-chart/README.md
+++ b/charts/rhaii-helm-chart/README.md
@@ -75,7 +75,7 @@ helm upgrade rhaii ./charts/rhaii-helm-chart/ \
 ```
 
 > [!WARNING]
-> `helm install --wait` is **not supported**. The chart uses post-install hook Jobs to create Custom Resources after the operators are deployed. These hooks require CRDs to be registered first, and the rhaii-operator depends on cert-manager to start correctly. Using `--wait` may cause the installation to time out or fail.
+> `helm install --wait` is **not supported**. The chart uses post-install hook Jobs to create Custom Resources after the operators are deployed. These hooks require CRDs to be registered first, and the rhai-operator depends on cert-manager to start correctly. Using `--wait` may cause the installation to time out or fail.
 
 ## How It Works
 
@@ -143,7 +143,7 @@ CRDs are **not** removed on uninstall (`helm.sh/resource-policy: keep`). To remo
 ```bash
 kubectl delete crd kserves.components.platform.opendatahub.io
 ```
-**Operator-created CRDs (created by rhaii-operator during KServe deployment):**
+**Operator-created CRDs (created by rhai-operator during KServe deployment):**
 ```bash
 kubectl delete crd llminferenceservices.serving.kserve.io
 kubectl delete crd llminferenceserviceconfigs.serving.kserve.io

--- a/charts/rhaii-helm-chart/README.md
+++ b/charts/rhaii-helm-chart/README.md
@@ -6,7 +6,7 @@ This chart installs the RHAI operator and its cloud manager components. Exactly 
 
 ## Table of Contents
 
-- [RHAI On XKS Helm Chart](#rhaii-helm-chart)
+- [RHAII Helm Chart](#rhaii-helm-chart)
   - [Table of Contents](#table-of-contents)
   - [Prerequisites](#prerequisites)
   - [Pull Secrets](#pull-secrets)

--- a/charts/rhaii-helm-chart/README.md
+++ b/charts/rhaii-helm-chart/README.md
@@ -1,6 +1,6 @@
 # RHAII Helm Chart
 
-Red Hat OpenShift AI Operator Helm chart for non-OLM installation.
+Red Hat AI Inference Helm chart for non-OLM installation.
 
 This chart installs the RHAI operator and its cloud manager components. Exactly one cloud provider (Azure or CoreWeave) must be enabled.
 
@@ -9,10 +9,10 @@ This chart installs the RHAI operator and its cloud manager components. Exactly 
 - [RHAII Helm Chart](#rhaii-helm-chart)
   - [Table of Contents](#table-of-contents)
   - [Prerequisites](#prerequisites)
+  - [Pull Secrets](#pull-secrets)
   - [Installation](#installation)
     - [Azure](#azure)
     - [CoreWeave](#coreweave)
-  - [Pull Secrets](#pull-secrets)
   - [How It Works](#how-it-works)
   - [Managed Dependencies](#managed-dependencies)
   - [Configuration Reference](#configuration-reference)
@@ -21,36 +21,40 @@ This chart installs the RHAI operator and its cloud manager components. Exactly 
 
 ## Prerequisites
 
-- Kubernetes cluster (or OpenShift)
+- Kubernetes cluster
 - Helm 4.x
 - Cluster-admin privileges (the chart creates CRDs, ClusterRoles, and namespaces)
-
-## Installation
-
-### Azure
-
-```bash
-helm upgrade rhaii ./charts/rhaii-helm-chart/ \
-  --install --create-namespace \
-  --namespace rhaii \
-  --set azure.enabled=true
-```
-
-### CoreWeave
-
-```bash
-helm upgrade rhaii ./charts/rhaii-helm-chart/ \
-  --install --create-namespace \
-  --namespace rhaii \
-  --set coreweave.enabled=true
-```
-
-> [!WARNING]
-> `helm install --wait` is **not supported**. The chart uses post-install hook Jobs to create Custom Resources after the operators are deployed. These hooks require CRDs to be registered first, and the rhods-operator depends on cert-manager to start correctly. Using `--wait` may cause the installation to time out or fail.
+- Pull secret for `registry.redhat.io` (see [Pull Secrets](#pull-secrets) below)
 
 ## Pull Secrets
 
-To pull images from private registries, pass your docker config JSON file during install:
+> [!IMPORTANT]
+> A pull secret is **required** to install this chart. The chart pulls images from `registry.redhat.io`, including the `ose-cli-rhel9:v4.21.0` image used by the post-install hook Job.
+
+### Obtaining credentials
+
+```bash
+podman login registry.redhat.io --authfile /path/to/auth.json
+```
+
+### What the pull secret does
+
+The `imagePullSecret.dockerConfigJson` parameter:
+
+1. Creates a `kubernetes.io/dockerconfigjson` Secret named `rhaii-pull-secret` in all chart-managed namespaces (operator, applications, release, cloud manager and all dependency namespaces)
+2. Adds `imagePullSecrets` to all chart-managed ServiceAccounts (RHAI operator, cloud manager, llmisvc-controller-manager, and the post-install hook)
+
+The secret name defaults to `rhaii-pull-secret` and **should not** be changed.
+
+> [!NOTE]
+> Pull secrets for dependency namespaces (`cert-manager-operator`, `cert-manager`, `istio-system`, `openshift-lws-operator`) are managed by this chart by default. To customize which dependency namespaces receive pull secrets, set `imagePullSecret.dependencyNamespaces`.
+
+## Installation
+
+> [!NOTE]
+> All commands below assume you are in the repository root directory.
+
+### Azure
 
 ```bash
 helm upgrade rhaii ./charts/rhaii-helm-chart/ \
@@ -60,15 +64,18 @@ helm upgrade rhaii ./charts/rhaii-helm-chart/ \
   --set-file imagePullSecret.dockerConfigJson=/path/to/auth.json
 ```
 
-This will:
+### CoreWeave
 
-1. Create a `kubernetes.io/dockerconfigjson` Secret named `rhaii-pull-secret` in all chart-managed namespaces (operator, applications, release, cloud manager and all dependency namespaces)
-2. Add `imagePullSecrets` to all chart-managed ServiceAccounts (RHAI operator, cloud manager and llmisvc-controller-manager in the applications namespace)
+```bash
+helm upgrade rhaii ./charts/rhaii-helm-chart/ \
+  --install --create-namespace \
+  --namespace rhaii \
+  --set coreweave.enabled=true \
+  --set-file imagePullSecret.dockerConfigJson=/path/to/auth.json
+```
 
-The secret name defaults to `rhaii-pull-secret` and **must not** be changed.
-
-> [!NOTE]
-> Pull secrets for dependency namespaces (`cert-manager-operator`, `cert-manager`, `istio-system`, `openshift-lws-operator`) are managed by this chart by default. To customize which dependency namespaces receive pull secrets, set `imagePullSecret.dependencyNamespaces`.
+> [!WARNING]
+> `helm install --wait` is **not supported**. The chart uses post-install hook Jobs to create Custom Resources after the operators are deployed. These hooks require CRDs to be registered first, and the rhaii-operator depends on cert-manager to start correctly. Using `--wait` may cause the installation to time out or fail.
 
 ## How It Works
 
@@ -128,10 +135,30 @@ helm upgrade rhaii ./charts/rhaii-helm-chart/ \
 helm uninstall rhaii -n rhaii
 ```
 
+### Clean up CRDs
+
 CRDs are **not** removed on uninstall (`helm.sh/resource-policy: keep`). To remove them manually:
 
+**Chart-managed CRDs:**
 ```bash
 kubectl delete crd kserves.components.platform.opendatahub.io
+```
+**Operator-created CRDs (created by rhaii-operator during KServe deployment):**
+```bash
+kubectl delete crd llminferenceservices.serving.kserve.io
+kubectl delete crd llminferenceserviceconfigs.serving.kserve.io
+```
+
+**Azure:**
+```bash
 kubectl delete crd azurekubernetesengines.infrastructure.opendatahub.io
+```
+
+**CoreWeave:**
+```bash
 kubectl delete crd coreweavekubernetesengines.infrastructure.opendatahub.io
 ```
+
+### Clean up namespaces
+
+The namespaces created by the chart are not automatically removed. Clean up the namespaces as needed based on your configuration.

--- a/charts/rhaii-helm-chart/README.md
+++ b/charts/rhaii-helm-chart/README.md
@@ -6,7 +6,7 @@ This chart installs the RHAI operator and its cloud manager components. Exactly 
 
 ## Table of Contents
 
-- [RHAII Helm Chart](#rhaii-helm-chart)
+- [RHAI On XKS Helm Chart](#rhaii-helm-chart)
   - [Table of Contents](#table-of-contents)
   - [Prerequisites](#prerequisites)
   - [Pull Secrets](#pull-secrets)

--- a/charts/rhaii-helm-chart/api-docs.md
+++ b/charts/rhaii-helm-chart/api-docs.md
@@ -1,6 +1,6 @@
 # rhaii-helm-chart
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.4.0](https://img.shields.io/badge/AppVersion-3.4.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.4.0-ea.2](https://img.shields.io/badge/AppVersion-3.4.0--ea.2-informational?style=flat-square)
 
 Red Hat OpenShift AI Operator Helm chart (non-OLM installation)
 

--- a/charts/rhaii-helm-chart/api-docs.md
+++ b/charts/rhaii-helm-chart/api-docs.md
@@ -1,6 +1,6 @@
 # rhaii-helm-chart
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.4.0-ea.2](https://img.shields.io/badge/AppVersion-3.4.0--ea.2-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.4.0](https://img.shields.io/badge/AppVersion-3.4.0-informational?style=flat-square)
 
 Red Hat OpenShift AI Operator Helm chart (non-OLM installation)
 

--- a/charts/rhaii-helm-chart/scripts/helmtemplate-config-cloudmanager.yaml
+++ b/charts/rhaii-helm-chart/scripts/helmtemplate-config-cloudmanager.yaml
@@ -44,12 +44,12 @@ rules:
         value: '{{ .Values.CLOUD_NAME.cloudManager.imagePullPolicy }}'
       - path: .spec.template.spec.containers[name=manager].env[name=RHAI_OPERATOR_NAMESPACE].value
         value: '{{ .Values.rhaiOperator.namespace }}'
-      # Update webhook cert secret name (rhods-operator to rhaii-operator) TODO: we should change in opendatahub-operator instead
+      # Update webhook cert secret name (rhods-operator to rhai-operator) TODO: we should change in opendatahub-operator instead
       - path: .spec.template.spec.containers[name=manager].env[name=RHAI_WEBHOOK_CERT_SECRET_NAME].value
-        value: rhaii-operator-controller-webhook-cert
-      # Update webhook service name (rhods-operator to rhaii-operator) TODO: we should change in opendatahub-operator instead
+        value: rhai-operator-controller-webhook-cert
+      # Update webhook service name (rhods-operator to rhai-operator) TODO: we should change in opendatahub-operator instead
       - path: .spec.template.spec.containers[name=manager].env[name=RHAI_WEBHOOK_SERVICE_NAME].value
-        value: rhaii-operator-webhook-service
+        value: rhai-operator-webhook-service
 
   - match:
       kinds:

--- a/charts/rhaii-helm-chart/scripts/helmtemplate-config-cloudmanager.yaml
+++ b/charts/rhaii-helm-chart/scripts/helmtemplate-config-cloudmanager.yaml
@@ -33,7 +33,7 @@ rules:
       - path: .subjects[0].namespace
         value: '{{ .Values.CLOUD_NAME.cloudManager.namespace }}'
 
-  # Replace container image with Helm value
+  # Replace container image with Helm value and update webhook references
   - match:
       kinds:
         - Deployment
@@ -44,6 +44,12 @@ rules:
         value: '{{ .Values.CLOUD_NAME.cloudManager.imagePullPolicy }}'
       - path: .spec.template.spec.containers[name=manager].env[name=RHAI_OPERATOR_NAMESPACE].value
         value: '{{ .Values.rhaiOperator.namespace }}'
+      # Update webhook cert secret name (rhods-operator to rhaii-operator) TODO: we should change in opendatahub-operator instead
+      - path: .spec.template.spec.containers[name=manager].env[name=RHAI_WEBHOOK_CERT_SECRET_NAME].value
+        value: rhaii-operator-controller-webhook-cert
+      # Update webhook service name (rhods-operator to rhaii-operator) TODO: we should change in opendatahub-operator instead
+      - path: .spec.template.spec.containers[name=manager].env[name=RHAI_WEBHOOK_SERVICE_NAME].value
+        value: rhaii-operator-webhook-service
 
   - match:
       kinds:

--- a/charts/rhaii-helm-chart/scripts/helmtemplate-config.yaml
+++ b/charts/rhaii-helm-chart/scripts/helmtemplate-config.yaml
@@ -78,8 +78,10 @@ rules:
       kinds:
         - Deployment
     changes:
+      # Replace RHAI_APPLICATIONS_NAMESPACE with templated value
       - path: .spec.template.spec.containers[name=rhods-operator].env[name=RHAI_APPLICATIONS_NAMESPACE].value
         value: '{{ .Values.rhaiOperator.applicationsNamespace }}'
+      # Add related images env vars
       - path: .spec.template.spec.containers[name=rhods-operator].env
         appendWith: |
           {{- range $name, $value := .Values.rhaiOperator.relatedImages }}
@@ -91,7 +93,146 @@ rules:
         value: '{{ .Values.rhaiOperator.image }}'
       - path: .spec.template.spec.containers[name=rhods-operator].imagePullPolicy
         value: '{{ .Values.rhaiOperator.imagePullPolicy }}'
+      # Update OPERATOR_NAME env var value
+      - path: .spec.template.spec.containers[name=rhods-operator].env[name=OPERATOR_NAME].value
+        value: rhaii-operator
+      # Rename container from rhods-operator to rhaii-operator (must be last)
+      - path: .spec.template.spec.containers[name=rhods-operator].name
+        value: rhaii-operator
+      # Rename deployment metadata and labels
+      - path: .metadata.name
+        value: rhaii-operator
+      - path: .metadata.labels.name
+        value: rhaii-operator
+      - path: .spec.selector.matchLabels.name
+        value: rhaii-operator
+      - path: .spec.template.metadata.labels.name
+        value: rhaii-operator
+      - path: .spec.template.metadata.annotations["kubectl.kubernetes.io/default-container"]
+        value: rhaii-operator
+      # Update podAntiAffinity label selector
+      - path: .spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values[0]
+        value: rhaii-operator
+      # Update serviceAccountName reference
+      - path: .spec.template.spec.serviceAccountName
+        value: rhaii-operator-controller-manager
 
+  # Rename ServiceAccount
+  - match:
+      kinds:
+        - ServiceAccount
+      names:
+        - "redhat-ods-operator-controller-manager"
+    changes:
+      - path: .metadata.name
+        value: rhaii-operator-controller-manager
+
+  # Rename ClusterRoles
+  - match:
+      kinds:
+        - ClusterRole
+      names:
+        - "rhods-operator-role"
+    changes:
+      - path: .metadata.name
+        value: rhaii-operator-role
+
+  - match:
+      kinds:
+        - ClusterRole
+      names:
+        - "redhat-ods-operator-metrics-reader"
+    changes:
+      - path: .metadata.name
+        value: rhaii-operator-metrics-reader
+
+  # Rename ClusterRoleBinding and update references
+  - match:
+      kinds:
+        - ClusterRoleBinding
+      names:
+        - "rhods-operator-rolebinding"
+    changes:
+      - path: .metadata.name
+        value: rhaii-operator-rolebinding
+      - path: .subjects[0].name
+        value: rhaii-operator-controller-manager
+      - path: .roleRef.name
+        value: rhaii-operator-role
+
+  # Rename Service and update selector
+  - match:
+      kinds:
+        - Service
+      names:
+        - "redhat-ods-operator-controller-manager-metrics-service"
+    changes:
+      - path: .metadata.name
+        value: rhaii-operator-controller-manager-metrics-service
+      - path: .spec.selector.name
+        value: rhaii-operator
+
+  # Rename Webhook Service and update labels and selector
+  - match:
+      kinds:
+        - Service
+      names:
+        - "rhods-operator-webhook-service"
+    changes:
+      - path: .metadata.name
+        value: rhaii-operator-webhook-service
+      - path: .metadata.labels["app.kubernetes.io/created-by"]
+        value: rhaii-operator
+      - path: .metadata.labels["app.kubernetes.io/instance"]
+        value: rhaii-operator
+      - path: .metadata.labels["app.kubernetes.io/name"]
+        value: rhaii-operator-webhook-service
+      - path: .metadata.labels["app.kubernetes.io/part-of"]
+        value: rhaii-operator
+      - path: .spec.selector.name
+        value: rhaii-operator
+
+  # Rename ValidatingWebhookConfiguration and update labels
+  - match:
+      kinds:
+        - ValidatingWebhookConfiguration
+      names:
+        - "rhods-operator-validating-webhook-configuration"
+    changes:
+      - path: .metadata.name
+        value: rhaii-operator-validating-webhook-configuration
+      - path: .webhooks[*].clientConfig.service.name
+        value: rhaii-operator-webhook-service
+      - path: .metadata.labels["app.kubernetes.io/created-by"]
+        value: rhaii-operator
+      - path: .metadata.labels["app.kubernetes.io/instance"]
+        value: rhaii-operator
+      - path: .metadata.labels["app.kubernetes.io/name"]
+        value: rhaii-operator-validating-webhook-configuration
+      - path: .metadata.labels["app.kubernetes.io/part-of"]
+        value: rhaii-operator
+
+  # Rename MutatingWebhookConfiguration and update labels
+  - match:
+      kinds:
+        - MutatingWebhookConfiguration
+      names:
+        - "rhods-operator-mutating-webhook-configuration"
+    changes:
+      - path: .metadata.name
+        value: rhaii-operator-mutating-webhook-configuration
+      - path: .webhooks[*].clientConfig.service.name
+        value: rhaii-operator-webhook-service
+      - path: .metadata.labels["app.kubernetes.io/created-by"]
+        value: rhaii-operator
+      - path: .metadata.labels["app.kubernetes.io/instance"]
+        value: rhaii-operator
+      - path: .metadata.labels["app.kubernetes.io/name"]
+        value: rhaii-operator-mutating-webhook-configuration
+      - path: .metadata.labels["app.kubernetes.io/part-of"]
+        value: rhaii-operator
+
+  # Add image pull secrets to ServiceAccount
   - match:
       kinds:
         - ServiceAccount

--- a/charts/rhaii-helm-chart/scripts/helmtemplate-config.yaml
+++ b/charts/rhaii-helm-chart/scripts/helmtemplate-config.yaml
@@ -95,27 +95,27 @@ rules:
         value: '{{ .Values.rhaiOperator.imagePullPolicy }}'
       # Update OPERATOR_NAME env var value
       - path: .spec.template.spec.containers[name=rhods-operator].env[name=OPERATOR_NAME].value
-        value: rhaii-operator
-      # Rename container from rhods-operator to rhaii-operator (must be last)
+        value: rhai-operator
+      # Rename container from rhods-operator to rhai-operator (must be last)
       - path: .spec.template.spec.containers[name=rhods-operator].name
-        value: rhaii-operator
+        value: rhai-operator
       # Rename deployment metadata and labels
       - path: .metadata.name
-        value: rhaii-operator
+        value: rhai-operator
       - path: .metadata.labels.name
-        value: rhaii-operator
+        value: rhai-operator
       - path: .spec.selector.matchLabels.name
-        value: rhaii-operator
+        value: rhai-operator
       - path: .spec.template.metadata.labels.name
-        value: rhaii-operator
+        value: rhai-operator
       - path: .spec.template.metadata.annotations["kubectl.kubernetes.io/default-container"]
-        value: rhaii-operator
+        value: rhai-operator
       # Update podAntiAffinity label selector
       - path: .spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchExpressions[0].values[0]
-        value: rhaii-operator
+        value: rhai-operator
       # Update serviceAccountName reference
       - path: .spec.template.spec.serviceAccountName
-        value: rhaii-operator-controller-manager
+        value: rhai-operator-controller-manager
 
   # Rename ServiceAccount
   - match:
@@ -125,7 +125,7 @@ rules:
         - "redhat-ods-operator-controller-manager"
     changes:
       - path: .metadata.name
-        value: rhaii-operator-controller-manager
+        value: rhai-operator-controller-manager
 
   # Rename ClusterRoles
   - match:
@@ -135,7 +135,7 @@ rules:
         - "rhods-operator-role"
     changes:
       - path: .metadata.name
-        value: rhaii-operator-role
+        value: rhai-operator-role
 
   - match:
       kinds:
@@ -144,7 +144,7 @@ rules:
         - "redhat-ods-operator-metrics-reader"
     changes:
       - path: .metadata.name
-        value: rhaii-operator-metrics-reader
+        value: rhai-operator-metrics-reader
 
   # Rename ClusterRoleBinding and update references
   - match:
@@ -154,11 +154,11 @@ rules:
         - "rhods-operator-rolebinding"
     changes:
       - path: .metadata.name
-        value: rhaii-operator-rolebinding
+        value: rhai-operator-rolebinding
       - path: .subjects[0].name
-        value: rhaii-operator-controller-manager
+        value: rhai-operator-controller-manager
       - path: .roleRef.name
-        value: rhaii-operator-role
+        value: rhai-operator-role
 
   # Rename Service and update selector
   - match:
@@ -168,9 +168,9 @@ rules:
         - "redhat-ods-operator-controller-manager-metrics-service"
     changes:
       - path: .metadata.name
-        value: rhaii-operator-controller-manager-metrics-service
+        value: rhai-operator-controller-manager-metrics-service
       - path: .spec.selector.name
-        value: rhaii-operator
+        value: rhai-operator
 
   # Rename Webhook Service and update labels and selector
   - match:
@@ -180,17 +180,17 @@ rules:
         - "rhods-operator-webhook-service"
     changes:
       - path: .metadata.name
-        value: rhaii-operator-webhook-service
+        value: rhai-operator-webhook-service
       - path: .metadata.labels["app.kubernetes.io/created-by"]
-        value: rhaii-operator
+        value: rhai-operator
       - path: .metadata.labels["app.kubernetes.io/instance"]
-        value: rhaii-operator
+        value: rhai-operator
       - path: .metadata.labels["app.kubernetes.io/name"]
-        value: rhaii-operator-webhook-service
+        value: rhai-operator-webhook-service
       - path: .metadata.labels["app.kubernetes.io/part-of"]
-        value: rhaii-operator
+        value: rhai-operator
       - path: .spec.selector.name
-        value: rhaii-operator
+        value: rhai-operator
 
   # Rename ValidatingWebhookConfiguration and update labels
   - match:
@@ -200,17 +200,17 @@ rules:
         - "rhods-operator-validating-webhook-configuration"
     changes:
       - path: .metadata.name
-        value: rhaii-operator-validating-webhook-configuration
+        value: rhai-operator-validating-webhook-configuration
       - path: .webhooks[*].clientConfig.service.name
-        value: rhaii-operator-webhook-service
+        value: rhai-operator-webhook-service
       - path: .metadata.labels["app.kubernetes.io/created-by"]
-        value: rhaii-operator
+        value: rhai-operator
       - path: .metadata.labels["app.kubernetes.io/instance"]
-        value: rhaii-operator
+        value: rhai-operator
       - path: .metadata.labels["app.kubernetes.io/name"]
-        value: rhaii-operator-validating-webhook-configuration
+        value: rhai-operator-validating-webhook-configuration
       - path: .metadata.labels["app.kubernetes.io/part-of"]
-        value: rhaii-operator
+        value: rhai-operator
 
   # Rename MutatingWebhookConfiguration and update labels
   - match:
@@ -220,17 +220,19 @@ rules:
         - "rhods-operator-mutating-webhook-configuration"
     changes:
       - path: .metadata.name
-        value: rhaii-operator-mutating-webhook-configuration
+        value: rhai-operator-mutating-webhook-configuration
+      - path: .metadata.annotations["cert-manager.io/inject-ca-from"]
+        value: '{{ .Values.rhaiOperator.namespace }}/rhai-operator-webhook-cert'
       - path: .webhooks[*].clientConfig.service.name
-        value: rhaii-operator-webhook-service
+        value: rhai-operator-webhook-service
       - path: .metadata.labels["app.kubernetes.io/created-by"]
-        value: rhaii-operator
+        value: rhai-operator
       - path: .metadata.labels["app.kubernetes.io/instance"]
-        value: rhaii-operator
+        value: rhai-operator
       - path: .metadata.labels["app.kubernetes.io/name"]
-        value: rhaii-operator-mutating-webhook-configuration
+        value: rhai-operator-mutating-webhook-configuration
       - path: .metadata.labels["app.kubernetes.io/part-of"]
-        value: rhaii-operator
+        value: rhai-operator
 
   # Add image pull secrets to ServiceAccount
   - match:

--- a/charts/rhaii-helm-chart/scripts/update-bundle.sh
+++ b/charts/rhaii-helm-chart/scripts/update-bundle.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Update RHAI operator Helm chart from RHDS rhods-operator git repo and cloudmanager resources.
+# Update RHAII operator Helm chart from rhods-operator repo and cloudmanager resources.
 #
 # By default, the rhods-operator repo is shallow-cloned from GitHub.
 # Use --odh-operator-dir to point to a local checkout instead.
@@ -111,6 +111,7 @@ fi
 # ==============================================================================
 
 echo "Running 'make manifests-all' in rhods-operator..."
+echo "  This generates CRDs and RBAC for ODH, RHOAI, and cloudmanager..."
 make -C "${ODH_OPERATOR_DIR}" manifests-all
 echo "  Done"
 echo ""
@@ -162,7 +163,7 @@ kustomize build "${RHAI_KUSTOMIZE_PATH}" | go run "${HELMTEMPLATE_GENERATOR_PKG}
     -c "${SCRIPT_DIR}/helmtemplate-config.yaml" \
     -o "${CHART_DIR}" \
     --template-dir "${SCRIPT_DIR}" \
-    --chart-name "rhai-on-xks-helm-chart" \
+    --chart-name "rhaii-helm-chart" \
     --default-namespace "${NAMESPACE}" \
     --chart-description "Red Hat OpenShift AI Operator Helm chart (non-OLM installation)" \
     --app-version "${APP_VERSION}"
@@ -179,7 +180,7 @@ echo "Cloudmanager Templates"
 echo "=============================================================================="
 echo ""
 echo "Configuration:"
-echo "  RHOAI Operator: ${ODH_OPERATOR_DIR}"
+echo "  RHODS Operator: ${ODH_OPERATOR_DIR}"
 echo ""
 
 for target_entry in "${CLOUD_TARGETS[@]}"; do

--- a/charts/rhaii-helm-chart/scripts/update-bundle.sh
+++ b/charts/rhaii-helm-chart/scripts/update-bundle.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
-# Update RHAII operator Helm chart from opendatahub-operator repo and cloudmanager resources.
+# Update RHAII operator Helm chart from rhods-operator repo and cloudmanager resources.
 #
-# By default, the opendatahub-operator repo is shallow-cloned from GitHub.
+# By default, the rhods-operator repo is shallow-cloned from GitHub.
 # Use --odh-operator-dir to point to a local checkout instead.
 #
 # Usage:
 #   ./update-bundle.sh <version> [options...]
 #
 # Options:
-#   --odh-operator-dir <path>   Path to a local opendatahub-operator checkout.
+#   --odh-operator-dir <path>   Path to a local rhods-operator checkout.
 #                               Skips cloning from GitHub when set.
-#   --branch <branch>           Branch to clone (default: main).
+#   --branch <branch>           Branch to clone (default: rhoai-3.4-ea.2).
 #                               Ignored when --odh-operator-dir is set.
 #
 # Examples:
-#   ./update-bundle.sh v2.19.0
-#   ./update-bundle.sh v2.19.0 --branch feat/my-branch
-#   ./update-bundle.sh v2.19.0 --odh-operator-dir /path/to/opendatahub-operator
+#   ./update-bundle.sh 3.4.0-ea.2
+#   ./update-bundle.sh 3.4.0 --branch rhoai-3.4
+#   ./update-bundle.sh 3.4.0-ea.2 --odh-operator-dir /path/to/rhods-operator
 
 set -euo pipefail
 
@@ -38,8 +38,8 @@ CLOUD_TARGETS=(
 )
 
 # Defaults
-ODH_REPO_URL="git@github.com:opendatahub-io/opendatahub-operator.git"
-ODH_BRANCH="main"
+ODH_REPO_URL="https://github.com/red-hat-data-services/rhods-operator.git"
+ODH_BRANCH="rhoai-3.4"
 ODH_OPERATOR_DIR=""
 LOCAL_MODE=false
 
@@ -87,20 +87,20 @@ if ! command -v go &> /dev/null; then
 fi
 
 # ==============================================================================
-# Resolve opendatahub-operator directory
+# Resolve rhods-operator directory
 # ==============================================================================
 
 if [[ "${LOCAL_MODE}" == "true" ]]; then
     if [[ ! -d "${ODH_OPERATOR_DIR}" ]]; then
-        echo "ERROR: opendatahub-operator directory not found at ${ODH_OPERATOR_DIR}" >&2
+        echo "ERROR: rhods-operator directory not found at ${ODH_OPERATOR_DIR}" >&2
         exit 1
     fi
-    echo "Using local opendatahub-operator: ${ODH_OPERATOR_DIR}"
+    echo "Using local rhods-operator: ${ODH_OPERATOR_DIR}"
 else
     ODH_OPERATOR_DIR="$(mktemp -d)"
     trap 'rm -rf "${ODH_OPERATOR_DIR}"' EXIT
 
-    echo "Cloning opendatahub-operator (branch: ${ODH_BRANCH})..."
+    echo "Cloning rhods-operator (branch: ${ODH_BRANCH})..."
     git clone --depth 1 --branch "${ODH_BRANCH}" "${ODH_REPO_URL}" "${ODH_OPERATOR_DIR}"
     echo "  Done"
     echo ""
@@ -110,8 +110,20 @@ fi
 # Step 1: Generate operator templates
 # ==============================================================================
 
-echo "Running 'make manifests-all' in opendatahub-operator..."
+echo "Running 'make manifests-all' in rhods-operator..."
+echo "  This generates CRDs and RBAC for ODH, RHOAI, and cloudmanager..."
 make -C "${ODH_OPERATOR_DIR}" manifests-all
+echo "  Done"
+echo ""
+
+echo "Generating kustomization.yaml from templates..."
+# Generate main operator kustomization (creates config/rhoai/manager/kustomization.yaml)
+make -C "${ODH_OPERATOR_DIR}" manager-kustomization ODH_PLATFORM_TYPE=rhoai
+# Generate cloudmanager kustomizations
+for cloud in azure coreweave; do
+    cp -f "${ODH_OPERATOR_DIR}/config/cloudmanager/${cloud}/manager/kustomization.yaml.in" \
+          "${ODH_OPERATOR_DIR}/config/cloudmanager/${cloud}/manager/kustomization.yaml"
+done
 echo "  Done"
 echo ""
 
@@ -168,7 +180,7 @@ echo "Cloudmanager Templates"
 echo "=============================================================================="
 echo ""
 echo "Configuration:"
-echo "  ODH Operator: ${ODH_OPERATOR_DIR}"
+echo "  RHODS Operator: ${ODH_OPERATOR_DIR}"
 echo ""
 
 for target_entry in "${CLOUD_TARGETS[@]}"; do

--- a/charts/rhaii-helm-chart/scripts/update-bundle.sh
+++ b/charts/rhaii-helm-chart/scripts/update-bundle.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Update RHAII operator Helm chart from rhods-operator repo and cloudmanager resources.
+# Update RHAI operator Helm chart from RHDS rhods-operator git repo and cloudmanager resources.
 #
 # By default, the rhods-operator repo is shallow-cloned from GitHub.
 # Use --odh-operator-dir to point to a local checkout instead.
@@ -111,7 +111,6 @@ fi
 # ==============================================================================
 
 echo "Running 'make manifests-all' in rhods-operator..."
-echo "  This generates CRDs and RBAC for ODH, RHOAI, and cloudmanager..."
 make -C "${ODH_OPERATOR_DIR}" manifests-all
 echo "  Done"
 echo ""
@@ -163,7 +162,7 @@ kustomize build "${RHAI_KUSTOMIZE_PATH}" | go run "${HELMTEMPLATE_GENERATOR_PKG}
     -c "${SCRIPT_DIR}/helmtemplate-config.yaml" \
     -o "${CHART_DIR}" \
     --template-dir "${SCRIPT_DIR}" \
-    --chart-name "rhaii-helm-chart" \
+    --chart-name "rhai-on-xks-helm-chart" \
     --default-namespace "${NAMESPACE}" \
     --chart-description "Red Hat OpenShift AI Operator Helm chart (non-OLM installation)" \
     --app-version "${APP_VERSION}"
@@ -180,7 +179,7 @@ echo "Cloudmanager Templates"
 echo "=============================================================================="
 echo ""
 echo "Configuration:"
-echo "  RHODS Operator: ${ODH_OPERATOR_DIR}"
+echo "  RHOAI Operator: ${ODH_OPERATOR_DIR}"
 echo ""
 
 for target_entry in "${CLOUD_TARGETS[@]}"; do

--- a/charts/rhaii-helm-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
+++ b/charts/rhaii-helm-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
@@ -53,9 +53,9 @@ spec:
             - name: RHAI_OPERATOR_NAMESPACE
               value: {{ .Values.rhaiOperator.namespace }}
             - name: RHAI_WEBHOOK_CERT_SECRET_NAME
-              value: rhaii-operator-controller-webhook-cert
+              value: rhai-operator-controller-webhook-cert
             - name: RHAI_WEBHOOK_SERVICE_NAME
-              value: rhaii-operator-webhook-service
+              value: rhai-operator-webhook-service
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/rhaii-helm-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
+++ b/charts/rhaii-helm-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
@@ -53,9 +53,9 @@ spec:
             - name: RHAI_OPERATOR_NAMESPACE
               value: {{ .Values.rhaiOperator.namespace }}
             - name: RHAI_WEBHOOK_CERT_SECRET_NAME
-              value: redhat-ods-operator-controller-webhook-cert
+              value: rhaii-operator-controller-webhook-cert
             - name: RHAI_WEBHOOK_SERVICE_NAME
-              value: rhods-operator-webhook-service
+              value: rhaii-operator-webhook-service
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/rhaii-helm-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
+++ b/charts/rhaii-helm-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
@@ -53,9 +53,9 @@ spec:
             - name: RHAI_OPERATOR_NAMESPACE
               value: {{ .Values.rhaiOperator.namespace }}
             - name: RHAI_WEBHOOK_CERT_SECRET_NAME
-              value: rhaii-operator-controller-webhook-cert
+              value: rhai-operator-controller-webhook-cert
             - name: RHAI_WEBHOOK_SERVICE_NAME
-              value: rhaii-operator-webhook-service
+              value: rhai-operator-webhook-service
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/rhaii-helm-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
+++ b/charts/rhaii-helm-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
@@ -53,9 +53,9 @@ spec:
             - name: RHAI_OPERATOR_NAMESPACE
               value: {{ .Values.rhaiOperator.namespace }}
             - name: RHAI_WEBHOOK_CERT_SECRET_NAME
-              value: redhat-ods-operator-controller-webhook-cert
+              value: rhaii-operator-controller-webhook-cert
             - name: RHAI_WEBHOOK_SERVICE_NAME
-              value: rhods-operator-webhook-service
+              value: rhaii-operator-webhook-service
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/rhaii-helm-chart/templates/manager/deployment-rhods-operator.yaml
+++ b/charts/rhaii-helm-chart/templates/manager/deployment-rhods-operator.yaml
@@ -93,7 +93,7 @@ spec:
             - name: RHAI_DISABLE_SETUPCONTROLLER_SERVICE
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
-              value: {{ .Values.rhaiOperator.applicationsNamespace }}
+              value: {{ .Values.rhaiOperator.applicationsNamespace | quote }}
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
@@ -104,9 +104,9 @@ spec:
                   fieldPath: metadata.namespace
             - name: DEFAULT_MANIFESTS_PATH
               value: /opt/manifests
-            {{- range $name, $value := .Values.rhaiOperator.relatedImages }}
-            - name: {{ $name }}
-              value: {{ $value }}
+            {{- range $item := .Values.rhaiOperator.relatedImages }}
+            - name: {{ $item.name | quote }}
+              value: {{ $item.value | quote }}
             {{- end }}
           image: {{ .Values.rhaiOperator.image }}
           imagePullPolicy: {{ .Values.rhaiOperator.imagePullPolicy }}

--- a/charts/rhaii-helm-chart/templates/manager/deployment-rhods-operator.yaml
+++ b/charts/rhaii-helm-chart/templates/manager/deployment-rhods-operator.yaml
@@ -3,20 +3,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    name: rhods-operator
-  name: rhods-operator
+    name: rhaii-operator
+  name: rhaii-operator
   namespace: {{ .Values.rhaiOperator.namespace }}
 spec:
   replicas: 3
   selector:
     matchLabels:
-      name: rhods-operator
+      name: rhaii-operator
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: rhods-operator
+        kubectl.kubernetes.io/default-container: rhaii-operator
       labels:
-        name: rhods-operator
+        name: rhaii-operator
     spec:
       affinity:
         nodeAffinity:
@@ -35,7 +35,7 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - rhods-operator
+                        - rhaii-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -97,7 +97,7 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
-              value: rhods-operator
+              value: rhaii-operator
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -116,7 +116,7 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
-          name: rhods-operator
+          name: rhaii-operator
           ports:
             - containerPort: 9443
               name: webhook-server
@@ -150,7 +150,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: redhat-ods-operator-controller-manager
+      serviceAccountName: rhaii-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cert

--- a/charts/rhaii-helm-chart/templates/manager/deployment-rhods-operator.yaml
+++ b/charts/rhaii-helm-chart/templates/manager/deployment-rhods-operator.yaml
@@ -3,20 +3,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    name: rhaii-operator
-  name: rhaii-operator
+    name: rhai-operator
+  name: rhai-operator
   namespace: {{ .Values.rhaiOperator.namespace }}
 spec:
   replicas: 3
   selector:
     matchLabels:
-      name: rhaii-operator
+      name: rhai-operator
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: rhaii-operator
+        kubectl.kubernetes.io/default-container: rhai-operator
       labels:
-        name: rhaii-operator
+        name: rhai-operator
     spec:
       affinity:
         nodeAffinity:
@@ -35,7 +35,7 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - rhaii-operator
+                        - rhai-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -97,7 +97,7 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
-              value: rhaii-operator
+              value: rhai-operator
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -116,7 +116,7 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
-          name: rhaii-operator
+          name: rhai-operator
           ports:
             - containerPort: 9443
               name: webhook-server
@@ -150,7 +150,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: rhaii-operator-controller-manager
+      serviceAccountName: rhai-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cert

--- a/charts/rhaii-helm-chart/templates/manager/deployment-rhods-operator.yaml
+++ b/charts/rhaii-helm-chart/templates/manager/deployment-rhods-operator.yaml
@@ -93,7 +93,7 @@ spec:
             - name: RHAI_DISABLE_SETUPCONTROLLER_SERVICE
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
-              value: {{ .Values.rhaiOperator.applicationsNamespace | quote }}
+              value: {{ .Values.rhaiOperator.applicationsNamespace }}
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
@@ -104,9 +104,9 @@ spec:
                   fieldPath: metadata.namespace
             - name: DEFAULT_MANIFESTS_PATH
               value: /opt/manifests
-            {{- range $item := .Values.rhaiOperator.relatedImages }}
-            - name: {{ $item.name | quote }}
-              value: {{ $item.value | quote }}
+            {{- range $name, $value := .Values.rhaiOperator.relatedImages }}
+            - name: {{ $name }}
+              value: {{ $value }}
             {{- end }}
           image: {{ .Values.rhaiOperator.image }}
           imagePullPolicy: {{ .Values.rhaiOperator.imagePullPolicy }}

--- a/charts/rhaii-helm-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
+++ b/charts/rhaii-helm-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   labels:
     name: rhods-operator
-  name: rhaii-operator-controller-manager-metrics-service
+  name: rhai-operator-controller-manager-metrics-service
   namespace: {{ .Values.rhaiOperator.namespace }}
 spec:
   ports:
@@ -13,5 +13,5 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    name: rhaii-operator
+    name: rhai-operator
 {{- end }}

--- a/charts/rhaii-helm-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
+++ b/charts/rhaii-helm-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   labels:
     name: rhods-operator
-  name: redhat-ods-operator-controller-manager-metrics-service
+  name: rhaii-operator-controller-manager-metrics-service
   namespace: {{ .Values.rhaiOperator.namespace }}
 spec:
   ports:
@@ -13,5 +13,5 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    name: rhods-operator
+    name: rhaii-operator
 {{- end }}

--- a/charts/rhaii-helm-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
+++ b/charts/rhaii-helm-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-operator-metrics-reader
+  name: rhai-operator-metrics-reader
 rules:
   - nonResourceURLs:
       - /metrics

--- a/charts/rhaii-helm-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
+++ b/charts/rhaii-helm-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: redhat-ods-operator-metrics-reader
+  name: rhaii-operator-metrics-reader
 rules:
   - nonResourceURLs:
       - /metrics

--- a/charts/rhaii-helm-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
+++ b/charts/rhaii-helm-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhods-operator-role
+  name: rhaii-operator-role
 rules:
   - apiGroups:
       - ""

--- a/charts/rhaii-helm-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
+++ b/charts/rhaii-helm-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-operator-role
+  name: rhai-operator-role
 rules:
   - apiGroups:
       - ""

--- a/charts/rhaii-helm-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
+++ b/charts/rhaii-helm-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhaii-operator-rolebinding
+  name: rhai-operator-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhaii-operator-role
+  name: rhai-operator-role
 subjects:
   - kind: ServiceAccount
-    name: rhaii-operator-controller-manager
+    name: rhai-operator-controller-manager
     namespace: {{ .Values.rhaiOperator.namespace }}
 {{- end }}

--- a/charts/rhaii-helm-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
+++ b/charts/rhaii-helm-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhods-operator-rolebinding
+  name: rhaii-operator-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhods-operator-role
+  name: rhaii-operator-role
 subjects:
   - kind: ServiceAccount
-    name: redhat-ods-operator-controller-manager
+    name: rhaii-operator-controller-manager
     namespace: {{ .Values.rhaiOperator.namespace }}
 {{- end }}

--- a/charts/rhaii-helm-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
+++ b/charts/rhaii-helm-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: redhat-ods-operator-controller-manager
+  name: rhaii-operator-controller-manager
   namespace: {{ .Values.rhaiOperator.namespace }}
 {{ include "rhaii-helm-chart.imagePullSecrets" . }}
 {{- end }}

--- a/charts/rhaii-helm-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
+++ b/charts/rhaii-helm-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rhaii-operator-controller-manager
+  name: rhai-operator-controller-manager
   namespace: {{ .Values.rhaiOperator.namespace }}
 {{ include "rhaii-helm-chart.imagePullSecrets" . }}
 {{- end }}

--- a/charts/rhaii-helm-chart/templates/webhooks/mutatingwebhookconfiguration-rhods-operator-mutating-webhook-configuration.yaml
+++ b/charts/rhaii-helm-chart/templates/webhooks/mutatingwebhookconfiguration-rhods-operator-mutating-webhook-configuration.yaml
@@ -4,14 +4,19 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ .Values.rhaiOperator.namespace }}/opendatahub-operator-webhook-cert
-  name: rhods-operator-mutating-webhook-configuration
+  name: rhaii-operator-mutating-webhook-configuration
   namespace: {{ .Values.rhaiOperator.namespace }}
+  labels:
+    app.kubernetes.io/created-by: rhaii-operator
+    app.kubernetes.io/instance: rhaii-operator
+    app.kubernetes.io/name: rhaii-operator-mutating-webhook-configuration
+    app.kubernetes.io/part-of: rhaii-operator
 webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
       service:
-        name: rhods-operator-webhook-service
+        name: rhaii-operator-webhook-service
         namespace: {{ .Values.rhaiOperator.namespace }}
         path: /platform-connection-isvc
     failurePolicy: Fail
@@ -31,7 +36,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: rhods-operator-webhook-service
+        name: rhaii-operator-webhook-service
         namespace: {{ .Values.rhaiOperator.namespace }}
         path: /platform-connection-llmisvc
     failurePolicy: Fail

--- a/charts/rhaii-helm-chart/templates/webhooks/mutatingwebhookconfiguration-rhods-operator-mutating-webhook-configuration.yaml
+++ b/charts/rhaii-helm-chart/templates/webhooks/mutatingwebhookconfiguration-rhods-operator-mutating-webhook-configuration.yaml
@@ -3,20 +3,20 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Values.rhaiOperator.namespace }}/opendatahub-operator-webhook-cert
-  name: rhaii-operator-mutating-webhook-configuration
+    cert-manager.io/inject-ca-from: {{ .Values.rhaiOperator.namespace }}/rhai-operator-webhook-cert
+  name: rhai-operator-mutating-webhook-configuration
   namespace: {{ .Values.rhaiOperator.namespace }}
   labels:
-    app.kubernetes.io/created-by: rhaii-operator
-    app.kubernetes.io/instance: rhaii-operator
-    app.kubernetes.io/name: rhaii-operator-mutating-webhook-configuration
-    app.kubernetes.io/part-of: rhaii-operator
+    app.kubernetes.io/created-by: rhai-operator
+    app.kubernetes.io/instance: rhai-operator
+    app.kubernetes.io/name: rhai-operator-mutating-webhook-configuration
+    app.kubernetes.io/part-of: rhai-operator
 webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
       service:
-        name: rhaii-operator-webhook-service
+        name: rhai-operator-webhook-service
         namespace: {{ .Values.rhaiOperator.namespace }}
         path: /platform-connection-isvc
     failurePolicy: Fail
@@ -36,7 +36,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: rhaii-operator-webhook-service
+        name: rhai-operator-webhook-service
         namespace: {{ .Values.rhaiOperator.namespace }}
         path: /platform-connection-llmisvc
     failurePolicy: Fail

--- a/charts/rhaii-helm-chart/templates/webhooks/service-rhods-operator-webhook-service.yaml
+++ b/charts/rhaii-helm-chart/templates/webhooks/service-rhods-operator-webhook-service.yaml
@@ -4,12 +4,12 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: rhods-operator
-    app.kubernetes.io/instance: rhods-operator
+    app.kubernetes.io/created-by: rhaii-operator
+    app.kubernetes.io/instance: rhaii-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: rhods-operator-webhook-service
-    app.kubernetes.io/part-of: rhods-operator
-  name: rhods-operator-webhook-service
+    app.kubernetes.io/name: rhaii-operator-webhook-service
+    app.kubernetes.io/part-of: rhaii-operator
+  name: rhaii-operator-webhook-service
   namespace: {{ .Values.rhaiOperator.namespace }}
 spec:
   ports:
@@ -17,5 +17,5 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    name: rhods-operator
+    name: rhaii-operator
 {{- end }}

--- a/charts/rhaii-helm-chart/templates/webhooks/service-rhods-operator-webhook-service.yaml
+++ b/charts/rhaii-helm-chart/templates/webhooks/service-rhods-operator-webhook-service.yaml
@@ -4,12 +4,12 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: rhaii-operator
-    app.kubernetes.io/instance: rhaii-operator
+    app.kubernetes.io/created-by: rhai-operator
+    app.kubernetes.io/instance: rhai-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: rhaii-operator-webhook-service
-    app.kubernetes.io/part-of: rhaii-operator
-  name: rhaii-operator-webhook-service
+    app.kubernetes.io/name: rhai-operator-webhook-service
+    app.kubernetes.io/part-of: rhai-operator
+  name: rhai-operator-webhook-service
   namespace: {{ .Values.rhaiOperator.namespace }}
 spec:
   ports:
@@ -17,5 +17,5 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    name: rhaii-operator
+    name: rhai-operator
 {{- end }}

--- a/charts/rhaii-helm-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -2642,7 +2642,7 @@ spec:
             - name: RHAI_DISABLE_SETUPCONTROLLER_SERVICE
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
-              value: redhat-ods-applications
+              value: "redhat-ods-applications"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME

--- a/charts/rhaii-helm-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -64,7 +64,7 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rhaii-operator-controller-manager
+  name: rhai-operator-controller-manager
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhaii-pull-secret
@@ -849,7 +849,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-operator-metrics-reader
+  name: rhai-operator-metrics-reader
 rules:
   - nonResourceURLs:
       - /metrics
@@ -860,7 +860,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-operator-role
+  name: rhai-operator-role
 rules:
   - apiGroups:
       - ""
@@ -2357,14 +2357,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhaii-operator-rolebinding
+  name: rhai-operator-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhaii-operator-role
+  name: rhai-operator-role
 subjects:
   - kind: ServiceAccount
-    name: rhaii-operator-controller-manager
+    name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
@@ -2412,7 +2412,7 @@ kind: Service
 metadata:
   labels:
     name: rhods-operator
-  name: rhaii-operator-controller-manager-metrics-service
+  name: rhai-operator-controller-manager-metrics-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2421,7 +2421,7 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    name: rhaii-operator
+    name: rhai-operator
 ---
 # Source: rhaii-helm-chart/templates/webhooks/service-rhods-operator-webhook-service.yaml
 apiVersion: v1
@@ -2429,12 +2429,12 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: rhaii-operator
-    app.kubernetes.io/instance: rhaii-operator
+    app.kubernetes.io/created-by: rhai-operator
+    app.kubernetes.io/instance: rhai-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: rhaii-operator-webhook-service
-    app.kubernetes.io/part-of: rhaii-operator
-  name: rhaii-operator-webhook-service
+    app.kubernetes.io/name: rhai-operator-webhook-service
+    app.kubernetes.io/part-of: rhai-operator
+  name: rhai-operator-webhook-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2442,7 +2442,7 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    name: rhaii-operator
+    name: rhai-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2499,9 +2499,9 @@ spec:
             - name: RHAI_OPERATOR_NAMESPACE
               value: redhat-ods-operator
             - name: RHAI_WEBHOOK_CERT_SECRET_NAME
-              value: rhaii-operator-controller-webhook-cert
+              value: rhai-operator-controller-webhook-cert
             - name: RHAI_WEBHOOK_SERVICE_NAME
-              value: rhaii-operator-webhook-service
+              value: rhai-operator-webhook-service
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2552,20 +2552,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    name: rhaii-operator
-  name: rhaii-operator
+    name: rhai-operator
+  name: rhai-operator
   namespace: redhat-ods-operator
 spec:
   replicas: 3
   selector:
     matchLabels:
-      name: rhaii-operator
+      name: rhai-operator
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: rhaii-operator
+        kubectl.kubernetes.io/default-container: rhai-operator
       labels:
-        name: rhaii-operator
+        name: rhai-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2584,7 +2584,7 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - rhaii-operator
+                        - rhai-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -2646,7 +2646,7 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
-              value: rhaii-operator
+              value: rhai-operator
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2661,7 +2661,7 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
-          name: rhaii-operator
+          name: rhai-operator
           ports:
             - containerPort: 9443
               name: webhook-server
@@ -2695,7 +2695,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: rhaii-operator-controller-manager
+      serviceAccountName: rhai-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cert
@@ -2708,20 +2708,20 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: redhat-ods-operator/opendatahub-operator-webhook-cert
-  name: rhaii-operator-mutating-webhook-configuration
+    cert-manager.io/inject-ca-from: redhat-ods-operator/rhai-operator-webhook-cert
+  name: rhai-operator-mutating-webhook-configuration
   namespace: redhat-ods-operator
   labels:
-    app.kubernetes.io/created-by: rhaii-operator
-    app.kubernetes.io/instance: rhaii-operator
-    app.kubernetes.io/name: rhaii-operator-mutating-webhook-configuration
-    app.kubernetes.io/part-of: rhaii-operator
+    app.kubernetes.io/created-by: rhai-operator
+    app.kubernetes.io/instance: rhai-operator
+    app.kubernetes.io/name: rhai-operator-mutating-webhook-configuration
+    app.kubernetes.io/part-of: rhai-operator
 webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
       service:
-        name: rhaii-operator-webhook-service
+        name: rhai-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-isvc
     failurePolicy: Fail
@@ -2741,7 +2741,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: rhaii-operator-webhook-service
+        name: rhai-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-llmisvc
     failurePolicy: Fail

--- a/charts/rhaii-helm-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -64,7 +64,7 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: redhat-ods-operator-controller-manager
+  name: rhaii-operator-controller-manager
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhaii-pull-secret
@@ -849,7 +849,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: redhat-ods-operator-metrics-reader
+  name: rhaii-operator-metrics-reader
 rules:
   - nonResourceURLs:
       - /metrics
@@ -860,7 +860,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhods-operator-role
+  name: rhaii-operator-role
 rules:
   - apiGroups:
       - ""
@@ -2357,14 +2357,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhods-operator-rolebinding
+  name: rhaii-operator-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhods-operator-role
+  name: rhaii-operator-role
 subjects:
   - kind: ServiceAccount
-    name: redhat-ods-operator-controller-manager
+    name: rhaii-operator-controller-manager
     namespace: redhat-ods-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
@@ -2412,7 +2412,7 @@ kind: Service
 metadata:
   labels:
     name: rhods-operator
-  name: redhat-ods-operator-controller-manager-metrics-service
+  name: rhaii-operator-controller-manager-metrics-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2421,7 +2421,7 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    name: rhods-operator
+    name: rhaii-operator
 ---
 # Source: rhaii-helm-chart/templates/webhooks/service-rhods-operator-webhook-service.yaml
 apiVersion: v1
@@ -2429,12 +2429,12 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: rhods-operator
-    app.kubernetes.io/instance: rhods-operator
+    app.kubernetes.io/created-by: rhaii-operator
+    app.kubernetes.io/instance: rhaii-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: rhods-operator-webhook-service
-    app.kubernetes.io/part-of: rhods-operator
-  name: rhods-operator-webhook-service
+    app.kubernetes.io/name: rhaii-operator-webhook-service
+    app.kubernetes.io/part-of: rhaii-operator
+  name: rhaii-operator-webhook-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2442,7 +2442,7 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    name: rhods-operator
+    name: rhaii-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2499,9 +2499,9 @@ spec:
             - name: RHAI_OPERATOR_NAMESPACE
               value: redhat-ods-operator
             - name: RHAI_WEBHOOK_CERT_SECRET_NAME
-              value: redhat-ods-operator-controller-webhook-cert
+              value: rhaii-operator-controller-webhook-cert
             - name: RHAI_WEBHOOK_SERVICE_NAME
-              value: rhods-operator-webhook-service
+              value: rhaii-operator-webhook-service
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2552,20 +2552,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    name: rhods-operator
-  name: rhods-operator
+    name: rhaii-operator
+  name: rhaii-operator
   namespace: redhat-ods-operator
 spec:
   replicas: 3
   selector:
     matchLabels:
-      name: rhods-operator
+      name: rhaii-operator
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: rhods-operator
+        kubectl.kubernetes.io/default-container: rhaii-operator
       labels:
-        name: rhods-operator
+        name: rhaii-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2584,7 +2584,7 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - rhods-operator
+                        - rhaii-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -2646,7 +2646,7 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
-              value: rhods-operator
+              value: rhaii-operator
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2661,7 +2661,7 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
-          name: rhods-operator
+          name: rhaii-operator
           ports:
             - containerPort: 9443
               name: webhook-server
@@ -2695,7 +2695,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: redhat-ods-operator-controller-manager
+      serviceAccountName: rhaii-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cert
@@ -2709,14 +2709,19 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: redhat-ods-operator/opendatahub-operator-webhook-cert
-  name: rhods-operator-mutating-webhook-configuration
+  name: rhaii-operator-mutating-webhook-configuration
   namespace: redhat-ods-operator
+  labels:
+    app.kubernetes.io/created-by: rhaii-operator
+    app.kubernetes.io/instance: rhaii-operator
+    app.kubernetes.io/name: rhaii-operator-mutating-webhook-configuration
+    app.kubernetes.io/part-of: rhaii-operator
 webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
       service:
-        name: rhods-operator-webhook-service
+        name: rhaii-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-isvc
     failurePolicy: Fail
@@ -2736,7 +2741,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: rhods-operator-webhook-service
+        name: rhaii-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-llmisvc
     failurePolicy: Fail

--- a/charts/rhaii-helm-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -2642,7 +2642,7 @@ spec:
             - name: RHAI_DISABLE_SETUPCONTROLLER_SERVICE
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
-              value: "redhat-ods-applications"
+              value: redhat-ods-applications
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME

--- a/charts/rhaii-helm-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -30,7 +30,7 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rhaii-operator-controller-manager
+  name: rhai-operator-controller-manager
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhaii-pull-secret
@@ -711,7 +711,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-operator-metrics-reader
+  name: rhai-operator-metrics-reader
 rules:
   - nonResourceURLs:
       - /metrics
@@ -722,7 +722,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-operator-role
+  name: rhai-operator-role
 rules:
   - apiGroups:
       - ""
@@ -2219,14 +2219,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhaii-operator-rolebinding
+  name: rhai-operator-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhaii-operator-role
+  name: rhai-operator-role
 subjects:
   - kind: ServiceAccount
-    name: rhaii-operator-controller-manager
+    name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
@@ -2274,7 +2274,7 @@ kind: Service
 metadata:
   labels:
     name: rhods-operator
-  name: rhaii-operator-controller-manager-metrics-service
+  name: rhai-operator-controller-manager-metrics-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2283,7 +2283,7 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    name: rhaii-operator
+    name: rhai-operator
 ---
 # Source: rhaii-helm-chart/templates/webhooks/service-rhods-operator-webhook-service.yaml
 apiVersion: v1
@@ -2291,12 +2291,12 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: rhaii-operator
-    app.kubernetes.io/instance: rhaii-operator
+    app.kubernetes.io/created-by: rhai-operator
+    app.kubernetes.io/instance: rhai-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: rhaii-operator-webhook-service
-    app.kubernetes.io/part-of: rhaii-operator
-  name: rhaii-operator-webhook-service
+    app.kubernetes.io/name: rhai-operator-webhook-service
+    app.kubernetes.io/part-of: rhai-operator
+  name: rhai-operator-webhook-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2304,7 +2304,7 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    name: rhaii-operator
+    name: rhai-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2361,9 +2361,9 @@ spec:
             - name: RHAI_OPERATOR_NAMESPACE
               value: redhat-ods-operator
             - name: RHAI_WEBHOOK_CERT_SECRET_NAME
-              value: rhaii-operator-controller-webhook-cert
+              value: rhai-operator-controller-webhook-cert
             - name: RHAI_WEBHOOK_SERVICE_NAME
-              value: rhaii-operator-webhook-service
+              value: rhai-operator-webhook-service
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2414,20 +2414,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    name: rhaii-operator
-  name: rhaii-operator
+    name: rhai-operator
+  name: rhai-operator
   namespace: redhat-ods-operator
 spec:
   replicas: 3
   selector:
     matchLabels:
-      name: rhaii-operator
+      name: rhai-operator
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: rhaii-operator
+        kubectl.kubernetes.io/default-container: rhai-operator
       labels:
-        name: rhaii-operator
+        name: rhai-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2446,7 +2446,7 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - rhaii-operator
+                        - rhai-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -2508,7 +2508,7 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
-              value: rhaii-operator
+              value: rhai-operator
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2525,7 +2525,7 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
-          name: rhaii-operator
+          name: rhai-operator
           ports:
             - containerPort: 9443
               name: webhook-server
@@ -2559,7 +2559,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: rhaii-operator-controller-manager
+      serviceAccountName: rhai-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cert
@@ -2572,20 +2572,20 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: redhat-ods-operator/opendatahub-operator-webhook-cert
-  name: rhaii-operator-mutating-webhook-configuration
+    cert-manager.io/inject-ca-from: redhat-ods-operator/rhai-operator-webhook-cert
+  name: rhai-operator-mutating-webhook-configuration
   namespace: redhat-ods-operator
   labels:
-    app.kubernetes.io/created-by: rhaii-operator
-    app.kubernetes.io/instance: rhaii-operator
-    app.kubernetes.io/name: rhaii-operator-mutating-webhook-configuration
-    app.kubernetes.io/part-of: rhaii-operator
+    app.kubernetes.io/created-by: rhai-operator
+    app.kubernetes.io/instance: rhai-operator
+    app.kubernetes.io/name: rhai-operator-mutating-webhook-configuration
+    app.kubernetes.io/part-of: rhai-operator
 webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
       service:
-        name: rhaii-operator-webhook-service
+        name: rhai-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-isvc
     failurePolicy: Fail
@@ -2605,7 +2605,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: rhaii-operator-webhook-service
+        name: rhai-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-llmisvc
     failurePolicy: Fail

--- a/charts/rhaii-helm-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -30,7 +30,7 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: redhat-ods-operator-controller-manager
+  name: rhaii-operator-controller-manager
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhaii-pull-secret
@@ -711,7 +711,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: redhat-ods-operator-metrics-reader
+  name: rhaii-operator-metrics-reader
 rules:
   - nonResourceURLs:
       - /metrics
@@ -722,7 +722,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhods-operator-role
+  name: rhaii-operator-role
 rules:
   - apiGroups:
       - ""
@@ -2219,14 +2219,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhods-operator-rolebinding
+  name: rhaii-operator-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhods-operator-role
+  name: rhaii-operator-role
 subjects:
   - kind: ServiceAccount
-    name: redhat-ods-operator-controller-manager
+    name: rhaii-operator-controller-manager
     namespace: redhat-ods-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
@@ -2274,7 +2274,7 @@ kind: Service
 metadata:
   labels:
     name: rhods-operator
-  name: redhat-ods-operator-controller-manager-metrics-service
+  name: rhaii-operator-controller-manager-metrics-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2283,7 +2283,7 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    name: rhods-operator
+    name: rhaii-operator
 ---
 # Source: rhaii-helm-chart/templates/webhooks/service-rhods-operator-webhook-service.yaml
 apiVersion: v1
@@ -2291,12 +2291,12 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: rhods-operator
-    app.kubernetes.io/instance: rhods-operator
+    app.kubernetes.io/created-by: rhaii-operator
+    app.kubernetes.io/instance: rhaii-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: rhods-operator-webhook-service
-    app.kubernetes.io/part-of: rhods-operator
-  name: rhods-operator-webhook-service
+    app.kubernetes.io/name: rhaii-operator-webhook-service
+    app.kubernetes.io/part-of: rhaii-operator
+  name: rhaii-operator-webhook-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2304,7 +2304,7 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    name: rhods-operator
+    name: rhaii-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2361,9 +2361,9 @@ spec:
             - name: RHAI_OPERATOR_NAMESPACE
               value: redhat-ods-operator
             - name: RHAI_WEBHOOK_CERT_SECRET_NAME
-              value: redhat-ods-operator-controller-webhook-cert
+              value: rhaii-operator-controller-webhook-cert
             - name: RHAI_WEBHOOK_SERVICE_NAME
-              value: rhods-operator-webhook-service
+              value: rhaii-operator-webhook-service
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2414,20 +2414,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    name: rhods-operator
-  name: rhods-operator
+    name: rhaii-operator
+  name: rhaii-operator
   namespace: redhat-ods-operator
 spec:
   replicas: 3
   selector:
     matchLabels:
-      name: rhods-operator
+      name: rhaii-operator
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: rhods-operator
+        kubectl.kubernetes.io/default-container: rhaii-operator
       labels:
-        name: rhods-operator
+        name: rhaii-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2446,7 +2446,7 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - rhods-operator
+                        - rhaii-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -2508,7 +2508,7 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
-              value: rhods-operator
+              value: rhaii-operator
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2525,7 +2525,7 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
-          name: rhods-operator
+          name: rhaii-operator
           ports:
             - containerPort: 9443
               name: webhook-server
@@ -2559,7 +2559,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: redhat-ods-operator-controller-manager
+      serviceAccountName: rhaii-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cert
@@ -2573,14 +2573,19 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: redhat-ods-operator/opendatahub-operator-webhook-cert
-  name: rhods-operator-mutating-webhook-configuration
+  name: rhaii-operator-mutating-webhook-configuration
   namespace: redhat-ods-operator
+  labels:
+    app.kubernetes.io/created-by: rhaii-operator
+    app.kubernetes.io/instance: rhaii-operator
+    app.kubernetes.io/name: rhaii-operator-mutating-webhook-configuration
+    app.kubernetes.io/part-of: rhaii-operator
 webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
       service:
-        name: rhods-operator-webhook-service
+        name: rhaii-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-isvc
     failurePolicy: Fail
@@ -2600,7 +2605,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: rhods-operator-webhook-service
+        name: rhaii-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-llmisvc
     failurePolicy: Fail

--- a/charts/rhaii-helm-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2504,7 +2504,7 @@ spec:
             - name: RHAI_DISABLE_SETUPCONTROLLER_SERVICE
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
-              value: redhat-ods-applications
+              value: "redhat-ods-applications"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
@@ -2515,8 +2515,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: DEFAULT_MANIFESTS_PATH
               value: /opt/manifests
-            - name: 0
-              value: map[name:RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE value:ghcr.io/opendatahub-io/kserve/odh-kserve-llmisvc-controller:release-v0.17]
+            - name: "RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE"
+              value: "ghcr.io/opendatahub-io/kserve/odh-kserve-llmisvc-controller:release-v0.17"
           image: quay.io/opendatahub/opendatahub-operator:latest
           imagePullPolicy: Always
           livenessProbe:

--- a/charts/rhaii-helm-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2504,7 +2504,7 @@ spec:
             - name: RHAI_DISABLE_SETUPCONTROLLER_SERVICE
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
-              value: "redhat-ods-applications"
+              value: redhat-ods-applications
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
@@ -2515,8 +2515,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: DEFAULT_MANIFESTS_PATH
               value: /opt/manifests
-            - name: "RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE"
-              value: "ghcr.io/opendatahub-io/kserve/odh-kserve-llmisvc-controller:release-v0.17"
+            - name: 0
+              value: map[name:RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE value:ghcr.io/opendatahub-io/kserve/odh-kserve-llmisvc-controller:release-v0.17]
           image: quay.io/opendatahub/opendatahub-operator:latest
           imagePullPolicy: Always
           livenessProbe:

--- a/charts/rhaii-helm-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -2642,7 +2642,7 @@ spec:
             - name: RHAI_DISABLE_SETUPCONTROLLER_SERVICE
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
-              value: redhat-ods-applications
+              value: "redhat-ods-applications"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME

--- a/charts/rhaii-helm-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -64,7 +64,7 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: redhat-ods-operator-controller-manager
+  name: rhaii-operator-controller-manager
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhaii-pull-secret
@@ -849,7 +849,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: redhat-ods-operator-metrics-reader
+  name: rhaii-operator-metrics-reader
 rules:
   - nonResourceURLs:
       - /metrics
@@ -860,7 +860,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhods-operator-role
+  name: rhaii-operator-role
 rules:
   - apiGroups:
       - ""
@@ -2357,14 +2357,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhods-operator-rolebinding
+  name: rhaii-operator-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhods-operator-role
+  name: rhaii-operator-role
 subjects:
   - kind: ServiceAccount
-    name: redhat-ods-operator-controller-manager
+    name: rhaii-operator-controller-manager
     namespace: redhat-ods-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/coreweave/rbac/role-coreweave-cloud-manager-leader-election-role.yaml
@@ -2412,7 +2412,7 @@ kind: Service
 metadata:
   labels:
     name: rhods-operator
-  name: redhat-ods-operator-controller-manager-metrics-service
+  name: rhaii-operator-controller-manager-metrics-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2421,7 +2421,7 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    name: rhods-operator
+    name: rhaii-operator
 ---
 # Source: rhaii-helm-chart/templates/webhooks/service-rhods-operator-webhook-service.yaml
 apiVersion: v1
@@ -2429,12 +2429,12 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: rhods-operator
-    app.kubernetes.io/instance: rhods-operator
+    app.kubernetes.io/created-by: rhaii-operator
+    app.kubernetes.io/instance: rhaii-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: rhods-operator-webhook-service
-    app.kubernetes.io/part-of: rhods-operator
-  name: rhods-operator-webhook-service
+    app.kubernetes.io/name: rhaii-operator-webhook-service
+    app.kubernetes.io/part-of: rhaii-operator
+  name: rhaii-operator-webhook-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2442,7 +2442,7 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    name: rhods-operator
+    name: rhaii-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2499,9 +2499,9 @@ spec:
             - name: RHAI_OPERATOR_NAMESPACE
               value: redhat-ods-operator
             - name: RHAI_WEBHOOK_CERT_SECRET_NAME
-              value: redhat-ods-operator-controller-webhook-cert
+              value: rhaii-operator-controller-webhook-cert
             - name: RHAI_WEBHOOK_SERVICE_NAME
-              value: rhods-operator-webhook-service
+              value: rhaii-operator-webhook-service
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2552,20 +2552,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    name: rhods-operator
-  name: rhods-operator
+    name: rhaii-operator
+  name: rhaii-operator
   namespace: redhat-ods-operator
 spec:
   replicas: 3
   selector:
     matchLabels:
-      name: rhods-operator
+      name: rhaii-operator
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: rhods-operator
+        kubectl.kubernetes.io/default-container: rhaii-operator
       labels:
-        name: rhods-operator
+        name: rhaii-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2584,7 +2584,7 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - rhods-operator
+                        - rhaii-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -2646,7 +2646,7 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
-              value: rhods-operator
+              value: rhaii-operator
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2661,7 +2661,7 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
-          name: rhods-operator
+          name: rhaii-operator
           ports:
             - containerPort: 9443
               name: webhook-server
@@ -2695,7 +2695,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: redhat-ods-operator-controller-manager
+      serviceAccountName: rhaii-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cert
@@ -2709,14 +2709,19 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: redhat-ods-operator/opendatahub-operator-webhook-cert
-  name: rhods-operator-mutating-webhook-configuration
+  name: rhaii-operator-mutating-webhook-configuration
   namespace: redhat-ods-operator
+  labels:
+    app.kubernetes.io/created-by: rhaii-operator
+    app.kubernetes.io/instance: rhaii-operator
+    app.kubernetes.io/name: rhaii-operator-mutating-webhook-configuration
+    app.kubernetes.io/part-of: rhaii-operator
 webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
       service:
-        name: rhods-operator-webhook-service
+        name: rhaii-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-isvc
     failurePolicy: Fail
@@ -2736,7 +2741,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: rhods-operator-webhook-service
+        name: rhaii-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-llmisvc
     failurePolicy: Fail

--- a/charts/rhaii-helm-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -64,7 +64,7 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rhaii-operator-controller-manager
+  name: rhai-operator-controller-manager
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhaii-pull-secret
@@ -849,7 +849,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-operator-metrics-reader
+  name: rhai-operator-metrics-reader
 rules:
   - nonResourceURLs:
       - /metrics
@@ -860,7 +860,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-operator-role
+  name: rhai-operator-role
 rules:
   - apiGroups:
       - ""
@@ -2357,14 +2357,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhaii-operator-rolebinding
+  name: rhai-operator-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhaii-operator-role
+  name: rhai-operator-role
 subjects:
   - kind: ServiceAccount
-    name: rhaii-operator-controller-manager
+    name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/coreweave/rbac/role-coreweave-cloud-manager-leader-election-role.yaml
@@ -2412,7 +2412,7 @@ kind: Service
 metadata:
   labels:
     name: rhods-operator
-  name: rhaii-operator-controller-manager-metrics-service
+  name: rhai-operator-controller-manager-metrics-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2421,7 +2421,7 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    name: rhaii-operator
+    name: rhai-operator
 ---
 # Source: rhaii-helm-chart/templates/webhooks/service-rhods-operator-webhook-service.yaml
 apiVersion: v1
@@ -2429,12 +2429,12 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: rhaii-operator
-    app.kubernetes.io/instance: rhaii-operator
+    app.kubernetes.io/created-by: rhai-operator
+    app.kubernetes.io/instance: rhai-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: rhaii-operator-webhook-service
-    app.kubernetes.io/part-of: rhaii-operator
-  name: rhaii-operator-webhook-service
+    app.kubernetes.io/name: rhai-operator-webhook-service
+    app.kubernetes.io/part-of: rhai-operator
+  name: rhai-operator-webhook-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2442,7 +2442,7 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    name: rhaii-operator
+    name: rhai-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2499,9 +2499,9 @@ spec:
             - name: RHAI_OPERATOR_NAMESPACE
               value: redhat-ods-operator
             - name: RHAI_WEBHOOK_CERT_SECRET_NAME
-              value: rhaii-operator-controller-webhook-cert
+              value: rhai-operator-controller-webhook-cert
             - name: RHAI_WEBHOOK_SERVICE_NAME
-              value: rhaii-operator-webhook-service
+              value: rhai-operator-webhook-service
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2552,20 +2552,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    name: rhaii-operator
-  name: rhaii-operator
+    name: rhai-operator
+  name: rhai-operator
   namespace: redhat-ods-operator
 spec:
   replicas: 3
   selector:
     matchLabels:
-      name: rhaii-operator
+      name: rhai-operator
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: rhaii-operator
+        kubectl.kubernetes.io/default-container: rhai-operator
       labels:
-        name: rhaii-operator
+        name: rhai-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2584,7 +2584,7 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - rhaii-operator
+                        - rhai-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -2646,7 +2646,7 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
-              value: rhaii-operator
+              value: rhai-operator
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2661,7 +2661,7 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
-          name: rhaii-operator
+          name: rhai-operator
           ports:
             - containerPort: 9443
               name: webhook-server
@@ -2695,7 +2695,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: rhaii-operator-controller-manager
+      serviceAccountName: rhai-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cert
@@ -2708,20 +2708,20 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: redhat-ods-operator/opendatahub-operator-webhook-cert
-  name: rhaii-operator-mutating-webhook-configuration
+    cert-manager.io/inject-ca-from: redhat-ods-operator/rhai-operator-webhook-cert
+  name: rhai-operator-mutating-webhook-configuration
   namespace: redhat-ods-operator
   labels:
-    app.kubernetes.io/created-by: rhaii-operator
-    app.kubernetes.io/instance: rhaii-operator
-    app.kubernetes.io/name: rhaii-operator-mutating-webhook-configuration
-    app.kubernetes.io/part-of: rhaii-operator
+    app.kubernetes.io/created-by: rhai-operator
+    app.kubernetes.io/instance: rhai-operator
+    app.kubernetes.io/name: rhai-operator-mutating-webhook-configuration
+    app.kubernetes.io/part-of: rhai-operator
 webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
       service:
-        name: rhaii-operator-webhook-service
+        name: rhai-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-isvc
     failurePolicy: Fail
@@ -2741,7 +2741,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: rhaii-operator-webhook-service
+        name: rhai-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-llmisvc
     failurePolicy: Fail

--- a/charts/rhaii-helm-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -2642,7 +2642,7 @@ spec:
             - name: RHAI_DISABLE_SETUPCONTROLLER_SERVICE
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
-              value: "redhat-ods-applications"
+              value: redhat-ods-applications
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME

--- a/charts/rhaii-helm-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/coreweave.snap.yaml
@@ -2504,7 +2504,7 @@ spec:
             - name: RHAI_DISABLE_SETUPCONTROLLER_SERVICE
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
-              value: redhat-ods-applications
+              value: "redhat-ods-applications"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME

--- a/charts/rhaii-helm-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/coreweave.snap.yaml
@@ -30,7 +30,7 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: redhat-ods-operator-controller-manager
+  name: rhaii-operator-controller-manager
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhaii-pull-secret
@@ -711,7 +711,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: redhat-ods-operator-metrics-reader
+  name: rhaii-operator-metrics-reader
 rules:
   - nonResourceURLs:
       - /metrics
@@ -722,7 +722,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhods-operator-role
+  name: rhaii-operator-role
 rules:
   - apiGroups:
       - ""
@@ -2219,14 +2219,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhods-operator-rolebinding
+  name: rhaii-operator-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhods-operator-role
+  name: rhaii-operator-role
 subjects:
   - kind: ServiceAccount
-    name: redhat-ods-operator-controller-manager
+    name: rhaii-operator-controller-manager
     namespace: redhat-ods-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/coreweave/rbac/role-coreweave-cloud-manager-leader-election-role.yaml
@@ -2274,7 +2274,7 @@ kind: Service
 metadata:
   labels:
     name: rhods-operator
-  name: redhat-ods-operator-controller-manager-metrics-service
+  name: rhaii-operator-controller-manager-metrics-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2283,7 +2283,7 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    name: rhods-operator
+    name: rhaii-operator
 ---
 # Source: rhaii-helm-chart/templates/webhooks/service-rhods-operator-webhook-service.yaml
 apiVersion: v1
@@ -2291,12 +2291,12 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: rhods-operator
-    app.kubernetes.io/instance: rhods-operator
+    app.kubernetes.io/created-by: rhaii-operator
+    app.kubernetes.io/instance: rhaii-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: rhods-operator-webhook-service
-    app.kubernetes.io/part-of: rhods-operator
-  name: rhods-operator-webhook-service
+    app.kubernetes.io/name: rhaii-operator-webhook-service
+    app.kubernetes.io/part-of: rhaii-operator
+  name: rhaii-operator-webhook-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2304,7 +2304,7 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    name: rhods-operator
+    name: rhaii-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2361,9 +2361,9 @@ spec:
             - name: RHAI_OPERATOR_NAMESPACE
               value: redhat-ods-operator
             - name: RHAI_WEBHOOK_CERT_SECRET_NAME
-              value: redhat-ods-operator-controller-webhook-cert
+              value: rhaii-operator-controller-webhook-cert
             - name: RHAI_WEBHOOK_SERVICE_NAME
-              value: rhods-operator-webhook-service
+              value: rhaii-operator-webhook-service
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2414,20 +2414,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    name: rhods-operator
-  name: rhods-operator
+    name: rhaii-operator
+  name: rhaii-operator
   namespace: redhat-ods-operator
 spec:
   replicas: 3
   selector:
     matchLabels:
-      name: rhods-operator
+      name: rhaii-operator
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: rhods-operator
+        kubectl.kubernetes.io/default-container: rhaii-operator
       labels:
-        name: rhods-operator
+        name: rhaii-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2446,7 +2446,7 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - rhods-operator
+                        - rhaii-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -2508,7 +2508,7 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
-              value: rhods-operator
+              value: rhaii-operator
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2523,7 +2523,7 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
-          name: rhods-operator
+          name: rhaii-operator
           ports:
             - containerPort: 9443
               name: webhook-server
@@ -2557,7 +2557,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: redhat-ods-operator-controller-manager
+      serviceAccountName: rhaii-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cert
@@ -2571,14 +2571,19 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: redhat-ods-operator/opendatahub-operator-webhook-cert
-  name: rhods-operator-mutating-webhook-configuration
+  name: rhaii-operator-mutating-webhook-configuration
   namespace: redhat-ods-operator
+  labels:
+    app.kubernetes.io/created-by: rhaii-operator
+    app.kubernetes.io/instance: rhaii-operator
+    app.kubernetes.io/name: rhaii-operator-mutating-webhook-configuration
+    app.kubernetes.io/part-of: rhaii-operator
 webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
       service:
-        name: rhods-operator-webhook-service
+        name: rhaii-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-isvc
     failurePolicy: Fail
@@ -2598,7 +2603,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: rhods-operator-webhook-service
+        name: rhaii-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-llmisvc
     failurePolicy: Fail

--- a/charts/rhaii-helm-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/coreweave.snap.yaml
@@ -30,7 +30,7 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rhaii-operator-controller-manager
+  name: rhai-operator-controller-manager
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhaii-pull-secret
@@ -711,7 +711,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-operator-metrics-reader
+  name: rhai-operator-metrics-reader
 rules:
   - nonResourceURLs:
       - /metrics
@@ -722,7 +722,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-operator-role
+  name: rhai-operator-role
 rules:
   - apiGroups:
       - ""
@@ -2219,14 +2219,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhaii-operator-rolebinding
+  name: rhai-operator-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhaii-operator-role
+  name: rhai-operator-role
 subjects:
   - kind: ServiceAccount
-    name: rhaii-operator-controller-manager
+    name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/coreweave/rbac/role-coreweave-cloud-manager-leader-election-role.yaml
@@ -2274,7 +2274,7 @@ kind: Service
 metadata:
   labels:
     name: rhods-operator
-  name: rhaii-operator-controller-manager-metrics-service
+  name: rhai-operator-controller-manager-metrics-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2283,7 +2283,7 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    name: rhaii-operator
+    name: rhai-operator
 ---
 # Source: rhaii-helm-chart/templates/webhooks/service-rhods-operator-webhook-service.yaml
 apiVersion: v1
@@ -2291,12 +2291,12 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: rhaii-operator
-    app.kubernetes.io/instance: rhaii-operator
+    app.kubernetes.io/created-by: rhai-operator
+    app.kubernetes.io/instance: rhai-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: rhaii-operator-webhook-service
-    app.kubernetes.io/part-of: rhaii-operator
-  name: rhaii-operator-webhook-service
+    app.kubernetes.io/name: rhai-operator-webhook-service
+    app.kubernetes.io/part-of: rhai-operator
+  name: rhai-operator-webhook-service
   namespace: redhat-ods-operator
 spec:
   ports:
@@ -2304,7 +2304,7 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    name: rhaii-operator
+    name: rhai-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2361,9 +2361,9 @@ spec:
             - name: RHAI_OPERATOR_NAMESPACE
               value: redhat-ods-operator
             - name: RHAI_WEBHOOK_CERT_SECRET_NAME
-              value: rhaii-operator-controller-webhook-cert
+              value: rhai-operator-controller-webhook-cert
             - name: RHAI_WEBHOOK_SERVICE_NAME
-              value: rhaii-operator-webhook-service
+              value: rhai-operator-webhook-service
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2414,20 +2414,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    name: rhaii-operator
-  name: rhaii-operator
+    name: rhai-operator
+  name: rhai-operator
   namespace: redhat-ods-operator
 spec:
   replicas: 3
   selector:
     matchLabels:
-      name: rhaii-operator
+      name: rhai-operator
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: rhaii-operator
+        kubectl.kubernetes.io/default-container: rhai-operator
       labels:
-        name: rhaii-operator
+        name: rhai-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2446,7 +2446,7 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - rhaii-operator
+                        - rhai-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -2508,7 +2508,7 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
-              value: rhaii-operator
+              value: rhai-operator
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2523,7 +2523,7 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
-          name: rhaii-operator
+          name: rhai-operator
           ports:
             - containerPort: 9443
               name: webhook-server
@@ -2557,7 +2557,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: rhaii-operator-controller-manager
+      serviceAccountName: rhai-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cert
@@ -2570,20 +2570,20 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: redhat-ods-operator/opendatahub-operator-webhook-cert
-  name: rhaii-operator-mutating-webhook-configuration
+    cert-manager.io/inject-ca-from: redhat-ods-operator/rhai-operator-webhook-cert
+  name: rhai-operator-mutating-webhook-configuration
   namespace: redhat-ods-operator
   labels:
-    app.kubernetes.io/created-by: rhaii-operator
-    app.kubernetes.io/instance: rhaii-operator
-    app.kubernetes.io/name: rhaii-operator-mutating-webhook-configuration
-    app.kubernetes.io/part-of: rhaii-operator
+    app.kubernetes.io/created-by: rhai-operator
+    app.kubernetes.io/instance: rhai-operator
+    app.kubernetes.io/name: rhai-operator-mutating-webhook-configuration
+    app.kubernetes.io/part-of: rhai-operator
 webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
       service:
-        name: rhaii-operator-webhook-service
+        name: rhai-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-isvc
     failurePolicy: Fail
@@ -2603,7 +2603,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: rhaii-operator-webhook-service
+        name: rhai-operator-webhook-service
         namespace: redhat-ods-operator
         path: /platform-connection-llmisvc
     failurePolicy: Fail

--- a/charts/rhaii-helm-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/coreweave.snap.yaml
@@ -2504,7 +2504,7 @@ spec:
             - name: RHAI_DISABLE_SETUPCONTROLLER_SERVICE
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
-              value: "redhat-ods-applications"
+              value: redhat-ods-applications
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME

--- a/charts/rhaii-helm-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -2504,7 +2504,7 @@ spec:
             - name: RHAI_DISABLE_SETUPCONTROLLER_SERVICE
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
-              value: rhai-applications
+              value: "rhai-applications"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME

--- a/charts/rhaii-helm-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -30,7 +30,7 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rhaii-operator-controller-manager
+  name: rhai-operator-controller-manager
   namespace: rhai-operator
 imagePullSecrets:
   - name: rhaii-pull-secret
@@ -711,7 +711,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-operator-metrics-reader
+  name: rhai-operator-metrics-reader
 rules:
   - nonResourceURLs:
       - /metrics
@@ -722,7 +722,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-operator-role
+  name: rhai-operator-role
 rules:
   - apiGroups:
       - ""
@@ -2219,14 +2219,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhaii-operator-rolebinding
+  name: rhai-operator-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhaii-operator-role
+  name: rhai-operator-role
 subjects:
   - kind: ServiceAccount
-    name: rhaii-operator-controller-manager
+    name: rhai-operator-controller-manager
     namespace: rhai-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
@@ -2274,7 +2274,7 @@ kind: Service
 metadata:
   labels:
     name: rhods-operator
-  name: rhaii-operator-controller-manager-metrics-service
+  name: rhai-operator-controller-manager-metrics-service
   namespace: rhai-operator
 spec:
   ports:
@@ -2283,7 +2283,7 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    name: rhaii-operator
+    name: rhai-operator
 ---
 # Source: rhaii-helm-chart/templates/webhooks/service-rhods-operator-webhook-service.yaml
 apiVersion: v1
@@ -2291,12 +2291,12 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: rhaii-operator
-    app.kubernetes.io/instance: rhaii-operator
+    app.kubernetes.io/created-by: rhai-operator
+    app.kubernetes.io/instance: rhai-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: rhaii-operator-webhook-service
-    app.kubernetes.io/part-of: rhaii-operator
-  name: rhaii-operator-webhook-service
+    app.kubernetes.io/name: rhai-operator-webhook-service
+    app.kubernetes.io/part-of: rhai-operator
+  name: rhai-operator-webhook-service
   namespace: rhai-operator
 spec:
   ports:
@@ -2304,7 +2304,7 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    name: rhaii-operator
+    name: rhai-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2361,9 +2361,9 @@ spec:
             - name: RHAI_OPERATOR_NAMESPACE
               value: rhai-operator
             - name: RHAI_WEBHOOK_CERT_SECRET_NAME
-              value: rhaii-operator-controller-webhook-cert
+              value: rhai-operator-controller-webhook-cert
             - name: RHAI_WEBHOOK_SERVICE_NAME
-              value: rhaii-operator-webhook-service
+              value: rhai-operator-webhook-service
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2414,20 +2414,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    name: rhaii-operator
-  name: rhaii-operator
+    name: rhai-operator
+  name: rhai-operator
   namespace: rhai-operator
 spec:
   replicas: 3
   selector:
     matchLabels:
-      name: rhaii-operator
+      name: rhai-operator
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: rhaii-operator
+        kubectl.kubernetes.io/default-container: rhai-operator
       labels:
-        name: rhaii-operator
+        name: rhai-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2446,7 +2446,7 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - rhaii-operator
+                        - rhai-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -2508,7 +2508,7 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
-              value: rhaii-operator
+              value: rhai-operator
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2523,7 +2523,7 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
-          name: rhaii-operator
+          name: rhai-operator
           ports:
             - containerPort: 9443
               name: webhook-server
@@ -2557,7 +2557,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: rhaii-operator-controller-manager
+      serviceAccountName: rhai-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cert
@@ -2570,20 +2570,20 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: rhai-operator/opendatahub-operator-webhook-cert
-  name: rhaii-operator-mutating-webhook-configuration
+    cert-manager.io/inject-ca-from: rhai-operator/rhai-operator-webhook-cert
+  name: rhai-operator-mutating-webhook-configuration
   namespace: rhai-operator
   labels:
-    app.kubernetes.io/created-by: rhaii-operator
-    app.kubernetes.io/instance: rhaii-operator
-    app.kubernetes.io/name: rhaii-operator-mutating-webhook-configuration
-    app.kubernetes.io/part-of: rhaii-operator
+    app.kubernetes.io/created-by: rhai-operator
+    app.kubernetes.io/instance: rhai-operator
+    app.kubernetes.io/name: rhai-operator-mutating-webhook-configuration
+    app.kubernetes.io/part-of: rhai-operator
 webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
       service:
-        name: rhaii-operator-webhook-service
+        name: rhai-operator-webhook-service
         namespace: rhai-operator
         path: /platform-connection-isvc
     failurePolicy: Fail
@@ -2603,7 +2603,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: rhaii-operator-webhook-service
+        name: rhai-operator-webhook-service
         namespace: rhai-operator
         path: /platform-connection-llmisvc
     failurePolicy: Fail

--- a/charts/rhaii-helm-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -30,7 +30,7 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: redhat-ods-operator-controller-manager
+  name: rhaii-operator-controller-manager
   namespace: rhai-operator
 imagePullSecrets:
   - name: rhaii-pull-secret
@@ -711,7 +711,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: redhat-ods-operator-metrics-reader
+  name: rhaii-operator-metrics-reader
 rules:
   - nonResourceURLs:
       - /metrics
@@ -722,7 +722,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhods-operator-role
+  name: rhaii-operator-role
 rules:
   - apiGroups:
       - ""
@@ -2219,14 +2219,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhods-operator-rolebinding
+  name: rhaii-operator-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhods-operator-role
+  name: rhaii-operator-role
 subjects:
   - kind: ServiceAccount
-    name: redhat-ods-operator-controller-manager
+    name: rhaii-operator-controller-manager
     namespace: rhai-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
@@ -2274,7 +2274,7 @@ kind: Service
 metadata:
   labels:
     name: rhods-operator
-  name: redhat-ods-operator-controller-manager-metrics-service
+  name: rhaii-operator-controller-manager-metrics-service
   namespace: rhai-operator
 spec:
   ports:
@@ -2283,7 +2283,7 @@ spec:
       protocol: TCP
       targetPort: http
   selector:
-    name: rhods-operator
+    name: rhaii-operator
 ---
 # Source: rhaii-helm-chart/templates/webhooks/service-rhods-operator-webhook-service.yaml
 apiVersion: v1
@@ -2291,12 +2291,12 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: rhods-operator
-    app.kubernetes.io/instance: rhods-operator
+    app.kubernetes.io/created-by: rhaii-operator
+    app.kubernetes.io/instance: rhaii-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: rhods-operator-webhook-service
-    app.kubernetes.io/part-of: rhods-operator
-  name: rhods-operator-webhook-service
+    app.kubernetes.io/name: rhaii-operator-webhook-service
+    app.kubernetes.io/part-of: rhaii-operator
+  name: rhaii-operator-webhook-service
   namespace: rhai-operator
 spec:
   ports:
@@ -2304,7 +2304,7 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    name: rhods-operator
+    name: rhaii-operator
 ---
 # Source: rhaii-helm-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2361,9 +2361,9 @@ spec:
             - name: RHAI_OPERATOR_NAMESPACE
               value: rhai-operator
             - name: RHAI_WEBHOOK_CERT_SECRET_NAME
-              value: redhat-ods-operator-controller-webhook-cert
+              value: rhaii-operator-controller-webhook-cert
             - name: RHAI_WEBHOOK_SERVICE_NAME
-              value: rhods-operator-webhook-service
+              value: rhaii-operator-webhook-service
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2414,20 +2414,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    name: rhods-operator
-  name: rhods-operator
+    name: rhaii-operator
+  name: rhaii-operator
   namespace: rhai-operator
 spec:
   replicas: 3
   selector:
     matchLabels:
-      name: rhods-operator
+      name: rhaii-operator
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: rhods-operator
+        kubectl.kubernetes.io/default-container: rhaii-operator
       labels:
-        name: rhods-operator
+        name: rhaii-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2446,7 +2446,7 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - rhods-operator
+                        - rhaii-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
@@ -2508,7 +2508,7 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME
-              value: rhods-operator
+              value: rhaii-operator
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2523,7 +2523,7 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
-          name: rhods-operator
+          name: rhaii-operator
           ports:
             - containerPort: 9443
               name: webhook-server
@@ -2557,7 +2557,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: redhat-ods-operator-controller-manager
+      serviceAccountName: rhaii-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cert
@@ -2571,14 +2571,19 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: rhai-operator/opendatahub-operator-webhook-cert
-  name: rhods-operator-mutating-webhook-configuration
+  name: rhaii-operator-mutating-webhook-configuration
   namespace: rhai-operator
+  labels:
+    app.kubernetes.io/created-by: rhaii-operator
+    app.kubernetes.io/instance: rhaii-operator
+    app.kubernetes.io/name: rhaii-operator-mutating-webhook-configuration
+    app.kubernetes.io/part-of: rhaii-operator
 webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
       service:
-        name: rhods-operator-webhook-service
+        name: rhaii-operator-webhook-service
         namespace: rhai-operator
         path: /platform-connection-isvc
     failurePolicy: Fail
@@ -2598,7 +2603,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: rhods-operator-webhook-service
+        name: rhaii-operator-webhook-service
         namespace: rhai-operator
         path: /platform-connection-llmisvc
     failurePolicy: Fail

--- a/charts/rhaii-helm-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -2504,7 +2504,7 @@ spec:
             - name: RHAI_DISABLE_SETUPCONTROLLER_SERVICE
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
-              value: "rhai-applications"
+              value: rhai-applications
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME

--- a/charts/rhaii-helm-chart/values.yaml
+++ b/charts/rhaii-helm-chart/values.yaml
@@ -13,7 +13,7 @@ rhaiOperator:
   namespace: redhat-ods-operator
   applicationsNamespace: redhat-ods-applications
   # Manager container image
-  image: quay.io/opendatahub/opendatahub-operator:latest
+  image: quay.io/opendatahub/opendatahub-operator:latest # TODO: need update to final release image
   # Image pull policy
   imagePullPolicy: Always
   # Related images env vars (RELATED_IMAGE_*)

--- a/charts/rhaii-helm-chart/values.yaml
+++ b/charts/rhaii-helm-chart/values.yaml
@@ -13,7 +13,7 @@ rhaiOperator:
   namespace: redhat-ods-operator
   applicationsNamespace: redhat-ods-applications
   # Manager container image
-  image: quay.io/opendatahub/opendatahub-operator:latest # image is updated during Helm chart build by konflux
+  image: quay.io/opendatahub/opendatahub-operator:latest # TODO: need update to final release image
   # Image pull policy
   imagePullPolicy: Always
   # Related images env vars (RELATED_IMAGE_*)

--- a/charts/rhaii-helm-chart/values.yaml
+++ b/charts/rhaii-helm-chart/values.yaml
@@ -13,7 +13,7 @@ rhaiOperator:
   namespace: redhat-ods-operator
   applicationsNamespace: redhat-ods-applications
   # Manager container image
-  image: quay.io/opendatahub/opendatahub-operator:latest # TODO: need update to final release image
+  image: quay.io/opendatahub/opendatahub-operator:latest # image is updated during Helm chart build by konflux
   # Image pull policy
   imagePullPolicy: Always
   # Related images env vars (RELATED_IMAGE_*)

--- a/scripts/uninstall-helm-chart.sh
+++ b/scripts/uninstall-helm-chart.sh
@@ -18,7 +18,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 HELM_RELEASE="${HELM_RELEASE:-odh}"
-HELM_NAMESPACE="${HELM_NAMESPACE:-opendatahub-gitops}"
+HELM_NAMESPACE="${HELM_NAMESPACE:-rhaii-gitops}"
 
 
 # Operator CRDs (created by ODH/RHOAI operator)

--- a/scripts/verify-helm-chart.sh
+++ b/scripts/verify-helm-chart.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-NAMESPACE="${NAMESPACE:-opendatahub-gitops}"
+NAMESPACE="${NAMESPACE:-rhaii-gitops}"
 TIMEOUT="${TIMEOUT:-600}"  # 10 minutes default
 INTERVAL="${INTERVAL:-10}"
 OPERATOR_TYPE="${OPERATOR_TYPE:-odh}"  # odh or rhoai


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- prep for this since we do not use OLM and less dependent on old name (rhods-operator, rhoai-XXXx) and will be easier for later rebrand to rhai
- update README with missing parts
- add missing wva and spark in values
- `OPERATOR_NAME` env is not used in operator
~~- rename `rhaii-helm-chart` to `rhai-on-xks-helm-chart`~~

Jira task: <!--- Link your JIRA and related links here for reference. -->
slack https://redhat-external.slack.com/archives/C09MRCKHHQS/p1774449076628159

## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->
run >./update-bundle.sh 3.4.0-ea.2

- [ ] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Spark Operator component support to the inference stack.
  * Enhanced pull secret configuration with explicit namespace injection for chart-managed ServiceAccounts.

* **Documentation**
  * Updated chart branding to "Red Hat AI Inference" with comprehensive pull secret configuration guidance.
  * Added CoreWeave deployment examples alongside Azure; expanded uninstall instructions with manual cleanup steps.
  * Updated OpenShift prerequisite to 4.19.9 or later.

* **Configuration Changes**
  * Updated default namespace from `opendatahub-gitops` to `rhaii-gitops`.
  * Standardized operator naming and service references across all deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->