### PR TITLE
fix: use digest for hook image

### DIFF
--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -37,6 +37,8 @@ Red Hat OpenShift AI Operator Helm chart (non-OLM installation)
 | coreweave.kubernetesEngine.spec.dependencies.sailOperator.configuration | object | `{}` |  |
 | coreweave.kubernetesEngine.spec.dependencies.sailOperator.managementPolicy | string | `"Managed"` |  |
 | enabled | bool | `true` |  |
+| hooks.postInstallCrs.enabled | bool | `true` |  |
+| hooks.postInstallCrs.image | string | `"registry.redhat.io/openshift4/ose-cli-rhel9@sha256:dcb3f93d34aa0fdab33eb37949adfaa8fdd11ff3479363bb7735c5ba3eb345ce"` |  |
 | imagePullSecret.dependencyNamespaces[0] | string | `"cert-manager-operator"` |  |
 | imagePullSecret.dependencyNamespaces[1] | string | `"cert-manager"` |  |
 | imagePullSecret.dependencyNamespaces[2] | string | `"openshift-lws-operator"` |  |

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.enabled }}
+{{- if .Values.hooks.postInstallCrs.enabled }}
 {{- $createKserve := .Values.components.kserve.enabled }}
 {{- $createAzureKE := and .Values.azure.enabled .Values.azure.kubernetesEngine.enabled }}
 {{- $createCoreweaveKE := and .Values.coreweave.enabled .Values.coreweave.kubernetesEngine.enabled }}
@@ -30,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: create-crs
-          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          image: {{ required "hooks.postInstallCrs.image is required" .Values.hooks.postInstallCrs.image | quote }}
           resources:
             limits:
               cpu: 200m
@@ -102,5 +103,6 @@ spec:
               EOF
               {{- end }}
               echo "Done."
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.enabled }}
+{{- if .Values.hooks.postInstallCrs.enabled }}
 {{- $createKserve := .Values.components.kserve.enabled }}
 {{- $createAzureKE := and .Values.azure.enabled .Values.azure.kubernetesEngine.enabled }}
 {{- $createCoreweaveKE := and .Values.coreweave.enabled .Values.coreweave.kubernetesEngine.enabled }}
@@ -64,5 +65,6 @@ subjects:
   - kind: ServiceAccount
     name: rhaii-post-install-hook
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -2858,7 +2858,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: create-crs
-          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9@sha256:dcb3f93d34aa0fdab33eb37949adfaa8fdd11ff3479363bb7735c5ba3eb345ce"
           resources:
             limits:
               cpu: 200m

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2722,7 +2722,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: create-crs
-          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9@sha256:dcb3f93d34aa0fdab33eb37949adfaa8fdd11ff3479363bb7735c5ba3eb345ce"
           resources:
             limits:
               cpu: 200m

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -2858,7 +2858,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: create-crs
-          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9@sha256:dcb3f93d34aa0fdab33eb37949adfaa8fdd11ff3479363bb7735c5ba3eb345ce"
           resources:
             limits:
               cpu: 200m

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -2720,7 +2720,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: create-crs
-          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9@sha256:dcb3f93d34aa0fdab33eb37949adfaa8fdd11ff3479363bb7735c5ba3eb345ce"
           resources:
             limits:
               cpu: 200m

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -2720,7 +2720,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: create-crs
-          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9@sha256:dcb3f93d34aa0fdab33eb37949adfaa8fdd11ff3479363bb7735c5ba3eb345ce"
           resources:
             limits:
               cpu: 200m

--- a/charts/rhai-on-xks-chart/values.schema.json
+++ b/charts/rhai-on-xks-chart/values.schema.json
@@ -37,6 +37,29 @@
         "type": "string"
       }
     },
+    "hooks": {
+      "type": "object",
+      "description": "Helm hooks configuration",
+      "properties": {
+        "postInstallCrs": {
+          "type": "object",
+          "description": "Post-install hook for creating CRs",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable post-install CR creation hook",
+              "default": true
+            },
+            "image": {
+              "type": "string",
+              "description": "Container image used by the post-install hook job"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["image"]
+        }
+      }
+    },
     "components": {
       "type": "object",
       "description": "Components configuration",

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -23,6 +23,11 @@ rhaiOperator:
   #   - name: RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE
   #     value: quay.io/opendatahub/kserve-controller:latest
 
+hooks:
+  postInstallCrs:
+    enabled: true
+    image: registry.redhat.io/openshift4/ose-cli-rhel9@sha256:dcb3f93d34aa0fdab33eb37949adfaa8fdd11ff3479363bb7735c5ba3eb345ce
+
 # Components configuration
 components:
   kserve:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Post-install CR creation hook now has its own toggle (enabled by default); hook resources only render when both the chart and this toggle are enabled.
  * Hook image is now configurable via chart values.

* **Chores**
  * Default hook image pinned to an immutable digest for reproducible deployments.
  * Added values schema and documentation entries to validate and document the hook configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->