### PR TITLE
RHOAIENG-57828: add CertManager/cluster CR to cert-manager-operator chart

### DIFF
--- a/charts/dependencies/cert-manager-operator/templates/certmanager.yaml
+++ b/charts/dependencies/cert-manager-operator/templates/certmanager.yaml
@@ -1,0 +1,6 @@
+apiVersion: operator.openshift.io/v1alpha1
+kind: CertManager
+metadata:
+  name: cluster
+spec:
+  managementState: Managed

--- a/charts/dependencies/cert-manager-operator/test/snapshots/default.snap.yaml
+++ b/charts/dependencies/cert-manager-operator/test/snapshots/default.snap.yaml
@@ -559,3 +559,11 @@ spec:
       volumes:
         - emptyDir: {}
           name: tmp
+---
+# Source: cert-manager-operator/templates/certmanager.yaml
+apiVersion: operator.openshift.io/v1alpha1
+kind: CertManager
+metadata:
+  name: cluster
+spec:
+  managementState: Managed


### PR DESCRIPTION
## Description

Add the `CertManager/cluster` CR (`operator.openshift.io/v1alpha1`) to the cert-manager-operator Helm chart templates.

Jira task: [RHOAIENG-57828](https://issues.redhat.com/browse/RHOAIENG-57828)

Depends on https://github.com/opendatahub-io/opendatahub-operator/pull/3432

### Why

The opendatahub-operator has a finalizer action (added in a companion PR to opendatahub-operator) that deletes `CertManager/cluster` before the Helm release cascade runs. This lets cert-manager-operator process its own finalizers and cleanly remove its operand Deployments before its operator pod is killed during uninstall.

That finalizer action identifies "our" `CertManager/cluster` CR by checking for an OwnerReference set through dynamic ownership. Dynamic ownership only applies to resources that are part of the Helm chart. Without this file in the chart templates, the CR has no OwnerReference, the finalizer action skips it, and cert-manager operand pods are left behind.

### What

- New file: `charts/dependencies/cert-manager-operator/templates/certmanager.yaml`
- Creates a `CertManager` resource named `cluster` with `managementState: Managed`
- This is the same CR that cert-manager-operator already creates on its own, but including it in the chart ensures it gets an OwnerReference for cleanup sequencing

## Has it been tested?

- [x] Installed on a real cluster to verify the changes
- Verified that after adding this template, the `CertManager/cluster` CR receives an OwnerReference via dynamic ownership
- Verified that the opendatahub-operator finalizer action correctly identifies and deletes `CertManager/cluster` before cascade, allowing cert-manager-operator to cleanly remove its operand Deployments

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>
