### PR TITLE
Update sail-operator bundle to 3.2.3 (includes OSSM-12585 fix)

### DIFF
--- a/charts/dependencies/sail-operator/Chart.yaml
+++ b/charts/dependencies/sail-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: sail-operator
 description: Red Hat Sail Operator (OSSM 3.x) for Kubernetes
 type: application
 version: 1.0.0
-appVersion: "3.2.1"
+appVersion: "3.2.3"
 keywords:
   - istio
   - service-mesh

--- a/charts/dependencies/sail-operator/api-docs.md
+++ b/charts/dependencies/sail-operator/api-docs.md
@@ -1,6 +1,6 @@
 # sail-operator
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.1](https://img.shields.io/badge/AppVersion-3.2.1-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.3](https://img.shields.io/badge/AppVersion-3.2.3-informational?style=flat-square)
 
 Red Hat Sail Operator (OSSM 3.x) for Kubernetes
 
@@ -18,7 +18,7 @@ Red Hat Sail Operator (OSSM 3.x) for Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| bundle.version | string | `"3.2.1"` |  |
+| bundle.version | string | `"3.2.3"` |  |
 | imagePullSecrets[0].name | string | `"rhaii-pull-secret"` |  |
 | namespace | string | `"istio-system"` |  |
 

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-istiocnis-sailoperator-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-istiocnis-sailoperator-io.yaml
@@ -21,7 +21,7 @@ spec:
           name: Namespace
           type: string
         - description: The selected profile (collection of value presets).
-          jsonPath: .spec.values.profile
+          jsonPath: .spec.profile
           name: Profile
           type: string
         - description: Whether the Istio CNI installation is ready to handle requests.
@@ -65,7 +65,7 @@ spec:
             spec:
               default:
                 namespace: istio-cni
-                version: v1.27.3
+                version: v1.27.8
               description: IstioCNISpec defines the desired state of IstioCNI
               properties:
                 namespace:
@@ -1370,14 +1370,17 @@ spec:
                       type: object
                   type: object
                 version:
-                  default: v1.27.3
+                  default: v1.27.8
                   description: |-
                     Defines the version of Istio to install.
-                    Must be one of: v1.27-latest, v1.27.3, v1.26-latest, v1.26.6, v1.26.4, v1.26.3, v1.26.2, v1.24-latest, v1.24.6, v1.24.5, v1.24.4, v1.24.3.
+                    Must be one of: v1.27-latest, v1.27.8, v1.27.5, v1.27.3, v1.26-latest, v1.26.8, v1.26.6, v1.26.4, v1.26.3, v1.26.2, v1.24-latest, v1.24.6, v1.24.5, v1.24.4, v1.24.3.
                   enum:
                     - v1.27-latest
+                    - v1.27.8
+                    - v1.27.5
                     - v1.27.3
                     - v1.26-latest
+                    - v1.26.8
                     - v1.26.6
                     - v1.26.4
                     - v1.26.3

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-istiorevisions-sailoperator-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-istiorevisions-sailoperator-io.yaml
@@ -114,8 +114,7 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                     gatewayClasses:
                       description: Configuration for Gateway Classes
-                      format: byte
-                      type: string
+                      x-kubernetes-preserve-unknown-fields: true
                     global:
                       description: Global configuration for Istio components.
                       properties:
@@ -9689,9 +9688,12 @@ spec:
                 version:
                   description: |-
                     Defines the version of Istio to install.
-                    Must be one of: v1.27.3, v1.26.6, v1.26.4, v1.26.3, v1.26.2, v1.24.6, v1.24.5, v1.24.4, v1.24.3.
+                    Must be one of: v1.27.8, v1.27.5, v1.27.3, v1.26.8, v1.26.6, v1.26.4, v1.26.3, v1.26.2, v1.24.6, v1.24.5, v1.24.4, v1.24.3.
                   enum:
+                    - v1.27.8
+                    - v1.27.5
                     - v1.27.3
+                    - v1.26.8
                     - v1.26.6
                     - v1.26.4
                     - v1.26.3

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-istios-sailoperator-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-istios-sailoperator-io.yaml
@@ -21,7 +21,7 @@ spec:
           name: Namespace
           type: string
         - description: The selected profile (collection of value presets).
-          jsonPath: .spec.values.profile
+          jsonPath: .spec.profile
           name: Profile
           type: string
         - description: Total number of IstioRevision objects currently associated with this object.
@@ -86,7 +86,7 @@ spec:
                 namespace: istio-system
                 updateStrategy:
                   type: InPlace
-                version: v1.27.3
+                version: v1.27.8
               description: IstioSpec defines the desired state of Istio
               properties:
                 namespace:
@@ -184,8 +184,7 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                     gatewayClasses:
                       description: Configuration for Gateway Classes
-                      format: byte
-                      type: string
+                      x-kubernetes-preserve-unknown-fields: true
                     global:
                       description: Global configuration for Istio components.
                       properties:
@@ -9757,14 +9756,17 @@ spec:
                       type: object
                   type: object
                 version:
-                  default: v1.27.3
+                  default: v1.27.8
                   description: |-
                     Defines the version of Istio to install.
-                    Must be one of: v1.27-latest, v1.27.3, v1.26-latest, v1.26.6, v1.26.4, v1.26.3, v1.26.2, v1.24-latest, v1.24.6, v1.24.5, v1.24.4, v1.24.3.
+                    Must be one of: v1.27-latest, v1.27.8, v1.27.5, v1.27.3, v1.26-latest, v1.26.8, v1.26.6, v1.26.4, v1.26.3, v1.26.2, v1.24-latest, v1.24.6, v1.24.5, v1.24.4, v1.24.3.
                   enum:
                     - v1.27-latest
+                    - v1.27.8
+                    - v1.27.5
                     - v1.27.3
                     - v1.26-latest
+                    - v1.26.8
                     - v1.26.6
                     - v1.26.4
                     - v1.26.3

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-ztunnels-sailoperator-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-ztunnels-sailoperator-io.yaml
@@ -61,7 +61,7 @@ spec:
             spec:
               default:
                 namespace: ztunnel
-                version: v1.27.3
+                version: v1.27.8
               description: ZTunnelSpec defines the desired state of ZTunnel
               properties:
                 namespace:
@@ -3228,14 +3228,17 @@ spec:
                       type: object
                   type: object
                 version:
-                  default: v1.27.3
+                  default: v1.27.8
                   description: |-
                     Defines the version of Istio to install.
-                    Must be one of: v1.27-latest, v1.27.3, v1.26-latest, v1.26.6, v1.26.4, v1.26.3, v1.26.2, v1.24-latest, v1.24.6, v1.24.5, v1.24.4, v1.24.3.
+                    Must be one of: v1.27-latest, v1.27.8, v1.27.5, v1.27.3, v1.26-latest, v1.26.8, v1.26.6, v1.26.4, v1.26.3, v1.26.2, v1.24-latest, v1.24.6, v1.24.5, v1.24.4, v1.24.3.
                   enum:
                     - v1.27-latest
+                    - v1.27.8
+                    - v1.27.5
                     - v1.27.3
                     - v1.26-latest
+                    - v1.26.8
                     - v1.26.6
                     - v1.26.4
                     - v1.26.3
@@ -3348,7 +3351,7 @@ spec:
               default:
                 namespace: ztunnel
                 profile: ambient
-                version: v1.27.3
+                version: v1.27.8
               description: ZTunnelSpec defines the desired state of ZTunnel
               properties:
                 namespace:
@@ -6533,14 +6536,17 @@ spec:
                       type: object
                   type: object
                 version:
-                  default: v1.27.3
+                  default: v1.27.8
                   description: |-
                     Defines the version of Istio to install.
-                    Must be one of: v1.27-latest, v1.27.3, v1.26-latest, v1.26.6, v1.26.4, v1.26.3, v1.26.2, v1.24-latest, v1.24.6, v1.24.5, v1.24.4, v1.24.3.
+                    Must be one of: v1.27-latest, v1.27.8, v1.27.5, v1.27.3, v1.26-latest, v1.26.8, v1.26.6, v1.26.4, v1.26.3, v1.26.2, v1.24-latest, v1.24.6, v1.24.5, v1.24.4, v1.24.3.
                   enum:
                     - v1.27-latest
+                    - v1.27.8
+                    - v1.27.5
                     - v1.27.3
                     - v1.26-latest
+                    - v1.26.8
                     - v1.26.6
                     - v1.26.4
                     - v1.26.3

--- a/charts/dependencies/sail-operator/templates/deployment-servicemesh-operator3.yaml
+++ b/charts/dependencies/sail-operator/templates/deployment-servicemesh-operator3.yaml
@@ -33,11 +33,11 @@ spec:
         images.v1_24_5.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:87b967785d7cc222f9df9cb49f0373a9819bf67910ce523dc3b8345849e881dd
         images.v1_24_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:7fa655f5efb1175ff1e1c138371fc1233e5d4313c5feb07194428d0d1fdd33a3
         images.v1_24_5.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:7ea9b82e192402566e69063a4787351be9f1ef50719bfd1a8f5d5940362b3f70
-        images.v1_24_6.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:54508ddeb570a45b5576d4e128fc6f4114e3bb0ed8cf600f2bcbf80d8b4f6b8a
-        images.v1_24_6.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:c018e5c2fe81d6b6577cbf32a9aa3f909c69c24ed411e4fa3fa7b4a891ce017e
-        images.v1_24_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:892c857d7ea35e60e13a277f5ab1268a4068c316353403a2846f116235d52a7b
-        images.v1_24_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:836c53299b170a1ef0bc8ce958da2abe14a48b8d84f9298e7c6b3d940fa8a1cc
-        images.v1_24_6.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:18897281e5ab5198506c4dd5cc0f5a96245794e6b33f63a2a4a3195bf23fbf60
+        images.v1_24_6.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:a650350c1c673c393def5cc8ad16a29a0514fbf72dcfe23858e103ee05ad3277
+        images.v1_24_6.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:f7c3b758ce6318f33c1fe7307182428b0bbd678ce6b69d4b4692cf44c581b4cb
+        images.v1_24_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:446d404e0e373750ab47406a55461e151f93e3771adf02b18f6ee427ac1fcdcd
+        images.v1_24_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:1bbae810c90431b87e31b6c67eb2f62d0754ac63b678e03fb1e5324926632f8b
+        images.v1_24_6.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:6e8b674e308f70c12c88f9d75ee407c2f59df8f929bec0dace1b5d6664636a59
         images.v1_26_2.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:14c5a52faf20267baa43d9a72ee6416f56fbc41dd640adc2aba3c4043802a0e9
         images.v1_26_2.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:028e10651db0d1ddb769a27c9483c6d41be6ac597f253afd9d599f395d9c82d8
         images.v1_26_2.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:366266f10e658c4cea86bddf6ee847e1908ea4dd780cb5f7fb0e466bac8995f1
@@ -58,11 +58,26 @@ spec:
         images.v1_26_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:8a21e30593e51f2fd2e51d9ab1d0ed2fc43eaa9b98173d7fb74f799d6b2f163d
         images.v1_26_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:47100186c27934adeda3002bb04cac28980ca8854eee7d6e4f4b3f85562e9a8e
         images.v1_26_6.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:f39e2c28ef36fce9f808f3946cc4e4126047e142ad84cb18c222cecceae29730
+        images.v1_26_8.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:edb5aab128bc90ba62a9b1d268be82ea8771ff70b0305ad9d85d8f669a995044
+        images.v1_26_8.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:6f9ed59521fab78d5cf576d0519b5aa40ea46963a13772b0a6ecabafbb32778b
+        images.v1_26_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:3e3e4a5f1e644796c13728c6c7f7ca8daab3b9a08d8ffd2a7a8c8f424d47b0b8
+        images.v1_26_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:6558eba168f2cb50aa40394b9ff9e71882c9e4a4c93ca189ba8f71f324c12ab4
+        images.v1_26_8.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:af4076fd0bef20612081bd8b0dbf9434a33a879545bba823cdaeeeb01ad39056
         images.v1_27_3.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:ddadd677161ad8c1077dd156821d6b4e32742ccbb210e9c14696fa66a58c0867
         images.v1_27_3.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:0850242436e88f7d82f0f2126de064c7e0f09844f31d8ff0f53dc8d3908075d9
         images.v1_27_3.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:742bc084c26769ff57cb3aa47b7a35c2b94684c3f67a9388da07a0490a942e5c
         images.v1_27_3.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:7d15cebf9b62f3f235c0eab5158ac8ff2fda86a1d193490dc94c301402c99da8
         images.v1_27_3.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:b2b3216a05f6136ed9ddb71d72d493030c6d6b431682dddffa692c760b6c9ba1
+        images.v1_27_5.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:2929b7df3da8228a728945542647ec5450c0585a2ed5cbdb84f8e3d81ab41806
+        images.v1_27_5.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:2e515a40de141bd4e516bfcf4fd0cbb8d236ac02799a7a35d77ae44f53916bc9
+        images.v1_27_5.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:d1baba8cb454b62d804dc427d4ccfea928348631c384d1ab3d170e1e2a9d1178
+        images.v1_27_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:650da1e2ad1cb93e6a0231dba7ca1f27f4cccac84e5925135281adc629a0caea
+        images.v1_27_5.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:0ae2919cd446e0e1f0a21d0850e7809ba8f44c06d484c023b3bee2787ca4bdd0
+        images.v1_27_8.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f072a10513086f330af8bbd4e70d6922167417cfb15674d4e9834565071f2c20
+        images.v1_27_8.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:2a25d47b4bb3bf346563a0ccea986c0ab0466709ca4cb9d2666ba6a02a8a5f31
+        images.v1_27_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:6eaedfbf16cfc73196e693b97d33e399acf438bce5fd7ec3c91f3f084c87edf0
+        images.v1_27_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:2b5f5aa5ee9974269d8e3666b1bfc58da10c172bf3f1d6defd555fbd1ac9a6ec
+        images.v1_27_8.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:4e085c9b6ca08f950798bf5153579e00e8e65226befe9c9043c19ae53f8a3a2d
         kubectl.kubernetes.io/default-container: sail-operator
       labels:
         app.kubernetes.io/created-by: servicemeshoperator3
@@ -93,7 +108,7 @@ spec:
             - --zap-log-level=info
           command:
             - /usr/local/bin/sail-operator
-          image: registry.redhat.io/openshift-service-mesh/istio-rhel9-operator@sha256:656511cdb0683ff7e3336d4f41a672b4063b665e9e6e34d5370640103fd49365
+          image: registry.redhat.io/openshift-service-mesh/istio-rhel9-operator@sha256:b2a576f6eaddba51d5f9a7847642e95b6dfaafc4498e779f17e5f216c677f873
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/dependencies/sail-operator/test/snapshots/default.snap.yaml
+++ b/charts/dependencies/sail-operator/test/snapshots/default.snap.yaml
@@ -426,11 +426,11 @@ spec:
         images.v1_24_5.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:87b967785d7cc222f9df9cb49f0373a9819bf67910ce523dc3b8345849e881dd
         images.v1_24_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:7fa655f5efb1175ff1e1c138371fc1233e5d4313c5feb07194428d0d1fdd33a3
         images.v1_24_5.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:7ea9b82e192402566e69063a4787351be9f1ef50719bfd1a8f5d5940362b3f70
-        images.v1_24_6.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:54508ddeb570a45b5576d4e128fc6f4114e3bb0ed8cf600f2bcbf80d8b4f6b8a
-        images.v1_24_6.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:c018e5c2fe81d6b6577cbf32a9aa3f909c69c24ed411e4fa3fa7b4a891ce017e
-        images.v1_24_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:892c857d7ea35e60e13a277f5ab1268a4068c316353403a2846f116235d52a7b
-        images.v1_24_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:836c53299b170a1ef0bc8ce958da2abe14a48b8d84f9298e7c6b3d940fa8a1cc
-        images.v1_24_6.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:18897281e5ab5198506c4dd5cc0f5a96245794e6b33f63a2a4a3195bf23fbf60
+        images.v1_24_6.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:a650350c1c673c393def5cc8ad16a29a0514fbf72dcfe23858e103ee05ad3277
+        images.v1_24_6.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:f7c3b758ce6318f33c1fe7307182428b0bbd678ce6b69d4b4692cf44c581b4cb
+        images.v1_24_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:446d404e0e373750ab47406a55461e151f93e3771adf02b18f6ee427ac1fcdcd
+        images.v1_24_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:1bbae810c90431b87e31b6c67eb2f62d0754ac63b678e03fb1e5324926632f8b
+        images.v1_24_6.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:6e8b674e308f70c12c88f9d75ee407c2f59df8f929bec0dace1b5d6664636a59
         images.v1_26_2.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:14c5a52faf20267baa43d9a72ee6416f56fbc41dd640adc2aba3c4043802a0e9
         images.v1_26_2.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:028e10651db0d1ddb769a27c9483c6d41be6ac597f253afd9d599f395d9c82d8
         images.v1_26_2.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:366266f10e658c4cea86bddf6ee847e1908ea4dd780cb5f7fb0e466bac8995f1
@@ -451,11 +451,26 @@ spec:
         images.v1_26_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:8a21e30593e51f2fd2e51d9ab1d0ed2fc43eaa9b98173d7fb74f799d6b2f163d
         images.v1_26_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:47100186c27934adeda3002bb04cac28980ca8854eee7d6e4f4b3f85562e9a8e
         images.v1_26_6.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:f39e2c28ef36fce9f808f3946cc4e4126047e142ad84cb18c222cecceae29730
+        images.v1_26_8.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:edb5aab128bc90ba62a9b1d268be82ea8771ff70b0305ad9d85d8f669a995044
+        images.v1_26_8.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:6f9ed59521fab78d5cf576d0519b5aa40ea46963a13772b0a6ecabafbb32778b
+        images.v1_26_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:3e3e4a5f1e644796c13728c6c7f7ca8daab3b9a08d8ffd2a7a8c8f424d47b0b8
+        images.v1_26_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:6558eba168f2cb50aa40394b9ff9e71882c9e4a4c93ca189ba8f71f324c12ab4
+        images.v1_26_8.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:af4076fd0bef20612081bd8b0dbf9434a33a879545bba823cdaeeeb01ad39056
         images.v1_27_3.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:ddadd677161ad8c1077dd156821d6b4e32742ccbb210e9c14696fa66a58c0867
         images.v1_27_3.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:0850242436e88f7d82f0f2126de064c7e0f09844f31d8ff0f53dc8d3908075d9
         images.v1_27_3.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:742bc084c26769ff57cb3aa47b7a35c2b94684c3f67a9388da07a0490a942e5c
         images.v1_27_3.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:7d15cebf9b62f3f235c0eab5158ac8ff2fda86a1d193490dc94c301402c99da8
         images.v1_27_3.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:b2b3216a05f6136ed9ddb71d72d493030c6d6b431682dddffa692c760b6c9ba1
+        images.v1_27_5.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:2929b7df3da8228a728945542647ec5450c0585a2ed5cbdb84f8e3d81ab41806
+        images.v1_27_5.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:2e515a40de141bd4e516bfcf4fd0cbb8d236ac02799a7a35d77ae44f53916bc9
+        images.v1_27_5.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:d1baba8cb454b62d804dc427d4ccfea928348631c384d1ab3d170e1e2a9d1178
+        images.v1_27_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:650da1e2ad1cb93e6a0231dba7ca1f27f4cccac84e5925135281adc629a0caea
+        images.v1_27_5.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:0ae2919cd446e0e1f0a21d0850e7809ba8f44c06d484c023b3bee2787ca4bdd0
+        images.v1_27_8.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f072a10513086f330af8bbd4e70d6922167417cfb15674d4e9834565071f2c20
+        images.v1_27_8.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:2a25d47b4bb3bf346563a0ccea986c0ab0466709ca4cb9d2666ba6a02a8a5f31
+        images.v1_27_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:6eaedfbf16cfc73196e693b97d33e399acf438bce5fd7ec3c91f3f084c87edf0
+        images.v1_27_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:2b5f5aa5ee9974269d8e3666b1bfc58da10c172bf3f1d6defd555fbd1ac9a6ec
+        images.v1_27_8.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:4e085c9b6ca08f950798bf5153579e00e8e65226befe9c9043c19ae53f8a3a2d
         kubectl.kubernetes.io/default-container: sail-operator
       labels:
         app.kubernetes.io/created-by: servicemeshoperator3
@@ -486,7 +501,7 @@ spec:
             - --zap-log-level=info
           command:
             - /usr/local/bin/sail-operator
-          image: registry.redhat.io/openshift-service-mesh/istio-rhel9-operator@sha256:656511cdb0683ff7e3336d4f41a672b4063b665e9e6e34d5370640103fd49365
+          image: registry.redhat.io/openshift-service-mesh/istio-rhel9-operator@sha256:b2a576f6eaddba51d5f9a7847642e95b6dfaafc4498e779f17e5f216c677f873
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/dependencies/sail-operator/values.yaml
+++ b/charts/dependencies/sail-operator/values.yaml
@@ -5,4 +5,4 @@ imagePullSecrets:
   - name: rhaii-pull-secret
 
 bundle:
-  version: "3.2.1"
+  version: "3.2.3"


### PR DESCRIPTION
 Update sail-operator dependency from 3.2.1 to 3.2.3.                                                                                                                                     
                                                                                                                                                                                           
  This includes the fix for [OSSM-12585](https://redhat.atlassian.net/browse/OSSM-12585) — "Merge Extra field during VirtualService merge for multiple InferencePools".                    
              
  Upstream fixes:
  - https://github.com/istio/istio/pull/59303 (release-1.28)
  - https://github.com/openshift-service-mesh/istio/pull/645 (release-1.26)
  - https://github.com/openshift-service-mesh/istio/pull/650 (release-1.27)

  ### Changes
  - Updated bundle manifests via `scripts/update-bundle.sh 3.2.3`
  - Updated `Chart.yaml` appVersion to 3.2.3
  - Updated CRDs (istios, istiocnis, istiorevisions, ztunnels)
  - Updated deployment with new Istio image digests

  ## Has it been tested?

  - [x] Installed on AKS cluster with PR #76 changes and verified all pods running


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Istio versions v1.27.8, v1.27.5, and v1.26.8.

* **Chores**
  * Sail Operator bumped to 3.2.3.
  * Default Istio version updated to v1.27.8.
  * Container image digests refreshed.

* **Bug Fixes / Improvements**
  * CRD display now shows Profile from the spec correctly.
  * GatewayClasses schema relaxed to allow unspecified/opaque shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->