### PR TITLE
update: rename rhaii-* to rhai-*

### DIFF
--- a/charts/dependencies/cert-manager-operator/api-docs.md
+++ b/charts/dependencies/cert-manager-operator/api-docs.md
@@ -15,7 +15,7 @@ Red Hat cert-manager Operator for vanilla Kubernetes (without OLM)
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | bundle.version | string | `"v1.18.1"` |  |
-| imagePullSecrets[0].name | string | `"rhaii-pull-secret"` |  |
+| imagePullSecrets[0].name | string | `"rhai-pull-secret"` |  |
 | operandNamespace | string | `"cert-manager"` |  |
 | operatorNamespace | string | `"cert-manager-operator"` |  |
 

--- a/charts/dependencies/cert-manager-operator/test/snapshots/default.snap.yaml
+++ b/charts/dependencies/cert-manager-operator/test/snapshots/default.snap.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cert-manager-operator-controller-manager
   namespace: cert-manager-operator
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: cert-manager-operator/templates/serviceaccount-cert-manager.yaml
 apiVersion: v1
@@ -27,7 +27,7 @@ metadata:
   name: cert-manager
   namespace: cert-manager
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: cert-manager-operator/templates/serviceaccount-cert-manager.yaml
 apiVersion: v1
@@ -36,7 +36,7 @@ metadata:
   name: cert-manager-cainjector
   namespace: cert-manager
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: cert-manager-operator/templates/serviceaccount-cert-manager.yaml
 apiVersion: v1
@@ -45,7 +45,7 @@ metadata:
   name: cert-manager-webhook
   namespace: cert-manager
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: cert-manager-operator/templates/clusterrole-cert-manager-operator-controller-manager-clusterro.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/dependencies/cert-manager-operator/values.yaml
+++ b/charts/dependencies/cert-manager-operator/values.yaml
@@ -3,7 +3,7 @@ operatorNamespace: cert-manager-operator
 operandNamespace: cert-manager
 
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 
 bundle:
   version: "v1.18.1"

--- a/charts/dependencies/lws-operator/api-docs.md
+++ b/charts/dependencies/lws-operator/api-docs.md
@@ -19,6 +19,6 @@ Red Hat Leader Worker Set Operator for Kubernetes
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | bundle.version | string | `"1.0"` |  |
-| imagePullSecrets[0].name | string | `"rhaii-pull-secret"` |  |
+| imagePullSecrets[0].name | string | `"rhai-pull-secret"` |  |
 | namespace | string | `"openshift-lws-operator"` |  |
 

--- a/charts/dependencies/lws-operator/test/snapshots/default.snap.yaml
+++ b/charts/dependencies/lws-operator/test/snapshots/default.snap.yaml
@@ -12,7 +12,7 @@ metadata:
   name: lws-controller-manager
   namespace: openshift-lws-operator
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: lws-operator/templates/serviceaccount-openshift-lws-operator.yaml
 apiVersion: v1
@@ -21,7 +21,7 @@ metadata:
   name: openshift-lws-operator
   namespace: openshift-lws-operator
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: lws-operator/templates/clusterrole-openshift-lws-operator-clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/dependencies/lws-operator/values.yaml
+++ b/charts/dependencies/lws-operator/values.yaml
@@ -2,7 +2,7 @@
 namespace: openshift-lws-operator
 
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 
 bundle:
   version: "1.0"

--- a/charts/dependencies/sail-operator/api-docs.md
+++ b/charts/dependencies/sail-operator/api-docs.md
@@ -18,7 +18,7 @@ Red Hat Sail Operator (OSSM 3.x) for Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| bundle.version | string | `"3.2.1"` |  |
-| imagePullSecrets[0].name | string | `"rhaii-pull-secret"` |  |
+| bundle.version | string | `"3.2.3"` |  |
+| imagePullSecrets[0].name | string | `"rhai-pull-secret"` |  |
 | namespace | string | `"istio-system"` |  |
 

--- a/charts/dependencies/sail-operator/test/snapshots/default.snap.yaml
+++ b/charts/dependencies/sail-operator/test/snapshots/default.snap.yaml
@@ -12,7 +12,7 @@ metadata:
   name: servicemesh-operator3
   namespace: istio-system
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: sail-operator/templates/clusterrole-metrics-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -553,4 +553,4 @@ spec:
           ENABLE_GATEWAY_API_INFERENCE_EXTENSION: "true"
     global:
       imagePullSecrets:
-        - rhaii-pull-secret
+        - rhai-pull-secret

