### PR TITLE
fix(rhai-on-openshift-chart): update jobset operator channel

### DIFF
--- a/charts/rhai-on-openshift-chart/api-docs.md
+++ b/charts/rhai-on-openshift-chart/api-docs.md
@@ -61,6 +61,10 @@ A Helm chart for installing ODH/RHOAI dependencies and component configurations
 | components.ray.dependencies | object | `{"certManager":true}` | Dependencies required by Ray |
 | components.ray.dsc | object | `{"managementState":"Removed"}` | DSC configuration for Ray |
 | components.ray.dsc.managementState | string | `"Removed"` | Management state for Ray (Managed or Removed) |
+| components.sparkoperator | object | `{"dependencies":{},"dsc":{"managementState":"Removed"}}` | Spark Operator component |
+| components.sparkoperator.dependencies | object | `{}` | Dependencies required by Spark Operator |
+| components.sparkoperator.dsc | object | `{"managementState":"Removed"}` | DSC configuration for Spark Operator |
+| components.sparkoperator.dsc.managementState | string | `"Removed"` | Management state for Spark Operator (Managed or Removed) |
 | components.trainer | object | `{"dependencies":{"certManager":true,"jobSet":true},"dsc":{"managementState":"Removed"}}` | Trainer component |
 | components.trainer.dependencies | object | `{"certManager":true,"jobSet":true}` | Dependencies required by Trainer |
 | components.trainer.dsc | object | `{"managementState":"Removed"}` | DSC configuration for Trainer |
@@ -89,7 +93,7 @@ A Helm chart for installing ODH/RHOAI dependencies and component configurations
 | dependencies.customMetricsAutoscaler | object | `{"dependencies":{},"enabled":"auto","olm":{"channel":"stable","name":"openshift-custom-metrics-autoscaler-operator","namespace":"openshift-keda"}}` | Custom Metrics Autoscaler (KEDA) operator |
 | dependencies.customMetricsAutoscaler.dependencies | object | `{}` | Dependencies required by custom-metrics-autoscaler |
 | dependencies.customMetricsAutoscaler.enabled | string | `"auto"` | Enable custom-metrics-autoscaler: auto (if needed), true (always), false (never) |
-| dependencies.jobSet | object | `{"config":{"spec":{"logLevel":"Normal","operatorLogLevel":"Normal"}},"dependencies":{"certManager":true},"enabled":"auto","olm":{"channel":"tech-preview-v0.1","name":"job-set","namespace":"openshift-jobset-operator","targetNamespaces":["openshift-jobset-operator"]}}` | Job Set operator |
+| dependencies.jobSet | object | `{"config":{"spec":{"logLevel":"Normal","operatorLogLevel":"Normal"}},"dependencies":{"certManager":true},"enabled":"auto","olm":{"channel":"stable-v1.0","name":"job-set","namespace":"openshift-jobset-operator","targetNamespaces":["openshift-jobset-operator"]}}` | Job Set operator |
 | dependencies.jobSet.config.spec | object | `{"logLevel":"Normal","operatorLogLevel":"Normal"}` | JobSetOperator CR spec (user can add any fields supported by the CR) |
 | dependencies.jobSet.dependencies | object | `{"certManager":true}` | Dependencies required by job-set |
 | dependencies.jobSet.enabled | string | `"auto"` | Enable job-set: auto (if needed), true (always), false (never) |

--- a/charts/rhai-on-openshift-chart/test/snapshots/all-components-managed.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/all-components-managed.snap.yaml
@@ -469,7 +469,7 @@ metadata:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
 spec:
-  channel: tech-preview-v0.1
+  channel: stable-v1.0
   installPlanApproval: Automatic
   name: job-set
   source: redhat-operators

--- a/charts/rhai-on-openshift-chart/test/snapshots/enable-llm-d-wva.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/enable-llm-d-wva.snap.yaml
@@ -306,7 +306,7 @@ metadata:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
 spec:
-  channel: tech-preview-v0.1
+  channel: stable-v1.0
   installPlanApproval: Automatic
   name: job-set
   source: redhat-operators

--- a/charts/rhai-on-openshift-chart/values.yaml
+++ b/charts/rhai-on-openshift-chart/values.yaml
@@ -342,6 +342,15 @@ components:
       # -- Management state for LlamaStack Operator (Managed or Removed)
       managementState: Removed
 
+  # -- Spark Operator component
+  sparkoperator:
+    # -- Dependencies required by Spark Operator
+    dependencies: {}
+    # -- DSC configuration for Spark Operator
+    dsc:
+      # -- Management state for Spark Operator (Managed or Removed)
+      managementState: Removed
+
 # =============================================================================
 # DEPENDENCIES - Operators required by components
 #
@@ -393,7 +402,7 @@ dependencies:
     dependencies:
       certManager: true
     olm:
-      channel: tech-preview-v0.1
+      channel: stable-v1.0
       name: job-set
       namespace: openshift-jobset-operator
       targetNamespaces:

--- a/components/operators/job-set-operator/subscription.yaml
+++ b/components/operators/job-set-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: job-set
   namespace: openshift-jobset-operator
 spec:
-  channel: tech-preview-v0.1 # To be updated once JobSet is GA
+  channel: stable-v1.0
   installPlanApproval: Automatic
   name: job-set
   source: redhat-operators

--- a/docs/examples/values-all-components-managed.yaml
+++ b/docs/examples/values-all-components-managed.yaml
@@ -80,6 +80,10 @@ components:
     dsc:
       managementState: Managed
 
+  sparkoperator:
+    dsc:
+      managementState: Managed
+
   llamastackoperator:
     dsc:
       managementState: Managed


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Update jobset operator channel to use the stable one

## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->

- [x] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * jobSet operator channel changed from tech-preview to stable.

* **New Features**
  * Spark operator added to chart values with configurable managementState (examples show Managed; chart default Removed).

* **Documentation**
  * Chart docs updated to describe Spark operator values and the jobSet channel change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->