### PR TITLE
  fix: use correct CA bundle ConfigMap name and mount path for gatewa…

### DIFF
--- a/charts/rhai-on-xks-chart/README.md
+++ b/charts/rhai-on-xks-chart/README.md
@@ -93,7 +93,7 @@ By default (`components.kserve.gateway.create: true`), the chart creates a Gatew
 
 1. Waits for Gateway API CRDs to be installed (by the cloud manager)
 2. Waits for the cert-manager CA secret (`opendatahub-ca`)
-3. Creates a CA bundle ConfigMap (`rhaii-ca-bundle`)
+3. Creates a CA bundle ConfigMap (`odh-ca-bundle`)
 4. Creates a gateway config ConfigMap (`inference-gateway-config`) with CA bundle mount for istio-proxy and Azure-specific health probe annotation (Azure only)
 5. Waits for the `istio` GatewayClass (created by Sail Operator)
 6. Creates the `inference-gateway` Gateway CR

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
@@ -86,7 +86,7 @@ spec:
               echo "Step 3: Creating CA bundle ConfigMap for Gateway CR 'inference-gateway'..."
               kubectl get secret opendatahub-ca -n cert-manager \
                 -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
-              kubectl create configmap rhaii-ca-bundle \
+              kubectl create configmap odh-ca-bundle \
                 --from-file=ca.crt=/tmp/ca.crt \
                 -n {{ $appNs }} \
                 --dry-run=client -o yaml | kubectl apply -f -
@@ -105,14 +105,14 @@ spec:
                     template:
                       spec:
                         volumes:
-                        - name: rhaii-ca-bundle
+                        - name: odh-ca-bundle
                           configMap:
-                            name: rhaii-ca-bundle
+                            name: odh-ca-bundle
                         containers:
                         - name: istio-proxy
                           volumeMounts:
-                          - name: rhaii-ca-bundle
-                            mountPath: /var/run/secrets/rhaii
+                          - name: odh-ca-bundle
+                            mountPath: /var/run/secrets/opendatahub
                             readOnly: true
               {{- if .Values.azure.enabled }}
                 service: |


### PR DESCRIPTION
  Fixes the post-install gateway hook to use the correct CA bundle ConfigMap name
  and mount path expected by KServe and vLLM pods.

  PR #68 introduced automatic gateway creation but used incorrect values:

  | | PR #68 (broken) | Expected |
  |---|---|---|
  | ConfigMap name | `rhaii-ca-bundle` | `odh-ca-bundle` |
  | Volume name | `rhaii-ca-bundle` | `odh-ca-bundle` |
  | Mount path | `/var/run/secrets/rhaii` | `/var/run/secrets/opendatahub` |

  This mismatch causes a TLS/SDS error when the gateway proxy tries to connect
  to vLLM pods over mTLS:

  upstream connect error or disconnect/reset before headers.
  transport failure reason: TLS error: Secret is not supplied by SDS

  The KServe LLMInferenceServiceConfig templates and the deployment samples in
  `docs/samples/llmisvc/` expect the CA bundle at `/var/run/secrets/opendatahub`
  with ConfigMap name `odh-ca-bundle`.

  Ref: #68


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for Azure and CoreWeave cloud managers

* **Chores**
  * Updated RHAI operator and related component images (KServe, vLLM, LLM-D scheduler, kube-rbac-proxy) to version 3.4.0-ea.2
  * Updated deployment resource naming conventions for CA bundle configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->