--- a/charts/dependencies/sail-operator/values.yaml
+++ b/charts/dependencies/sail-operator/values.yaml
@@ -2,7 +2,7 @@
 namespace: istio-system
 
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 
 bundle:
-  version: "3.2.1"
+  version: "3.2.3"

--- a/charts/rhai-on-xks-chart/README.md
+++ b/charts/rhai-on-xks-chart/README.md
@@ -41,10 +41,10 @@ podman login registry.redhat.io --authfile /path/to/auth.json
 
 The `imagePullSecret.dockerConfigJson` parameter:
 
-1. Creates a `kubernetes.io/dockerconfigjson` Secret named `rhaii-pull-secret` in all chart-managed namespaces (operator, applications, release, cloud manager and all dependency namespaces)
+1. Creates a `kubernetes.io/dockerconfigjson` Secret named `rhai-pull-secret` in all chart-managed namespaces (operator, applications, release, cloud manager and all dependency namespaces)
 2. Adds `imagePullSecrets` to all chart-managed ServiceAccounts (RHAI operator, cloud manager, llmisvc-controller-manager, and the post-install hook)
 
-The secret name defaults to `rhaii-pull-secret` and **should not** be changed.
+The secret name defaults to `rhai-pull-secret` and **should not** be changed.
 
 > [!NOTE]
 > Pull secrets for dependency namespaces (`cert-manager-operator`, `cert-manager`, `istio-system`, `openshift-lws-operator`) are managed by this chart by default. To customize which dependency namespaces receive pull secrets, set `imagePullSecret.dependencyNamespaces`.
@@ -92,8 +92,8 @@ Phase 2 and 3 are necessary because the CRs depend on CRDs and resources that ar
 By default (`components.kserve.gateway.create: true`), the chart creates a Gateway CR named `inference-gateway` in the applications namespace. This gateway is required for KServe model inference traffic. The hook:
 
 1. Waits for Gateway API CRDs to be installed (by the cloud manager)
-2. Waits for the cert-manager CA secret (`rhaii-ca`)
-3. Creates a CA bundle ConfigMap (`rhaii-ca-bundle`)
+2. Waits for the cert-manager CA secret (`rhai-ca`)
+3. Creates a CA bundle ConfigMap (`rhai-ca-bundle`)
 4. Creates a gateway config ConfigMap (`inference-gateway-config`) with CA bundle mount for istio-proxy and Azure-specific health probe annotation (Azure only)
 5. Waits for the `istio` GatewayClass (created by Sail Operator)
 6. Creates the `inference-gateway` Gateway CR

--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -45,7 +45,7 @@ Red Hat OpenShift AI Operator Helm chart (non-OLM installation)
 | imagePullSecret.dependencyNamespaces[2] | string | `"openshift-lws-operator"` |  |
 | imagePullSecret.dependencyNamespaces[3] | string | `"istio-system"` |  |
 | imagePullSecret.dockerConfigJson | string | `""` |  |
-| imagePullSecret.name | string | `"rhaii-pull-secret"` |  |
+| imagePullSecret.name | string | `"rhai-pull-secret"` |  |
 | installCRDs | bool | `true` |  |
 | labels | object | `{}` |  |
 | rhaiOperator.applicationsNamespace | string | `"redhat-ods-applications"` |  |

--- a/charts/rhai-on-xks-chart/templates/_helpers.tpl
+++ b/charts/rhai-on-xks-chart/templates/_helpers.tpl
@@ -36,7 +36,7 @@ true
 Return the imagePullSecret name.
 */}}
 {{- define "rhai-on-xks-chart.imagePullSecretName" -}}
