### PR TITLE
fix: for rhaii we only use llmisvc-controller not the kserve-controller

### DIFF
--- a/charts/rhaii-helm-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhaii-helm-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2515,8 +2515,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: DEFAULT_MANIFESTS_PATH
               value: /opt/manifests
-            - name: "RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE"
-              value: "quay.io/opendatahub/kserve-controller:latest"
+            - name: "RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE"
+              value: "ghcr.io/opendatahub-io/kserve/odh-kserve-llmisvc-controller:release-v0.17"
           image: quay.io/opendatahub/opendatahub-operator:latest
           imagePullPolicy: Always
           livenessProbe:

--- a/scripts/snapshot-config.yaml
+++ b/scripts/snapshot-config.yaml
@@ -72,8 +72,8 @@ charts:
       - name: azure-with-related-images
         setFlags:
           - azure.enabled=true
-          - rhaiOperator.relatedImages[0].name=RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE
-          - rhaiOperator.relatedImages[0].value=quay.io/opendatahub/kserve-controller:latest
+          - rhaiOperator.relatedImages[0].name=RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE
+          - rhaiOperator.relatedImages[0].value=ghcr.io/opendatahub-io/kserve/odh-kserve-llmisvc-controller:release-v0.17
 
       - name: with-custom-namespace
         setFlags:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
this is only for the snapshot reflect what rhaii need, 
for the final chart we release, it does not matter with or without this fix, it is done in https://github.com/red-hat-data-services/RHOAI-Build-Config/blob/rhoai-3.4/helm/values-patch.yaml by some sort of devops automation thingy


cc @davidebianchi 

Jira task: <!--- Link your JIRA and related links here for reference. -->

## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->

- [ ] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart configuration and test snapshots to utilize the specialized LLMisvc kserve controller component with the latest stable release. This change improves image reference management and ensures consistent deployment configurations across related environments while maintaining full compatibility with current platform requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->