### PR TITLE
fix(RHOAIENG-57045): add RHAI_VERSION env var to rhai operator

### DIFF
--- a/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
+++ b/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
@@ -81,6 +81,8 @@ rules:
       # Replace RHAI_APPLICATIONS_NAMESPACE with templated value
       - path: .spec.template.spec.containers[name=rhods-operator].env[name=RHAI_APPLICATIONS_NAMESPACE].value
         value: '{{ .Values.rhaiOperator.applicationsNamespace | quote }}'
+      - path: .spec.template.spec.containers[name=rhods-operator].env[name=RHAI_VERSION].value
+        value: '{{ .Chart.AppVersion | quote }}'
       # Add related images env vars
       - path: .spec.template.spec.containers[name=rhods-operator].env
         appendWith: |

--- a/charts/rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
+++ b/charts/rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
@@ -94,6 +94,8 @@ spec:
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: {{ .Values.rhaiOperator.applicationsNamespace | quote }}
+            - name: RHAI_VERSION
+              value: {{ .Chart.AppVersion | quote }}
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME

--- a/charts/rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
+++ b/charts/rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
@@ -248,18 +248,6 @@ rules:
       - cert-manager.io
     resources:
       - certificates
-      - clusterissuers
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
       - issuers
     verbs:
       - create
@@ -634,8 +622,6 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines
-      - coreweavekubernetesengines
       - hardwareprofiles
     verbs:
       - create
@@ -648,16 +634,12 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/finalizers
-      - coreweavekubernetesengines/finalizers
       - hardwareprofiles/finalizers
     verbs:
       - update
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/status
-      - coreweavekubernetesengines/status
       - hardwareprofiles/status
     verbs:
       - get
@@ -1002,18 +984,12 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.openshift.io
+      - operator.authorino.kuadrant.io
     resources:
-      - certmanagers
-      - leaderworkersetoperators
+      - authorinos
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - operator.openshift.io
     resources:
@@ -1029,6 +1005,7 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
+      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -1141,113 +1118,11 @@ rules:
       - rbac.authorization.k8s.io
     resources:
       - clusterrolebindings
+      - clusterroles
       - rolebindings
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterroles
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - cert-manager-operator-controller-manager-clusterrole
-      - cert-manager-operator-metrics-reader
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - metrics-reader
-      - servicemesh-operator3-clusterrole
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - openshift-lws-operator-clusterrole
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
       - roles
     verbs:
       - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - cert-manager-operator-controller-manager-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - openshift-lws-operator-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - servicemesh-operator3-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - route.openshift.io
     resources:
@@ -1275,18 +1150,6 @@ rules:
       - create
       - patch
       - update
-  - apiGroups:
-      - sailoperator.io
-    resources:
-      - istios
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - security.openshift.io
     resources:
@@ -1421,6 +1284,18 @@ rules:
       - delete
       - get
       - patch
+  - apiGroups:
+      - telemetry.istio.io
+    resources:
+      - telemetries
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -1106,18 +1106,6 @@ rules:
       - cert-manager.io
     resources:
       - certificates
-      - clusterissuers
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
       - issuers
     verbs:
       - create
@@ -1492,8 +1480,6 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines
-      - coreweavekubernetesengines
       - hardwareprofiles
     verbs:
       - create
@@ -1506,16 +1492,12 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/finalizers
-      - coreweavekubernetesengines/finalizers
       - hardwareprofiles/finalizers
     verbs:
       - update
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/status
-      - coreweavekubernetesengines/status
       - hardwareprofiles/status
     verbs:
       - get
@@ -1860,18 +1842,12 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.openshift.io
+      - operator.authorino.kuadrant.io
     resources:
-      - certmanagers
-      - leaderworkersetoperators
+      - authorinos
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - operator.openshift.io
     resources:
@@ -1887,6 +1863,7 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
+      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -1999,113 +1976,11 @@ rules:
       - rbac.authorization.k8s.io
     resources:
       - clusterrolebindings
+      - clusterroles
       - rolebindings
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterroles
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - cert-manager-operator-controller-manager-clusterrole
-      - cert-manager-operator-metrics-reader
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - metrics-reader
-      - servicemesh-operator3-clusterrole
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - openshift-lws-operator-clusterrole
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
       - roles
     verbs:
       - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - cert-manager-operator-controller-manager-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - openshift-lws-operator-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - servicemesh-operator3-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - route.openshift.io
     resources:
@@ -2133,18 +2008,6 @@ rules:
       - create
       - patch
       - update