-{{- .Values.imagePullSecret.name | default "rhaii-pull-secret" -}}
+{{- .Values.imagePullSecret.name | default "rhai-pull-secret" -}}
 {{- end -}}
 
 {{/*

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
@@ -59,11 +59,11 @@ spec:
             - name: RHAI_WEBHOOK_CERT_NAME
               value: rhai-operator-webhook-cert
             - name: RHAI_CA_SECRET_NAME
-              value: rhaii-ca
+              value: rhai-ca
             - name: RHAI_CA_SECRET_NAMESPACE
               value: cert-manager
             - name: RHAI_ISSUER_REF_NAME
-              value: rhaii-ca-issuer
+              value: rhai-ca-issuer
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
@@ -59,11 +59,11 @@ spec:
             - name: RHAI_WEBHOOK_CERT_NAME
               value: rhai-operator-webhook-cert
             - name: RHAI_CA_SECRET_NAME
-              value: rhaii-ca
+              value: rhai-ca
             - name: RHAI_CA_SECRET_NAMESPACE
               value: cert-manager
             - name: RHAI_ISSUER_REF_NAME
-              value: rhaii-ca-issuer
+              value: rhai-ca-issuer
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rhaii-post-install-crs
+  name: rhai-post-install-crs
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
@@ -23,7 +23,7 @@ spec:
         {{- include "rhai-on-xks-chart.labels" . | nindent 8 }}
     spec:
       restartPolicy: Never
-      serviceAccountName: rhaii-post-install-hook
+      serviceAccountName: rhai-post-install-hook
       {{- include "rhai-on-xks-chart.imagePullSecrets" . | nindent 6 }}
       securityContext:
         runAsNonRoot: true

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -8,7 +8,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
@@ -20,7 +20,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   labels:
     {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
   annotations:
@@ -89,7 +89,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   labels:
     {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
   annotations:
@@ -99,10 +99,10 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
 subjects:
   - kind: ServiceAccount
-    name: rhaii-post-install-hook
+    name: rhai-post-install-hook
     namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rhaii-post-create-gateway
+  name: rhai-post-create-gateway
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
@@ -20,7 +20,7 @@ spec:
         {{- include "rhai-on-xks-chart.labels" . | nindent 8 }}
     spec:
       restartPolicy: Never
-      serviceAccountName: rhaii-post-install-hook
+      serviceAccountName: rhai-post-install-hook
       {{- include "rhai-on-xks-chart.imagePullSecrets" . | nindent 6 }}
       securityContext:
         runAsNonRoot: true
@@ -72,7 +72,7 @@ spec:
 
               echo "Step 2: Waiting for cert-manager CA secret required by Gateway CR 'inference-gateway'..."
               ELAPSED=0
-              until kubectl get secret rhaii-ca -n cert-manager >/dev/null 2>&1; do
+              until kubectl get secret rhai-ca -n cert-manager >/dev/null 2>&1; do
                 if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
                   echo "ERROR: Timed out waiting for CA secret after ${TIMEOUT}s"
                   exit 1
@@ -84,9 +84,9 @@ spec:
               echo "CA secret is available."
 
               echo "Step 3: Creating CA bundle ConfigMap for Gateway CR 'inference-gateway'..."
-              kubectl get secret rhaii-ca -n cert-manager \
+              kubectl get secret rhai-ca -n cert-manager \
                 -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
-              kubectl create configmap rhaii-ca-bundle \
+              kubectl create configmap rhai-ca-bundle \
                 --from-file=ca.crt=/tmp/ca.crt \
                 -n {{ $appNs }} \
                 --dry-run=client -o yaml | kubectl apply -f -
@@ -105,14 +105,14 @@ spec:
                     template:
                       spec:
                         volumes:
-                        - name: rhaii-ca-bundle
+                        - name: rhai-ca-bundle
                           configMap:
-                            name: rhaii-ca-bundle
+                            name: rhai-ca-bundle
                         containers:
                         - name: istio-proxy
                           volumeMounts:
-                          - name: rhaii-ca-bundle
-                            mountPath: /var/run/secrets/rhaii
+                          - name: rhai-ca-bundle
+                            mountPath: /var/run/secrets/rhai
                             readOnly: true
               {{- if .Values.azure.enabled }}
                 service: |

--- a/charts/rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
+++ b/charts/rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
@@ -99,13 +99,13 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME
-              value: rhaii-ca
+              value: rhai-ca
             - name: RHAI_CA_SECRET_NAMESPACE
               value: cert-manager
             - name: RHAI_ISSUER_REF_NAME
-              value: rhaii-ca-issuer
+              value: rhai-ca-issuer
             - name: RHAI_ISTIO_CA_CERTIFICATE_PATH
-              value: /var/run/secrets/rhaii/ca.crt
+              value: /var/run/secrets/rhai/ca.crt
             - name: OPERATOR_NAME
               value: rhai-operator
             - name: OPERATOR_NAMESPACE

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -48,7 +48,7 @@ metadata:
   name: azure-cloud-manager-operator
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 # TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
@@ -58,7 +58,7 @@ metadata:
   name: llmisvc-controller-manager
   namespace: redhat-ods-applications
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -67,13 +67,13 @@ metadata:
   name: rhai-operator-controller-manager
   namespace: redhat-ods-operator
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: redhat-ods-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -86,7 +86,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: redhat-ods-applications
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -99,7 +99,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -112,7 +112,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: rhai-cloudmanager-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -125,7 +125,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: cert-manager-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -138,7 +138,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: cert-manager
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -151,7 +151,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: openshift-lws-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -164,7 +164,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: istio-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2380,11 +2380,11 @@ spec:
             - name: RHAI_WEBHOOK_CERT_NAME
               value: rhai-operator-webhook-cert
             - name: RHAI_CA_SECRET_NAME
-              value: rhaii-ca
+              value: rhai-ca
             - name: RHAI_CA_SECRET_NAMESPACE
               value: cert-manager
             - name: RHAI_ISSUER_REF_NAME
-              value: rhaii-ca-issuer
+              value: rhai-ca-issuer
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2531,13 +2531,13 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME
-              value: rhaii-ca
+              value: rhai-ca
             - name: RHAI_CA_SECRET_NAMESPACE
               value: cert-manager
             - name: RHAI_ISSUER_REF_NAME
-              value: rhaii-ca-issuer
+              value: rhai-ca-issuer
             - name: RHAI_ISTIO_CA_CERTIFICATE_PATH
-              value: /var/run/secrets/rhaii/ca.crt
+              value: /var/run/secrets/rhai/ca.crt
             - name: OPERATOR_NAME
               value: rhai-operator
             - name: OPERATOR_NAMESPACE
@@ -2688,7 +2688,7 @@ webhooks:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2702,7 +2702,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -2771,7 +2771,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -2782,17 +2782,17 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
 subjects:
   - kind: ServiceAccount
-    name: rhaii-post-install-hook
+    name: rhai-post-install-hook
     namespace: default
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rhaii-post-install-crs
+  name: rhai-post-install-crs
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2810,9 +2810,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
     spec:
       restartPolicy: Never
-      serviceAccountName: rhaii-post-install-hook
+      serviceAccountName: rhai-post-install-hook
       imagePullSecrets:
-        - name: rhaii-pull-secret
+        - name: rhai-pull-secret
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -2880,7 +2880,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rhaii-post-create-gateway
+  name: rhai-post-create-gateway
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2898,9 +2898,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
     spec:
       restartPolicy: Never
-      serviceAccountName: rhaii-post-install-hook
+      serviceAccountName: rhai-post-install-hook
       imagePullSecrets:
-        - name: rhaii-pull-secret
+        - name: rhai-pull-secret
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -2951,7 +2951,7 @@ spec:
 
               echo "Step 2: Waiting for cert-manager CA secret required by Gateway CR 'inference-gateway'..."
               ELAPSED=0
-              until kubectl get secret rhaii-ca -n cert-manager >/dev/null 2>&1; do
+              until kubectl get secret rhai-ca -n cert-manager >/dev/null 2>&1; do
                 if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
                   echo "ERROR: Timed out waiting for CA secret after ${TIMEOUT}s"
                   exit 1
@@ -2963,9 +2963,9 @@ spec:
               echo "CA secret is available."
 
               echo "Step 3: Creating CA bundle ConfigMap for Gateway CR 'inference-gateway'..."
-              kubectl get secret rhaii-ca -n cert-manager \
+              kubectl get secret rhai-ca -n cert-manager \
                 -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
-              kubectl create configmap rhaii-ca-bundle \
+              kubectl create configmap rhai-ca-bundle \
                 --from-file=ca.crt=/tmp/ca.crt \
                 -n redhat-ods-applications \
                 --dry-run=client -o yaml | kubectl apply -f -
@@ -2984,14 +2984,14 @@ spec:
                     template:
                       spec:
                         volumes:
-                        - name: rhaii-ca-bundle
+                        - name: rhai-ca-bundle
                           configMap:
-                            name: rhaii-ca-bundle
+                            name: rhai-ca-bundle
                         containers:
                         - name: istio-proxy
                           volumeMounts:
-                          - name: rhaii-ca-bundle
-                            mountPath: /var/run/secrets/rhaii
+                          - name: rhai-ca-bundle
+                            mountPath: /var/run/secrets/rhai
                             readOnly: true
                 service: |
                   metadata:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -24,7 +24,7 @@ metadata:
   name: azure-cloud-manager-operator
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -33,7 +33,7 @@ metadata:
   name: rhai-operator-controller-manager
   namespace: redhat-ods-operator
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/crds/customresourcedefinition-azurekubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -2242,11 +2242,11 @@ spec:
             - name: RHAI_WEBHOOK_CERT_NAME
               value: rhai-operator-webhook-cert
             - name: RHAI_CA_SECRET_NAME
-              value: rhaii-ca
+              value: rhai-ca
             - name: RHAI_CA_SECRET_NAMESPACE
               value: cert-manager
             - name: RHAI_ISSUER_REF_NAME
-              value: rhaii-ca-issuer
+              value: rhai-ca-issuer
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2393,13 +2393,13 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME
-              value: rhaii-ca
+              value: rhai-ca
             - name: RHAI_CA_SECRET_NAMESPACE
               value: cert-manager
             - name: RHAI_ISSUER_REF_NAME
-              value: rhaii-ca-issuer
+              value: rhai-ca-issuer
             - name: RHAI_ISTIO_CA_CERTIFICATE_PATH
-              value: /var/run/secrets/rhaii/ca.crt
+              value: /var/run/secrets/rhai/ca.crt
             - name: OPERATOR_NAME
               value: rhai-operator
             - name: OPERATOR_NAMESPACE
@@ -2552,7 +2552,7 @@ webhooks:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2566,7 +2566,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -2635,7 +2635,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -2646,17 +2646,17 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
 subjects:
   - kind: ServiceAccount
-    name: rhaii-post-install-hook
+    name: rhai-post-install-hook
     namespace: default
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rhaii-post-install-crs
+  name: rhai-post-install-crs
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2674,9 +2674,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
     spec:
       restartPolicy: Never
-      serviceAccountName: rhaii-post-install-hook
+      serviceAccountName: rhai-post-install-hook
       imagePullSecrets:
-        - name: rhaii-pull-secret
+        - name: rhai-pull-secret
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -2744,7 +2744,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rhaii-post-create-gateway
+  name: rhai-post-create-gateway
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2762,9 +2762,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
     spec:
       restartPolicy: Never
-      serviceAccountName: rhaii-post-install-hook
+      serviceAccountName: rhai-post-install-hook
       imagePullSecrets:
-        - name: rhaii-pull-secret
+        - name: rhai-pull-secret
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -2815,7 +2815,7 @@ spec:
 
               echo "Step 2: Waiting for cert-manager CA secret required by Gateway CR 'inference-gateway'..."
               ELAPSED=0
-              until kubectl get secret rhaii-ca -n cert-manager >/dev/null 2>&1; do
+              until kubectl get secret rhai-ca -n cert-manager >/dev/null 2>&1; do
                 if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
                   echo "ERROR: Timed out waiting for CA secret after ${TIMEOUT}s"
                   exit 1
@@ -2827,9 +2827,9 @@ spec:
               echo "CA secret is available."
 
               echo "Step 3: Creating CA bundle ConfigMap for Gateway CR 'inference-gateway'..."
-              kubectl get secret rhaii-ca -n cert-manager \
+              kubectl get secret rhai-ca -n cert-manager \
                 -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
-              kubectl create configmap rhaii-ca-bundle \
+              kubectl create configmap rhai-ca-bundle \
                 --from-file=ca.crt=/tmp/ca.crt \
                 -n redhat-ods-applications \
                 --dry-run=client -o yaml | kubectl apply -f -
@@ -2848,14 +2848,14 @@ spec:
                     template:
                       spec:
                         volumes:
-                        - name: rhaii-ca-bundle
+                        - name: rhai-ca-bundle
                           configMap:
-                            name: rhaii-ca-bundle
+                            name: rhai-ca-bundle
                         containers:
                         - name: istio-proxy
                           volumeMounts:
-                          - name: rhaii-ca-bundle
-                            mountPath: /var/run/secrets/rhaii
+                          - name: rhai-ca-bundle
+                            mountPath: /var/run/secrets/rhai
                             readOnly: true
                 service: |
                   metadata:

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -48,7 +48,7 @@ metadata:
   name: coreweave-cloud-manager-operator
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 # TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
@@ -58,7 +58,7 @@ metadata:
   name: llmisvc-controller-manager
   namespace: redhat-ods-applications
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -67,13 +67,13 @@ metadata:
   name: rhai-operator-controller-manager
   namespace: redhat-ods-operator
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: redhat-ods-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -86,7 +86,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: redhat-ods-applications
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -99,7 +99,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -112,7 +112,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: rhai-cloudmanager-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -125,7 +125,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: cert-manager-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -138,7 +138,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: cert-manager
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -151,7 +151,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: openshift-lws-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -164,7 +164,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   namespace: istio-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2380,11 +2380,11 @@ spec:
             - name: RHAI_WEBHOOK_CERT_NAME
               value: rhai-operator-webhook-cert
             - name: RHAI_CA_SECRET_NAME
-              value: rhaii-ca
+              value: rhai-ca
             - name: RHAI_CA_SECRET_NAMESPACE
               value: cert-manager
             - name: RHAI_ISSUER_REF_NAME
-              value: rhaii-ca-issuer
+              value: rhai-ca-issuer
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2531,13 +2531,13 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME
-              value: rhaii-ca
+              value: rhai-ca
             - name: RHAI_CA_SECRET_NAMESPACE
               value: cert-manager
             - name: RHAI_ISSUER_REF_NAME
-              value: rhaii-ca-issuer
+              value: rhai-ca-issuer
             - name: RHAI_ISTIO_CA_CERTIFICATE_PATH
-              value: /var/run/secrets/rhaii/ca.crt
+              value: /var/run/secrets/rhai/ca.crt
             - name: OPERATOR_NAME
               value: rhai-operator
             - name: OPERATOR_NAMESPACE
@@ -2688,7 +2688,7 @@ webhooks:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2702,7 +2702,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -2771,7 +2771,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -2782,17 +2782,17 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
 subjects:
   - kind: ServiceAccount
-    name: rhaii-post-install-hook
+    name: rhai-post-install-hook
     namespace: default
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rhaii-post-install-crs
+  name: rhai-post-install-crs
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2810,9 +2810,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
     spec:
       restartPolicy: Never
-      serviceAccountName: rhaii-post-install-hook
+      serviceAccountName: rhai-post-install-hook
       imagePullSecrets:
-        - name: rhaii-pull-secret
+        - name: rhai-pull-secret
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -2880,7 +2880,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rhaii-post-create-gateway
+  name: rhai-post-create-gateway
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2898,9 +2898,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
     spec:
       restartPolicy: Never
-      serviceAccountName: rhaii-post-install-hook
+      serviceAccountName: rhai-post-install-hook
       imagePullSecrets:
-        - name: rhaii-pull-secret
+        - name: rhai-pull-secret
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -2951,7 +2951,7 @@ spec:
 
               echo "Step 2: Waiting for cert-manager CA secret required by Gateway CR 'inference-gateway'..."
               ELAPSED=0
-              until kubectl get secret rhaii-ca -n cert-manager >/dev/null 2>&1; do
+              until kubectl get secret rhai-ca -n cert-manager >/dev/null 2>&1; do
                 if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
                   echo "ERROR: Timed out waiting for CA secret after ${TIMEOUT}s"
                   exit 1
@@ -2963,9 +2963,9 @@ spec:
               echo "CA secret is available."
 
               echo "Step 3: Creating CA bundle ConfigMap for Gateway CR 'inference-gateway'..."
-              kubectl get secret rhaii-ca -n cert-manager \
+              kubectl get secret rhai-ca -n cert-manager \
                 -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
-              kubectl create configmap rhaii-ca-bundle \
+              kubectl create configmap rhai-ca-bundle \
                 --from-file=ca.crt=/tmp/ca.crt \
                 -n redhat-ods-applications \
                 --dry-run=client -o yaml | kubectl apply -f -
@@ -2984,14 +2984,14 @@ spec:
                     template:
                       spec:
                         volumes:
-                        - name: rhaii-ca-bundle
+                        - name: rhai-ca-bundle
                           configMap:
-                            name: rhaii-ca-bundle
+                            name: rhai-ca-bundle
                         containers:
                         - name: istio-proxy
                           volumeMounts:
-                          - name: rhaii-ca-bundle
-                            mountPath: /var/run/secrets/rhaii
+                          - name: rhai-ca-bundle
+                            mountPath: /var/run/secrets/rhai
                             readOnly: true
               EOF
               echo "ConfigMap used by Gateway CR 'inference-gateway' created."

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -24,7 +24,7 @@ metadata:
   name: coreweave-cloud-manager-operator
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -33,7 +33,7 @@ metadata:
   name: rhai-operator-controller-manager
   namespace: redhat-ods-operator
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/crds/customresourcedefinition-coreweavekubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -2242,11 +2242,11 @@ spec:
             - name: RHAI_WEBHOOK_CERT_NAME
               value: rhai-operator-webhook-cert
             - name: RHAI_CA_SECRET_NAME
-              value: rhaii-ca
+              value: rhai-ca
             - name: RHAI_CA_SECRET_NAMESPACE
               value: cert-manager
             - name: RHAI_ISSUER_REF_NAME
-              value: rhaii-ca-issuer
+              value: rhai-ca-issuer
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2393,13 +2393,13 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME
-              value: rhaii-ca
+              value: rhai-ca
             - name: RHAI_CA_SECRET_NAMESPACE
               value: cert-manager
             - name: RHAI_ISSUER_REF_NAME
-              value: rhaii-ca-issuer
+              value: rhai-ca-issuer
             - name: RHAI_ISTIO_CA_CERTIFICATE_PATH
-              value: /var/run/secrets/rhaii/ca.crt
+              value: /var/run/secrets/rhai/ca.crt
             - name: OPERATOR_NAME
               value: rhai-operator
             - name: OPERATOR_NAMESPACE
@@ -2550,7 +2550,7 @@ webhooks:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2564,7 +2564,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -2633,7 +2633,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -2644,17 +2644,17 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
 subjects:
   - kind: ServiceAccount
-    name: rhaii-post-install-hook
+    name: rhai-post-install-hook
     namespace: default
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rhaii-post-install-crs
+  name: rhai-post-install-crs
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2672,9 +2672,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
     spec:
       restartPolicy: Never
-      serviceAccountName: rhaii-post-install-hook
+      serviceAccountName: rhai-post-install-hook
       imagePullSecrets:
-        - name: rhaii-pull-secret
+        - name: rhai-pull-secret
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -2742,7 +2742,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rhaii-post-create-gateway
+  name: rhai-post-create-gateway
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2760,9 +2760,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
     spec:
       restartPolicy: Never
-      serviceAccountName: rhaii-post-install-hook
+      serviceAccountName: rhai-post-install-hook
       imagePullSecrets:
-        - name: rhaii-pull-secret
+        - name: rhai-pull-secret
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -2813,7 +2813,7 @@ spec:
 
               echo "Step 2: Waiting for cert-manager CA secret required by Gateway CR 'inference-gateway'..."
               ELAPSED=0
-              until kubectl get secret rhaii-ca -n cert-manager >/dev/null 2>&1; do
+              until kubectl get secret rhai-ca -n cert-manager >/dev/null 2>&1; do
                 if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
                   echo "ERROR: Timed out waiting for CA secret after ${TIMEOUT}s"
                   exit 1
@@ -2825,9 +2825,9 @@ spec:
               echo "CA secret is available."
 
               echo "Step 3: Creating CA bundle ConfigMap for Gateway CR 'inference-gateway'..."
-              kubectl get secret rhaii-ca -n cert-manager \
+              kubectl get secret rhai-ca -n cert-manager \
                 -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
-              kubectl create configmap rhaii-ca-bundle \
+              kubectl create configmap rhai-ca-bundle \
                 --from-file=ca.crt=/tmp/ca.crt \
                 -n redhat-ods-applications \
                 --dry-run=client -o yaml | kubectl apply -f -
@@ -2846,14 +2846,14 @@ spec:
                     template:
                       spec:
                         volumes:
-                        - name: rhaii-ca-bundle
+                        - name: rhai-ca-bundle
                           configMap:
-                            name: rhaii-ca-bundle
+                            name: rhai-ca-bundle
                         containers:
                         - name: istio-proxy
                           volumeMounts:
-                          - name: rhaii-ca-bundle
-                            mountPath: /var/run/secrets/rhaii
+                          - name: rhai-ca-bundle
+                            mountPath: /var/run/secrets/rhai
                             readOnly: true
               EOF
               echo "ConfigMap used by Gateway CR 'inference-gateway' created."

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -24,7 +24,7 @@ metadata:
   name: azure-cloud-manager-operator
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -33,7 +33,7 @@ metadata:
   name: rhai-operator-controller-manager
   namespace: rhai-operator
 imagePullSecrets:
-  - name: rhaii-pull-secret
+  - name: rhai-pull-secret
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/crds/customresourcedefinition-azurekubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -2242,11 +2242,11 @@ spec:
             - name: RHAI_WEBHOOK_CERT_NAME
               value: rhai-operator-webhook-cert
             - name: RHAI_CA_SECRET_NAME
-              value: rhaii-ca
+              value: rhai-ca
             - name: RHAI_CA_SECRET_NAMESPACE
               value: cert-manager
             - name: RHAI_ISSUER_REF_NAME
-              value: rhaii-ca-issuer
+              value: rhai-ca-issuer
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -2393,13 +2393,13 @@ spec:
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME
-              value: rhaii-ca
+              value: rhai-ca
             - name: RHAI_CA_SECRET_NAMESPACE
               value: cert-manager
             - name: RHAI_ISSUER_REF_NAME
-              value: rhaii-ca-issuer
+              value: rhai-ca-issuer
             - name: RHAI_ISTIO_CA_CERTIFICATE_PATH
-              value: /var/run/secrets/rhaii/ca.crt
+              value: /var/run/secrets/rhai/ca.crt
             - name: OPERATOR_NAME
               value: rhai-operator
             - name: OPERATOR_NAMESPACE
@@ -2550,7 +2550,7 @@ webhooks:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2564,7 +2564,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -2633,7 +2633,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -2644,17 +2644,17 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhaii-post-install-hook
+  name: rhai-post-install-hook
 subjects:
   - kind: ServiceAccount
-    name: rhaii-post-install-hook
+    name: rhai-post-install-hook
     namespace: default
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rhaii-post-install-crs
+  name: rhai-post-install-crs
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2672,9 +2672,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
     spec:
       restartPolicy: Never
-      serviceAccountName: rhaii-post-install-hook
+      serviceAccountName: rhai-post-install-hook
       imagePullSecrets:
-        - name: rhaii-pull-secret
+        - name: rhai-pull-secret
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -2742,7 +2742,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rhaii-post-create-gateway
+  name: rhai-post-create-gateway
   namespace: default
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -2760,9 +2760,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
     spec:
       restartPolicy: Never
-      serviceAccountName: rhaii-post-install-hook
+      serviceAccountName: rhai-post-install-hook
       imagePullSecrets:
-        - name: rhaii-pull-secret
+        - name: rhai-pull-secret
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -2813,7 +2813,7 @@ spec:
 
               echo "Step 2: Waiting for cert-manager CA secret required by Gateway CR 'inference-gateway'..."
               ELAPSED=0
-              until kubectl get secret rhaii-ca -n cert-manager >/dev/null 2>&1; do
+              until kubectl get secret rhai-ca -n cert-manager >/dev/null 2>&1; do
                 if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
                   echo "ERROR: Timed out waiting for CA secret after ${TIMEOUT}s"
                   exit 1
@@ -2825,9 +2825,9 @@ spec:
               echo "CA secret is available."
 
               echo "Step 3: Creating CA bundle ConfigMap for Gateway CR 'inference-gateway'..."
-              kubectl get secret rhaii-ca -n cert-manager \
+              kubectl get secret rhai-ca -n cert-manager \
                 -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
-              kubectl create configmap rhaii-ca-bundle \
+              kubectl create configmap rhai-ca-bundle \
                 --from-file=ca.crt=/tmp/ca.crt \
                 -n rhai-applications \
                 --dry-run=client -o yaml | kubectl apply -f -
@@ -2846,14 +2846,14 @@ spec:
                     template:
                       spec:
                         volumes:
-                        - name: rhaii-ca-bundle
+                        - name: rhai-ca-bundle
                           configMap:
-                            name: rhaii-ca-bundle
+                            name: rhai-ca-bundle
                         containers:
                         - name: istio-proxy
                           volumeMounts:
-                          - name: rhaii-ca-bundle
-                            mountPath: /var/run/secrets/rhaii
+                          - name: rhai-ca-bundle
+                            mountPath: /var/run/secrets/rhai
                             readOnly: true
                 service: |
                   metadata:

--- a/charts/rhai-on-xks-chart/values.schema.json
+++ b/charts/rhai-on-xks-chart/values.schema.json
@@ -247,8 +247,8 @@
         "name": {
           "type": "string",
           "description": "Name of the pull secret to create in target namespaces",
-          "default": "rhaii-pull-secret",
-          "const": "rhaii-pull-secret"
+          "default": "rhai-pull-secret",
+          "const": "rhai-pull-secret"
         },
         "dockerConfigJson": {
           "type": "string",

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -100,7 +100,7 @@ coreweave:
 imagePullSecret:
   # Name of the pull secret to create in target namespaces. This name MUST not be changed
   # as it is referred also in other installed dependencies and not yet configurable.
-  name: rhaii-pull-secret
+  name: rhai-pull-secret
   # Docker config JSON content (populated via --set-file)
   dockerConfigJson: ""
   # Namespaces created by dependency operators where pull secrets should be injected


### PR DESCRIPTION


<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- keep profile as rhaii
- keep exmpale namespace rhaii-gitops , release name rhaii
- follow up https://github.com/opendatahub-io/opendatahub-operator/pull/3419#discussion_r3091305017

Jira task: <!--- Link your JIRA and related links here for reference. -->
https://redhat.atlassian.net/browse/INFERENG-6113
## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->

- [ ] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized resource names across charts: renamed pull secrets, cert/issuer identifiers, mount paths, and post-install hook resource names for consistency; updated chart defaults and schema to the new names; updated snapshots and rendered manifests accordingly.
  * Bumped sail-operator bundle version to 3.2.3.

* **Documentation**
  * Updated chart README and API docs to reflect the renamed resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->