### PR TITLE
feat: add creation of Gateway CR after post-hook

### DIFF
--- a/charts/rhai-on-xks-chart/README.md
+++ b/charts/rhai-on-xks-chart/README.md
@@ -79,12 +79,33 @@ helm upgrade rhaii ./charts/rhai-on-xks-chart/ \
 
 ## How It Works
 
-The chart performs a **two-phase installation**:
+The chart performs a **multi-phase installation**:
 
 1. **Phase 1 — Helm install:** deploys all operator resources (Deployments, RBAC, CRDs, etc.)
-2. **Phase 2 — Post-install hook:** a Helm hook Job runs after install/upgrade to create the Custom Resources that configure the operators
+2. **Phase 2 — Post-install hook (weight 1):** a Helm hook Job creates the Custom Resources (Kserve CR, KubernetesEngine CR) that configure the operators
+3. **Phase 3 — Post-install hook (weight 2):** a Helm hook Job waits for dependencies (Gateway API CRDs, cert-manager CA secret, GatewayClass `istio`) and then creates the `inference-gateway` Gateway CR along with its supporting ConfigMaps
 
-This two-phase approach is necessary because the CRs depend on CRDs that are only available after the operators are deployed.
+Phase 2 and 3 are necessary because the CRs depend on CRDs and resources that are only available after the operators are deployed and reconciled.
+
+### Inference Gateway
+
+By default (`components.kserve.gateway.create: true`), the chart creates a Gateway CR named `inference-gateway` in the applications namespace. This gateway is required for KServe model inference traffic. The hook:
+
+1. Waits for Gateway API CRDs to be installed (by the cloud manager)
+2. Waits for the cert-manager CA secret (`opendatahub-ca`)
+3. Creates a CA bundle ConfigMap (`rhaii-ca-bundle`)
+4. Creates a gateway config ConfigMap (`inference-gateway-config`) with CA bundle mount for istio-proxy and Azure-specific health probe annotation (Azure only)
+5. Waits for the `istio` GatewayClass (created by Sail Operator)
+6. Creates the `inference-gateway` Gateway CR
+
+To disable automatic gateway creation:
+
+```yaml
+components:
+  kserve:
+    gateway:
+      create: false
+```
 
 ## Managed Dependencies
 

--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -22,6 +22,7 @@ Red Hat OpenShift AI Operator Helm chart (non-OLM installation)
 | azure.kubernetesEngine.spec.dependencies.sailOperator.configuration | object | `{}` |  |
 | azure.kubernetesEngine.spec.dependencies.sailOperator.managementPolicy | string | `"Managed"` |  |
 | components.kserve.enabled | bool | `true` |  |
+| components.kserve.gateway.create | bool | `true` |  |
 | components.kserve.spec | object | `{}` |  |
 | coreweave.cloudManager.image | string | `"quay.io/opendatahub/opendatahub-operator:latest"` |  |
 | coreweave.cloudManager.imagePullPolicy | string | `"Always"` |  |

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -2,7 +2,8 @@
 {{- $createKserve := .Values.components.kserve.enabled }}
 {{- $createAzureKE := and .Values.azure.enabled .Values.azure.kubernetesEngine.enabled }}
 {{- $createCoreweaveKE := and .Values.coreweave.enabled .Values.coreweave.kubernetesEngine.enabled }}