-  - apiGroups:
-      - sailoperator.io
-    resources:
-      - istios
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - security.openshift.io
     resources:
@@ -2279,6 +2142,18 @@ rules:
       - delete
       - get
       - patch
+  - apiGroups:
+      - telemetry.istio.io
+    resources:
+      - telemetries
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - template.openshift.io
     resources:
@@ -2643,6 +2518,8 @@ spec:
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
+            - name: RHAI_VERSION
+              value: "3.4.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -968,18 +968,6 @@ rules:
       - cert-manager.io
     resources:
       - certificates
-      - clusterissuers
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
       - issuers
     verbs:
       - create
@@ -1354,8 +1342,6 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines
-      - coreweavekubernetesengines
       - hardwareprofiles
     verbs:
       - create
@@ -1368,16 +1354,12 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/finalizers
-      - coreweavekubernetesengines/finalizers
       - hardwareprofiles/finalizers
     verbs:
       - update
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/status
-      - coreweavekubernetesengines/status
       - hardwareprofiles/status
     verbs:
       - get
@@ -1722,18 +1704,12 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.openshift.io
+      - operator.authorino.kuadrant.io
     resources:
-      - certmanagers
-      - leaderworkersetoperators
+      - authorinos
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - operator.openshift.io
     resources:
@@ -1749,6 +1725,7 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
+      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -1861,113 +1838,11 @@ rules:
       - rbac.authorization.k8s.io
     resources:
       - clusterrolebindings
+      - clusterroles
       - rolebindings
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterroles
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - cert-manager-operator-controller-manager-clusterrole
-      - cert-manager-operator-metrics-reader
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - metrics-reader
-      - servicemesh-operator3-clusterrole
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - openshift-lws-operator-clusterrole
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
       - roles
     verbs:
       - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - cert-manager-operator-controller-manager-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - openshift-lws-operator-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - servicemesh-operator3-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - route.openshift.io
     resources:
@@ -1995,18 +1870,6 @@ rules:
       - create
       - patch
       - update
-  - apiGroups:
-      - sailoperator.io
-    resources:
-      - istios
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - security.openshift.io
     resources:
@@ -2141,6 +2004,18 @@ rules:
       - delete
       - get
       - patch
+  - apiGroups:
+      - telemetry.istio.io
+    resources:
+      - telemetries
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - template.openshift.io
     resources:
@@ -2505,6 +2380,8 @@ spec:
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
+            - name: RHAI_VERSION
+              value: "3.4.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -1106,18 +1106,6 @@ rules:
       - cert-manager.io
     resources:
       - certificates
-      - clusterissuers
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
       - issuers
     verbs:
       - create
@@ -1492,8 +1480,6 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines
-      - coreweavekubernetesengines
       - hardwareprofiles
     verbs:
       - create
@@ -1506,16 +1492,12 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/finalizers
-      - coreweavekubernetesengines/finalizers
       - hardwareprofiles/finalizers
     verbs:
       - update
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/status
-      - coreweavekubernetesengines/status
       - hardwareprofiles/status
     verbs:
       - get
@@ -1860,18 +1842,12 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.openshift.io
+      - operator.authorino.kuadrant.io
     resources:
-      - certmanagers
-      - leaderworkersetoperators
+      - authorinos
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - operator.openshift.io
     resources:
@@ -1887,6 +1863,7 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
+      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -1999,113 +1976,11 @@ rules:
       - rbac.authorization.k8s.io
     resources:
       - clusterrolebindings
+      - clusterroles
       - rolebindings
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterroles
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - cert-manager-operator-controller-manager-clusterrole
-      - cert-manager-operator-metrics-reader
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - metrics-reader
-      - servicemesh-operator3-clusterrole
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - openshift-lws-operator-clusterrole
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
       - roles
     verbs:
       - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - cert-manager-operator-controller-manager-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - openshift-lws-operator-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - servicemesh-operator3-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - route.openshift.io
     resources:
@@ -2133,18 +2008,6 @@ rules:
       - create
       - patch
       - update
-  - apiGroups:
-      - sailoperator.io
-    resources:
-      - istios
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - security.openshift.io
     resources:
@@ -2279,6 +2142,18 @@ rules:
       - delete
       - get
       - patch
+  - apiGroups:
+      - telemetry.istio.io
+    resources:
+      - telemetries
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - template.openshift.io
     resources:
@@ -2643,6 +2518,8 @@ spec:
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
+            - name: RHAI_VERSION
+              value: "3.4.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -968,18 +968,6 @@ rules:
       - cert-manager.io
     resources:
       - certificates
