### PR TITLE
fix: rename secret name in manager volumes to match the rhai name

### DIFF
--- a/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
+++ b/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
@@ -80,7 +80,7 @@ rules:
     changes:
       # Replace RHAI_APPLICATIONS_NAMESPACE with templated value
       - path: .spec.template.spec.containers[name=rhods-operator].env[name=RHAI_APPLICATIONS_NAMESPACE].value
-        value: '{{ .Values.rhaiOperator.applicationsNamespace }}'
+        value: '{{ .Values.rhaiOperator.applicationsNamespace | quote }}'
       # Add related images env vars
       - path: .spec.template.spec.containers[name=rhods-operator].env
         appendWith: |
@@ -224,9 +224,8 @@ rules:
     changes:
       - path: .metadata.name
         value: rhai-operator-mutating-webhook-configuration
-        # TODO: Uncomment this when the webhook cert secret is renamed
-      # - path: .metadata.annotations["cert-manager.io/inject-ca-from"]
-      #   value: '{{ .Values.rhaiOperator.namespace }}/rhai-operator-controller-webhook-cert'
+      - path: .metadata.annotations["cert-manager.io/inject-ca-from"]
+        value: '{{ .Values.rhaiOperator.namespace }}/opendatahub-operator-webhook-cert'
       - path: .webhooks[*].clientConfig.service.name
         value: rhai-operator-webhook-service
       - path: .metadata.labels["app.kubernetes.io/created-by"]

--- a/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
+++ b/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
@@ -224,8 +224,9 @@ rules:
     changes:
       - path: .metadata.name
         value: rhai-operator-mutating-webhook-configuration
-      - path: .metadata.annotations["cert-manager.io/inject-ca-from"]
-        value: '{{ .Values.rhaiOperator.namespace }}/rhai-operator-webhook-cert'
+        # TODO: Uncomment this when the webhook cert secret is renamed
+      # - path: .metadata.annotations["cert-manager.io/inject-ca-from"]
+      #   value: '{{ .Values.rhaiOperator.namespace }}/rhai-operator-controller-webhook-cert'
       - path: .webhooks[*].clientConfig.service.name
         value: rhai-operator-webhook-service
       - path: .metadata.labels["app.kubernetes.io/created-by"]

--- a/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
+++ b/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
@@ -116,6 +116,9 @@ rules:
       # Update serviceAccountName reference
       - path: .spec.template.spec.serviceAccountName
         value: rhai-operator-controller-manager
+      # Rename webhook cert secret in volume (rhods-operator to rhai-operator)
+      - path: .spec.template.spec.volumes[name=cert].secret.secretName
+        value: rhai-operator-controller-webhook-cert
 
   # Rename ServiceAccount
   - match:

--- a/charts/rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
+++ b/charts/rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
@@ -156,5 +156,5 @@ spec:
         - name: cert
           secret:
             defaultMode: 420
-            secretName: redhat-ods-operator-controller-webhook-cert
+            secretName: rhai-operator-controller-webhook-cert
 {{- end }}

--- a/charts/rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhods-operator-mutating-webhook-configuration.yaml
+++ b/charts/rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhods-operator-mutating-webhook-configuration.yaml
@@ -3,7 +3,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Values.rhaiOperator.namespace }}/rhai-operator-webhook-cert
+    cert-manager.io/inject-ca-from: {{ .Values.rhaiOperator.namespace }}/opendatahub-operator-webhook-cert
   name: rhai-operator-mutating-webhook-configuration
   namespace: {{ .Values.rhaiOperator.namespace }}
   labels:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -2708,7 +2708,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: redhat-ods-operator/rhai-operator-webhook-cert
+    cert-manager.io/inject-ca-from: redhat-ods-operator/opendatahub-operator-webhook-cert
   name: rhai-operator-mutating-webhook-configuration
   namespace: redhat-ods-operator
   labels:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -2701,7 +2701,7 @@ spec:
         - name: cert
           secret:
             defaultMode: 420
-            secretName: redhat-ods-operator-controller-webhook-cert
+            secretName: rhai-operator-controller-webhook-cert
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhods-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2565,7 +2565,7 @@ spec:
         - name: cert
           secret:
             defaultMode: 420
-            secretName: redhat-ods-operator-controller-webhook-cert
+            secretName: rhai-operator-controller-webhook-cert
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhods-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2572,7 +2572,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: redhat-ods-operator/rhai-operator-webhook-cert
+    cert-manager.io/inject-ca-from: redhat-ods-operator/opendatahub-operator-webhook-cert
   name: rhai-operator-mutating-webhook-configuration
   namespace: redhat-ods-operator
   labels:

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -2708,7 +2708,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: redhat-ods-operator/rhai-operator-webhook-cert
+    cert-manager.io/inject-ca-from: redhat-ods-operator/opendatahub-operator-webhook-cert
   name: rhai-operator-mutating-webhook-configuration
   namespace: redhat-ods-operator
   labels:

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -2701,7 +2701,7 @@ spec:
         - name: cert
           secret:
             defaultMode: 420
-            secretName: redhat-ods-operator-controller-webhook-cert
+            secretName: rhai-operator-controller-webhook-cert
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhods-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -2563,7 +2563,7 @@ spec:
         - name: cert
           secret:
             defaultMode: 420
-            secretName: redhat-ods-operator-controller-webhook-cert
+            secretName: rhai-operator-controller-webhook-cert
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhods-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -2570,7 +2570,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: redhat-ods-operator/rhai-operator-webhook-cert
+    cert-manager.io/inject-ca-from: redhat-ods-operator/opendatahub-operator-webhook-cert
   name: rhai-operator-mutating-webhook-configuration
   namespace: redhat-ods-operator
   labels:

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -2570,7 +2570,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: rhai-operator/rhai-operator-webhook-cert
+    cert-manager.io/inject-ca-from: rhai-operator/opendatahub-operator-webhook-cert
   name: rhai-operator-mutating-webhook-configuration
   namespace: rhai-operator
   labels:

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -2563,7 +2563,7 @@ spec:
         - name: cert
           secret:
             defaultMode: 420
-            secretName: redhat-ods-operator-controller-webhook-cert
+            secretName: rhai-operator-controller-webhook-cert
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhods-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
This fix complete the secret rename value, as it is also read from the manager volume.

Also, fixed the certificate name as it is now defined in cloud manager

## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->

- [ ] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated webhook TLS secret references so operator deployments mount the correct certificate secret for webhook servers.
  * Adjusted mutating webhook annotation used by cert-manager to reference the opendatahub operator webhook certificate, aligning TLS CA injection across manifests.
  * Regenerated chart snapshots and test outputs to reflect the updated webhook certificate and annotation values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->