-{{- if or $createKserve $createAzureKE $createCoreweaveKE }}
+{{- $createGateway := and .Values.components.kserve.enabled .Values.components.kserve.gateway.create }}
+{{- if or $createKserve $createAzureKE $createCoreweaveKE $createGateway }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -45,6 +46,44 @@ rules:
       - create
       - patch
       - update
+  {{- if $createGateway }}
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+    verbs:
+      - get
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
@@ -1,0 +1,165 @@
+{{- if .Values.enabled }}
+{{- if and .Values.components.kserve.enabled .Values.components.kserve.gateway.create }}
+{{- $appNs := .Values.rhaiOperator.applicationsNamespace }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhaii-post-create-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "rhai-on-xks-chart.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhaii-post-install-hook
+      {{- include "rhai-on-xks-chart.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: create-gateway
+          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              TIMEOUT=300
+              INTERVAL=5
+              ELAPSED=0
+
+              echo "Step 1: Waiting for Gateway API CRDs required by Gateway CR 'inference-gateway'..."
+              until kubectl get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for Gateway API CRDs after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "CRD not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "Gateway API CRDs are available."
+
+              echo "Step 2: Waiting for cert-manager CA secret required by Gateway CR 'inference-gateway'..."
+              ELAPSED=0
+              until kubectl get secret opendatahub-ca -n cert-manager >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for CA secret after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "CA secret not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "CA secret is available."
+
+              echo "Step 3: Creating CA bundle ConfigMap for Gateway CR 'inference-gateway'..."
+              kubectl get secret opendatahub-ca -n cert-manager \
+                -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
+              kubectl create configmap rhaii-ca-bundle \
+                --from-file=ca.crt=/tmp/ca.crt \
+                -n {{ $appNs }} \
+                --dry-run=client -o yaml | kubectl apply -f -
+              echo "CA bundle ConfigMap created."
+
+              echo "Step 4: Create ConfigMap used by Gateway CR 'inference-gateway'..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: inference-gateway-config
+                namespace: {{ $appNs }}
+              data:
+                deployment: |
+                  spec:
+                    template:
+                      spec:
+                        volumes:
+                        - name: rhaii-ca-bundle
+                          configMap:
+                            name: rhaii-ca-bundle
+                        containers:
+                        - name: istio-proxy
+                          volumeMounts:
+                          - name: rhaii-ca-bundle
+                            mountPath: /var/run/secrets/rhaii
+                            readOnly: true
+              {{- if .Values.azure.enabled }}
+                service: |
+                  metadata:
+                    annotations:
+                      service.beta.kubernetes.io/port_80_health-probe_protocol: tcp
+              {{- end }}
+              EOF
+              echo "ConfigMap used by Gateway CR 'inference-gateway' created."
+
+              echo "Step 5: Waiting for GatewayClass 'istio' required by Gateway CR 'inference-gateway'..."
+              ELAPSED=0
+              until kubectl get gatewayclass istio >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for GatewayClass 'istio' after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "GatewayClass 'istio' not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "GatewayClass 'istio' is available."
+
+              echo "Step 6: Creating Gateway CR 'inference-gateway'..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: inference-gateway
+                namespace: {{ $appNs }}
+              spec:
+                gatewayClassName: istio
+                listeners:
+                  - name: http
+                    port: 80
+                    protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: All
+                infrastructure:
+                  labels:
+                    serving.kserve.io/gateway: kserve-ingress-gateway
+                  parametersRef:
+                    group: ""
+                    kind: ConfigMap
+                    name: inference-gateway-config
+              EOF
+              echo "Gateway CR 'inference-gateway' created successfully."
+{{- end }}
+{{- end }}

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -2805,6 +2805,42 @@ rules:
       - create
       - patch
       - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+    verbs:
+      - get
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - patch
+      - update
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2914,3 +2950,166 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
+---
+# Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhaii-post-create-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhaii-post-install-hook
+      imagePullSecrets:
+        - name: rhaii-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: create-gateway
+          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              TIMEOUT=300
+              INTERVAL=5
+              ELAPSED=0
+
+              echo "Step 1: Waiting for Gateway API CRDs required by Gateway CR 'inference-gateway'..."
+              until kubectl get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for Gateway API CRDs after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "CRD not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "Gateway API CRDs are available."
+
+              echo "Step 2: Waiting for cert-manager CA secret required by Gateway CR 'inference-gateway'..."
+              ELAPSED=0
+              until kubectl get secret opendatahub-ca -n cert-manager >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for CA secret after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "CA secret not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "CA secret is available."
+
+              echo "Step 3: Creating CA bundle ConfigMap for Gateway CR 'inference-gateway'..."
+              kubectl get secret opendatahub-ca -n cert-manager \
+                -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
+              kubectl create configmap rhaii-ca-bundle \
+                --from-file=ca.crt=/tmp/ca.crt \
+                -n redhat-ods-applications \
+                --dry-run=client -o yaml | kubectl apply -f -
+              echo "CA bundle ConfigMap created."
+
+              echo "Step 4: Create ConfigMap used by Gateway CR 'inference-gateway'..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: inference-gateway-config
+                namespace: redhat-ods-applications
+              data:
+                deployment: |
+                  spec:
+                    template:
+                      spec:
+                        volumes:
+                        - name: rhaii-ca-bundle
+                          configMap:
+                            name: rhaii-ca-bundle
+                        containers:
+                        - name: istio-proxy
+                          volumeMounts:
+                          - name: rhaii-ca-bundle
+                            mountPath: /var/run/secrets/rhaii
+                            readOnly: true
+                service: |
+                  metadata:
+                    annotations:
+                      service.beta.kubernetes.io/port_80_health-probe_protocol: tcp
+              EOF
+              echo "ConfigMap used by Gateway CR 'inference-gateway' created."
+
+              echo "Step 5: Waiting for GatewayClass 'istio' required by Gateway CR 'inference-gateway'..."
+              ELAPSED=0
+              until kubectl get gatewayclass istio >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for GatewayClass 'istio' after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "GatewayClass 'istio' not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "GatewayClass 'istio' is available."
+
+              echo "Step 6: Creating Gateway CR 'inference-gateway'..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: inference-gateway
+                namespace: redhat-ods-applications
+              spec:
+                gatewayClassName: istio
+                listeners:
+                  - name: http
+                    port: 80
+                    protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: All
+                infrastructure:
+                  labels:
+                    serving.kserve.io/gateway: kserve-ingress-gateway
+                  parametersRef:
+                    group: ""
+                    kind: ConfigMap
+                    name: inference-gateway-config
+              EOF
+              echo "Gateway CR 'inference-gateway' created successfully."

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2669,6 +2669,42 @@ rules:
       - create
       - patch
       - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+    verbs:
+      - get
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - patch
+      - update
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2778,3 +2814,166 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
+---
+# Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhaii-post-create-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhaii-post-install-hook
+      imagePullSecrets:
+        - name: rhaii-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: create-gateway
+          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              TIMEOUT=300
+              INTERVAL=5
+              ELAPSED=0
+
+              echo "Step 1: Waiting for Gateway API CRDs required by Gateway CR 'inference-gateway'..."
+              until kubectl get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for Gateway API CRDs after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "CRD not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "Gateway API CRDs are available."
+
+              echo "Step 2: Waiting for cert-manager CA secret required by Gateway CR 'inference-gateway'..."
+              ELAPSED=0
+              until kubectl get secret opendatahub-ca -n cert-manager >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for CA secret after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "CA secret not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "CA secret is available."
+
+              echo "Step 3: Creating CA bundle ConfigMap for Gateway CR 'inference-gateway'..."
+              kubectl get secret opendatahub-ca -n cert-manager \
+                -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
+              kubectl create configmap rhaii-ca-bundle \
+                --from-file=ca.crt=/tmp/ca.crt \
+                -n redhat-ods-applications \
+                --dry-run=client -o yaml | kubectl apply -f -
+              echo "CA bundle ConfigMap created."
+
+              echo "Step 4: Create ConfigMap used by Gateway CR 'inference-gateway'..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: inference-gateway-config
+                namespace: redhat-ods-applications
+              data:
+                deployment: |
+                  spec:
+                    template:
+                      spec:
+                        volumes:
+                        - name: rhaii-ca-bundle
+                          configMap:
+                            name: rhaii-ca-bundle
+                        containers:
+                        - name: istio-proxy
+                          volumeMounts:
+                          - name: rhaii-ca-bundle
+                            mountPath: /var/run/secrets/rhaii
+                            readOnly: true
+                service: |
+                  metadata:
+                    annotations:
+                      service.beta.kubernetes.io/port_80_health-probe_protocol: tcp
+              EOF
+              echo "ConfigMap used by Gateway CR 'inference-gateway' created."
+
+              echo "Step 5: Waiting for GatewayClass 'istio' required by Gateway CR 'inference-gateway'..."
+              ELAPSED=0
+              until kubectl get gatewayclass istio >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for GatewayClass 'istio' after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "GatewayClass 'istio' not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "GatewayClass 'istio' is available."
+
+              echo "Step 6: Creating Gateway CR 'inference-gateway'..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: inference-gateway
+                namespace: redhat-ods-applications
+              spec:
+                gatewayClassName: istio
+                listeners:
+                  - name: http
+                    port: 80
+                    protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: All
+                infrastructure:
+                  labels:
+                    serving.kserve.io/gateway: kserve-ingress-gateway
+                  parametersRef:
+                    group: ""
+                    kind: ConfigMap
+                    name: inference-gateway-config
+              EOF
+              echo "Gateway CR 'inference-gateway' created successfully."

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -2805,6 +2805,42 @@ rules:
       - create
       - patch
       - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+    verbs:
+      - get
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - patch
+      - update
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2914,3 +2950,162 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
+---
+# Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhaii-post-create-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhaii-post-install-hook
+      imagePullSecrets:
+        - name: rhaii-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: create-gateway
+          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              TIMEOUT=300
+              INTERVAL=5
+              ELAPSED=0
+
+              echo "Step 1: Waiting for Gateway API CRDs required by Gateway CR 'inference-gateway'..."
+              until kubectl get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for Gateway API CRDs after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "CRD not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "Gateway API CRDs are available."
+
+              echo "Step 2: Waiting for cert-manager CA secret required by Gateway CR 'inference-gateway'..."
+              ELAPSED=0
+              until kubectl get secret opendatahub-ca -n cert-manager >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for CA secret after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "CA secret not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "CA secret is available."
+
+              echo "Step 3: Creating CA bundle ConfigMap for Gateway CR 'inference-gateway'..."
+              kubectl get secret opendatahub-ca -n cert-manager \
+                -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
+              kubectl create configmap rhaii-ca-bundle \
+                --from-file=ca.crt=/tmp/ca.crt \
+                -n redhat-ods-applications \
+                --dry-run=client -o yaml | kubectl apply -f -
+              echo "CA bundle ConfigMap created."
+
+              echo "Step 4: Create ConfigMap used by Gateway CR 'inference-gateway'..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: inference-gateway-config
+                namespace: redhat-ods-applications
+              data:
+                deployment: |
+                  spec:
+                    template:
+                      spec:
+                        volumes:
+                        - name: rhaii-ca-bundle
+                          configMap:
+                            name: rhaii-ca-bundle
+                        containers:
+                        - name: istio-proxy
+                          volumeMounts:
+                          - name: rhaii-ca-bundle
+                            mountPath: /var/run/secrets/rhaii
+                            readOnly: true
+              EOF
+              echo "ConfigMap used by Gateway CR 'inference-gateway' created."
+
+              echo "Step 5: Waiting for GatewayClass 'istio' required by Gateway CR 'inference-gateway'..."
+              ELAPSED=0
+              until kubectl get gatewayclass istio >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for GatewayClass 'istio' after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "GatewayClass 'istio' not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "GatewayClass 'istio' is available."
+
+              echo "Step 6: Creating Gateway CR 'inference-gateway'..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: inference-gateway
+                namespace: redhat-ods-applications
+              spec:
+                gatewayClassName: istio
+                listeners:
+                  - name: http
+                    port: 80
+                    protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: All
+                infrastructure:
+                  labels:
+                    serving.kserve.io/gateway: kserve-ingress-gateway
+                  parametersRef:
+                    group: ""
+                    kind: ConfigMap
+                    name: inference-gateway-config
+              EOF
+              echo "Gateway CR 'inference-gateway' created successfully."

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -2667,6 +2667,42 @@ rules:
       - create
       - patch
       - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+    verbs:
+      - get
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - patch
+      - update
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2776,3 +2812,162 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
+---
+# Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhaii-post-create-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhaii-post-install-hook
+      imagePullSecrets:
+        - name: rhaii-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: create-gateway
+          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              TIMEOUT=300
+              INTERVAL=5
+              ELAPSED=0
+
+              echo "Step 1: Waiting for Gateway API CRDs required by Gateway CR 'inference-gateway'..."
+              until kubectl get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for Gateway API CRDs after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "CRD not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "Gateway API CRDs are available."
+
+              echo "Step 2: Waiting for cert-manager CA secret required by Gateway CR 'inference-gateway'..."
+              ELAPSED=0
+              until kubectl get secret opendatahub-ca -n cert-manager >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for CA secret after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "CA secret not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "CA secret is available."
+
+              echo "Step 3: Creating CA bundle ConfigMap for Gateway CR 'inference-gateway'..."
+              kubectl get secret opendatahub-ca -n cert-manager \
+                -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
+              kubectl create configmap rhaii-ca-bundle \
+                --from-file=ca.crt=/tmp/ca.crt \
+                -n redhat-ods-applications \
+                --dry-run=client -o yaml | kubectl apply -f -
+              echo "CA bundle ConfigMap created."
+
+              echo "Step 4: Create ConfigMap used by Gateway CR 'inference-gateway'..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: inference-gateway-config
+                namespace: redhat-ods-applications
+              data:
+                deployment: |
+                  spec:
+                    template:
+                      spec:
+                        volumes:
+                        - name: rhaii-ca-bundle
+                          configMap:
+                            name: rhaii-ca-bundle
+                        containers:
+                        - name: istio-proxy
+                          volumeMounts:
+                          - name: rhaii-ca-bundle
+                            mountPath: /var/run/secrets/rhaii
+                            readOnly: true
+              EOF
+              echo "ConfigMap used by Gateway CR 'inference-gateway' created."
+
+              echo "Step 5: Waiting for GatewayClass 'istio' required by Gateway CR 'inference-gateway'..."
+              ELAPSED=0
+              until kubectl get gatewayclass istio >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for GatewayClass 'istio' after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "GatewayClass 'istio' not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "GatewayClass 'istio' is available."
+
+              echo "Step 6: Creating Gateway CR 'inference-gateway'..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: inference-gateway
+                namespace: redhat-ods-applications
+              spec:
+                gatewayClassName: istio
+                listeners:
+                  - name: http
+                    port: 80
+                    protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: All
+                infrastructure:
+                  labels:
+                    serving.kserve.io/gateway: kserve-ingress-gateway
+                  parametersRef:
+                    group: ""
+                    kind: ConfigMap
+                    name: inference-gateway-config
+              EOF
+              echo "Gateway CR 'inference-gateway' created successfully."

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -2667,6 +2667,42 @@ rules:
       - create
       - patch
       - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+    verbs:
+      - get
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - patch
+      - update
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2776,3 +2812,166 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
+---
+# Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhaii-post-create-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhaii-post-install-hook
+      imagePullSecrets:
+        - name: rhaii-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: create-gateway
+          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              TIMEOUT=300
+              INTERVAL=5
+              ELAPSED=0
+
+              echo "Step 1: Waiting for Gateway API CRDs required by Gateway CR 'inference-gateway'..."
+              until kubectl get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for Gateway API CRDs after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "CRD not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "Gateway API CRDs are available."
+
+              echo "Step 2: Waiting for cert-manager CA secret required by Gateway CR 'inference-gateway'..."
+              ELAPSED=0
+              until kubectl get secret opendatahub-ca -n cert-manager >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for CA secret after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "CA secret not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "CA secret is available."
+
+              echo "Step 3: Creating CA bundle ConfigMap for Gateway CR 'inference-gateway'..."
+              kubectl get secret opendatahub-ca -n cert-manager \
+                -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
+              kubectl create configmap rhaii-ca-bundle \
+                --from-file=ca.crt=/tmp/ca.crt \
+                -n rhai-applications \
+                --dry-run=client -o yaml | kubectl apply -f -
+              echo "CA bundle ConfigMap created."
+
+              echo "Step 4: Create ConfigMap used by Gateway CR 'inference-gateway'..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: inference-gateway-config
+                namespace: rhai-applications
+              data:
+                deployment: |
+                  spec:
+                    template:
+                      spec:
+                        volumes:
+                        - name: rhaii-ca-bundle
+                          configMap:
+                            name: rhaii-ca-bundle
+                        containers:
+                        - name: istio-proxy
+                          volumeMounts:
+                          - name: rhaii-ca-bundle
+                            mountPath: /var/run/secrets/rhaii
+                            readOnly: true
+                service: |
+                  metadata:
+                    annotations:
+                      service.beta.kubernetes.io/port_80_health-probe_protocol: tcp
+              EOF
+              echo "ConfigMap used by Gateway CR 'inference-gateway' created."
+
+              echo "Step 5: Waiting for GatewayClass 'istio' required by Gateway CR 'inference-gateway'..."
+              ELAPSED=0
+              until kubectl get gatewayclass istio >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for GatewayClass 'istio' after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "GatewayClass 'istio' not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "GatewayClass 'istio' is available."
+
+              echo "Step 6: Creating Gateway CR 'inference-gateway'..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: inference-gateway
+                namespace: rhai-applications
+              spec:
+                gatewayClassName: istio
+                listeners:
+                  - name: http
+                    port: 80
+                    protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: All
+                infrastructure:
+                  labels:
+                    serving.kserve.io/gateway: kserve-ingress-gateway
+                  parametersRef:
+                    group: ""
+                    kind: ConfigMap
+                    name: inference-gateway-config
+              EOF
+              echo "Gateway CR 'inference-gateway' created successfully."

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -29,6 +29,10 @@ components:
     # Create Kserve CR via post-install hook
     enabled: true
     spec: {}
+    # Gateway configuration for KServe inference
+    gateway:
+      # Create Gateway and ConfigMaps via post-install hook
+      create: true
 
 # Azure cloud configuration
 azure:


### PR DESCRIPTION

Not for 3.4ea2, we can follow document for that release
this PR mainly borrow the stesp from rhaii-on-xks readme

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
- use the hardcoded GW CR name
- use a flag in values.yaml , default to true
- check on GWC CR, GW CRD, before create it

Jira task: <!--- Link your JIRA and related links here for reference. -->


## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->

- [ ] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic inference gateway creation during install, with a toggle (components.kserve.gateway.create).
  * Installer now runs an ordered post-install step that waits for prerequisites (Gateway API CRDs, cert-manager CA, GatewayClass) before creating the gateway and related configs.

* **Documentation**
  * Installation flow updated from two-phase to three-phase and a new "Inference Gateway" section added describing behavior and the gateway toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->