-      - clusterissuers
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
       - issuers
     verbs:
       - create
@@ -1354,8 +1342,6 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines
-      - coreweavekubernetesengines
       - hardwareprofiles
     verbs:
       - create
@@ -1368,16 +1354,12 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/finalizers
-      - coreweavekubernetesengines/finalizers
       - hardwareprofiles/finalizers
     verbs:
       - update
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/status
-      - coreweavekubernetesengines/status
       - hardwareprofiles/status
     verbs:
       - get
@@ -1722,18 +1704,12 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.openshift.io
+      - operator.authorino.kuadrant.io
     resources:
-      - certmanagers
-      - leaderworkersetoperators
+      - authorinos
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - operator.openshift.io
     resources:
@@ -1749,6 +1725,7 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
+      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -1861,113 +1838,11 @@ rules:
       - rbac.authorization.k8s.io
     resources:
       - clusterrolebindings
+      - clusterroles
       - rolebindings
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterroles
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - cert-manager-operator-controller-manager-clusterrole
-      - cert-manager-operator-metrics-reader
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - metrics-reader
-      - servicemesh-operator3-clusterrole
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - openshift-lws-operator-clusterrole
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
       - roles
     verbs:
       - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - cert-manager-operator-controller-manager-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - openshift-lws-operator-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - servicemesh-operator3-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - route.openshift.io
     resources:
@@ -1995,18 +1870,6 @@ rules:
       - create
       - patch
       - update
-  - apiGroups:
-      - sailoperator.io
-    resources:
-      - istios
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - security.openshift.io
     resources:
@@ -2141,6 +2004,18 @@ rules:
       - delete
       - get
       - patch
+  - apiGroups:
+      - telemetry.istio.io
+    resources:
+      - telemetries
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - template.openshift.io
     resources:
@@ -2505,6 +2380,8 @@ spec:
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
+            - name: RHAI_VERSION
+              value: "3.4.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -968,18 +968,6 @@ rules:
       - cert-manager.io
     resources:
       - certificates
-      - clusterissuers
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
       - issuers
     verbs:
       - create
@@ -1354,8 +1342,6 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines
-      - coreweavekubernetesengines
       - hardwareprofiles
     verbs:
       - create
@@ -1368,16 +1354,12 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/finalizers
-      - coreweavekubernetesengines/finalizers
       - hardwareprofiles/finalizers
     verbs:
       - update
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/status
-      - coreweavekubernetesengines/status
       - hardwareprofiles/status
     verbs:
       - get
@@ -1722,18 +1704,12 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.openshift.io
+      - operator.authorino.kuadrant.io
     resources:
-      - certmanagers
-      - leaderworkersetoperators
+      - authorinos
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - operator.openshift.io
     resources:
@@ -1749,6 +1725,7 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
+      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -1861,113 +1838,11 @@ rules:
       - rbac.authorization.k8s.io
     resources:
       - clusterrolebindings
+      - clusterroles
       - rolebindings
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterroles
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - cert-manager-operator-controller-manager-clusterrole
-      - cert-manager-operator-metrics-reader
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - metrics-reader
-      - servicemesh-operator3-clusterrole
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - openshift-lws-operator-clusterrole
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
       - roles
     verbs:
       - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - cert-manager-operator-controller-manager-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - openshift-lws-operator-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resourceNames:
-      - servicemesh-operator3-role
-    resources:
-      - roles
-    verbs:
-      - bind
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - route.openshift.io
     resources:
@@ -1995,18 +1870,6 @@ rules:
       - create
       - patch
       - update
-  - apiGroups:
-      - sailoperator.io
-    resources:
-      - istios
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - security.openshift.io
     resources:
@@ -2141,6 +2004,18 @@ rules:
       - delete
       - get
       - patch
+  - apiGroups:
+      - telemetry.istio.io
+    resources:
+      - telemetries
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - template.openshift.io
     resources:
@@ -2505,6 +2380,8 @@ spec:
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "rhai-applications"
+            - name: RHAI_VERSION
+              value: "3.4.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: OPERATOR_NAME


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Add RHAI_VERSION env var from app version

Jira task: https://redhat.atlassian.net/browse/RHOAIENG-57045

## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->

- [ ] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment now exposes the application version to the runtime via an environment variable for improved traceability.
* **Chores**
  * Cluster role permissions tightened and simplified: several broad permissions were removed or reduced, and Istio telemetry permissions were added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->