### PR TITLE
update: bump sail opereator version from 3.2.1 to 3.3.0

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -20,7 +20,7 @@ Extracted from Red Hat operator bundles for deploying operators on vanilla Kuber
 | [`cert-manager-operator`](dependencies/cert-manager-operator/) | v1.18.1 | `cert-manager-operator` / `cert-manager` | Red Hat cert-manager Operator |
 | [`gateway-api`](dependencies/gateway-api/) | v1.4.0 | cluster-scoped | [Kubernetes Gateway API](https://github.com/kubernetes-sigs/gateway-api) CRDs |
 | [`lws-operator`](dependencies/lws-operator/) | 1.0 | `openshift-lws-operator` | Leader-Worker-Set Operator |
-| [`sail-operator`](dependencies/sail-operator/) | 3.2.1 (Istio up to v1.27.3) | `istio-system` | Red Hat Sail (Istio) Operator |
+| [`sail-operator`](dependencies/sail-operator/) | 3.3.0 (Istio up to v1.28.5) | `istio-system` | Red Hat Sail (Istio) Operator |
 
 ---
 
@@ -263,7 +263,7 @@ podman login registry.redhat.io
 ```bash
 ./charts/dependencies/cert-manager-operator/scripts/update-bundle.sh v1.18.1
 ./charts/dependencies/lws-operator/scripts/update-bundle.sh 1.0
-./charts/dependencies/sail-operator/scripts/update-bundle.sh 3.2.1
+./charts/dependencies/sail-operator/scripts/update-bundle.sh 3.3.0
 ```
 
 The scripts:

--- a/charts/dependencies/sail-operator/Chart.yaml
+++ b/charts/dependencies/sail-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: sail-operator
 description: Red Hat Sail Operator (OSSM 3.x) for Kubernetes
 type: application
 version: 1.0.0
-appVersion: "3.2.1"
+appVersion: "3.3.0"
 keywords:
   - istio
   - service-mesh

--- a/charts/dependencies/sail-operator/api-docs.md
+++ b/charts/dependencies/sail-operator/api-docs.md
@@ -1,6 +1,6 @@
 # sail-operator
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.1](https://img.shields.io/badge/AppVersion-3.2.1-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
 
 Red Hat Sail Operator (OSSM 3.x) for Kubernetes
 
@@ -18,7 +18,7 @@ Red Hat Sail Operator (OSSM 3.x) for Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| bundle.version | string | `"3.2.1"` |  |
+| bundle.version | string | `"3.3"` |  |
 | imagePullSecrets[0].name | string | `"rhaii-pull-secret"` |  |
 | namespace | string | `"istio-system"` |  |
 

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-authorizationpolicies-security-istio-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-authorizationpolicies-security-istio-io.yaml
@@ -378,7 +378,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -735,6 +735,6 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-destinationrules-networking-istio-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-destinationrules-networking-istio-io.yaml
@@ -202,6 +202,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -517,6 +531,20 @@ spec:
                                         httpCookie:
                                           description: Hash based on HTTP cookie.
                                           properties:
+                                            attributes:
+                                              description: Additional attributes for the cookie.
+                                              items:
+                                                properties:
+                                                  name:
+                                                    description: The name of the cookie attribute.
+                                                    type: string
+                                                  value:
+                                                    description: The optional value of the cookie attribute.
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
                                             name:
                                               description: Name of the cookie.
                                               type: string
@@ -978,6 +1006,20 @@ spec:
                             httpCookie:
                               description: Hash based on HTTP cookie.
                               properties:
+                                attributes:
+                                  description: Additional attributes for the cookie.
+                                  items:
+                                    properties:
+                                      name:
+                                        description: The name of the cookie attribute.
+                                        type: string
+                                      value:
+                                        description: The optional value of the cookie attribute.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
                                 name:
                                   description: Name of the cookie.
                                   type: string
@@ -1293,6 +1335,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -1883,6 +1939,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -2198,6 +2268,20 @@ spec:
                                         httpCookie:
                                           description: Hash based on HTTP cookie.
                                           properties:
+                                            attributes:
+                                              description: Additional attributes for the cookie.
+                                              items:
+                                                properties:
+                                                  name:
+                                                    description: The name of the cookie attribute.
+                                                    type: string
+                                                  value:
+                                                    description: The optional value of the cookie attribute.
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
                                             name:
                                               description: Name of the cookie.
                                               type: string
@@ -2659,6 +2743,20 @@ spec:
                             httpCookie:
                               description: Hash based on HTTP cookie.
                               properties:
+                                attributes:
+                                  description: Additional attributes for the cookie.
+                                  items:
+                                    properties:
+                                      name:
+                                        description: The name of the cookie attribute.
+                                        type: string
+                                      value:
+                                        description: The optional value of the cookie attribute.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
                                 name:
                                   description: Name of the cookie.
                                   type: string
@@ -2974,6 +3072,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -3564,6 +3676,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string
@@ -3879,6 +4005,20 @@ spec:
                                         httpCookie:
                                           description: Hash based on HTTP cookie.
                                           properties:
+                                            attributes:
+                                              description: Additional attributes for the cookie.
+                                              items:
+                                                properties:
+                                                  name:
+                                                    description: The name of the cookie attribute.
+                                                    type: string
+                                                  value:
+                                                    description: The optional value of the cookie attribute.
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
                                             name:
                                               description: Name of the cookie.
                                               type: string
@@ -4340,6 +4480,20 @@ spec:
                             httpCookie:
                               description: Hash based on HTTP cookie.
                               properties:
+                                attributes:
+                                  description: Additional attributes for the cookie.
+                                  items:
+                                    properties:
+                                      name:
+                                        description: The name of the cookie attribute.
+                                        type: string
+                                      value:
+                                        description: The optional value of the cookie attribute.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
                                 name:
                                   description: Name of the cookie.
                                   type: string
@@ -4655,6 +4809,20 @@ spec:
                                   httpCookie:
                                     description: Hash based on HTTP cookie.
                                     properties:
+                                      attributes:
+                                        description: Additional attributes for the cookie.
+                                        items:
+                                          properties:
+                                            name:
+                                              description: The name of the cookie attribute.
+                                              type: string
+                                            value:
+                                              description: The optional value of the cookie attribute.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
                                       name:
                                         description: Name of the cookie.
                                         type: string

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-gateways-networking-istio-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-gateways-networking-istio-io.yaml
@@ -78,6 +78,9 @@ spec:
                       tls:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -320,6 +323,9 @@ spec:
                       tls:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -562,6 +568,9 @@ spec:
                       tls:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-istiocnis-sailoperator-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-istiocnis-sailoperator-io.yaml
@@ -21,7 +21,7 @@ spec:
           name: Namespace
           type: string
         - description: The selected profile (collection of value presets).
-          jsonPath: .spec.values.profile
+          jsonPath: .spec.profile
           name: Profile
           type: string
         - description: Whether the Istio CNI installation is ready to handle requests.
@@ -65,7 +65,7 @@ spec:
             spec:
               default:
                 namespace: istio-cni
-                version: v1.27.3
+                version: v1.28.5
               description: IstioCNISpec defines the desired state of IstioCNI
               properties:
                 namespace:
@@ -1009,6 +1009,11 @@ spec:
                             The directory path within the cluster node's filesystem where network namespaces are located.
                             Defaults to '/var/run/netns', in minikube/docker/others can be '/var/run/docker/netns'.
                           type: string
+                        daemonSetLabels:
+                          additionalProperties:
+                            type: string
+                          description: Additional labels to apply to the istio-cni DaemonSet.
+                          type: object
                         env:
                           additionalProperties:
                             type: string
@@ -1056,6 +1061,11 @@ spec:
                             Additional annotations to apply to the istio-cni Pods.
 
                             Deprecated: Marked as deprecated in pkg/apis/values_types.proto.
+                          type: object
+                        podLabels:
+                          additionalProperties:
+                            type: string
+                          description: Additional labels to apply to the istio-cni Pods.
                           type: object
                         privileged:
                           description: |-
@@ -1140,7 +1150,7 @@ spec:
                               type: string
                           type: object
                         resource_quotas:
-                          description: The resource quotas configration for the CNI DaemonSet.
+                          description: The resource quotas configuration for the CNI DaemonSet.
                           properties:
                             enabled:
                               description: Controls whether to create resource quotas or not for the CNI DaemonSet.
@@ -1370,23 +1380,24 @@ spec:
                       type: object
                   type: object
                 version:
-                  default: v1.27.3
+                  default: v1.28.5
                   description: |-
                     Defines the version of Istio to install.
-                    Must be one of: v1.27-latest, v1.27.3, v1.26-latest, v1.26.6, v1.26.4, v1.26.3, v1.26.2, v1.24-latest, v1.24.6, v1.24.5, v1.24.4, v1.24.3.
+                    Must be one of: v1.28-latest, v1.28.5, v1.28.4, v1.27-latest, v1.27.8, v1.27.5, v1.27.3, v1.26-latest, v1.26.8, v1.26.6, v1.26.4, v1.26.3, v1.26.2.
                   enum:
+                    - v1.28-latest
+                    - v1.28.5
+                    - v1.28.4
                     - v1.27-latest
+                    - v1.27.8
+                    - v1.27.5
                     - v1.27.3
                     - v1.26-latest
+                    - v1.26.8
                     - v1.26.6
                     - v1.26.4
                     - v1.26.3
                     - v1.26.2
-                    - v1.24-latest
-                    - v1.24.6
-                    - v1.24.5
-                    - v1.24.4
-                    - v1.24.3
                   type: string
               required:
                 - namespace

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-istiorevisions-sailoperator-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-istiorevisions-sailoperator-io.yaml
@@ -114,8 +114,7 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                     gatewayClasses:
                       description: Configuration for Gateway Classes
-                      format: byte
-                      type: string
+                      x-kubernetes-preserve-unknown-fields: true
                     global:
                       description: Global configuration for Istio components.
                       properties:
@@ -1075,6 +1074,16 @@ spec:
                           type: object
                         remotePilotAddress:
                           description: Specifies the Istio control plane’s pilot Pod IP address or remote cluster DNS resolvable hostname.
+                          type: string
+                        resourceScope:
+                          description: |-
+                            Specifies resource scope for discovery selectors.
+                            This is useful when installing Istio on a cluster where some resources need to be owned by a cluster administrator and some can be owned by the mesh administrator.
+                          enum:
+                            - undefined
+                            - all
+                            - cluster
+                            - namespace
                           type: string
                         revision:
                           description: Configures the revision this control plane is a part of
@@ -3409,6 +3418,25 @@ spec:
                                         true.
                                       type: boolean
                                   type: object
+                                xForwardedHost:
+                                  description: |-
+                                    Controls the `X-Forwarded-Host` header. If enabled, the `X-Forwarded-Host` header is appended
+                                    with the original host when it is rewritten.
+                                    This header is disabled by default.
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                xForwardedPort:
+                                  description: |-
+                                    Controls the `X-Forwarded-Port` header. If enabled, the `X-Forwarded-Port` header is header with the port value
+                                    client used to connect to Envoy. It will be ignored if the “x-forwarded-port“ header has been set by any
+                                    trusted proxy in front of Envoy.
+                                    This header is disabled by default.
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
                               type: object
                             proxyMetadata:
                               additionalProperties:
@@ -5241,6 +5269,15 @@ spec:
                                       service defined by the Kubernetes service or ServiceEntry.
 
                                       Example: "zipkin.default.svc.cluster.local" or "bar/zipkin.example.com".
+                                    type: string
+                                  traceContextOption:
+                                    description: |-
+                                      Optional. Determines which trace context format to use for trace header extraction and propagation.
+                                      This controls both downstream request header extraction and upstream request header injection.
+                                      The default value is USE_B3 to maintain backward compatibility.
+                                    enum:
+                                      - USE_B3
+                                      - USE_B3_WITH_W3C_PROPAGATION
                                     type: string
                                 required:
                                   - port
@@ -9689,17 +9726,18 @@ spec:
                 version:
                   description: |-
                     Defines the version of Istio to install.
-                    Must be one of: v1.27.3, v1.26.6, v1.26.4, v1.26.3, v1.26.2, v1.24.6, v1.24.5, v1.24.4, v1.24.3.
+                    Must be one of: v1.28.5, v1.28.4, v1.27.8, v1.27.5, v1.27.3, v1.26.8, v1.26.6, v1.26.4, v1.26.3, v1.26.2.
                   enum:
+                    - v1.28.5
+                    - v1.28.4
+                    - v1.27.8
+                    - v1.27.5
                     - v1.27.3
+                    - v1.26.8
                     - v1.26.6
                     - v1.26.4
                     - v1.26.3
                     - v1.26.2
-                    - v1.24.6
-                    - v1.24.5
-                    - v1.24.4
-                    - v1.24.3
                   type: string
               required:
                 - namespace

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-istios-sailoperator-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-istios-sailoperator-io.yaml
@@ -21,7 +21,7 @@ spec:
           name: Namespace
           type: string
         - description: The selected profile (collection of value presets).
-          jsonPath: .spec.values.profile
+          jsonPath: .spec.profile
           name: Profile
           type: string
         - description: Total number of IstioRevision objects currently associated with this object.
@@ -86,7 +86,7 @@ spec:
                 namespace: istio-system
                 updateStrategy:
                   type: InPlace
-                version: v1.27.3
+                version: v1.28.5
               description: IstioSpec defines the desired state of Istio
               properties:
                 namespace:
@@ -184,8 +184,7 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                     gatewayClasses:
                       description: Configuration for Gateway Classes
-                      format: byte
-                      type: string
+                      x-kubernetes-preserve-unknown-fields: true
                     global:
                       description: Global configuration for Istio components.
                       properties:
@@ -1145,6 +1144,16 @@ spec:
                           type: object
                         remotePilotAddress:
                           description: Specifies the Istio control plane’s pilot Pod IP address or remote cluster DNS resolvable hostname.
+                          type: string
+                        resourceScope:
+                          description: |-
+                            Specifies resource scope for discovery selectors.
+                            This is useful when installing Istio on a cluster where some resources need to be owned by a cluster administrator and some can be owned by the mesh administrator.
+                          enum:
+                            - undefined
+                            - all
+                            - cluster
+                            - namespace
                           type: string
                         revision:
                           description: Configures the revision this control plane is a part of
@@ -3479,6 +3488,25 @@ spec:
                                         true.
                                       type: boolean
                                   type: object
+                                xForwardedHost:
+                                  description: |-
+                                    Controls the `X-Forwarded-Host` header. If enabled, the `X-Forwarded-Host` header is appended
+                                    with the original host when it is rewritten.
+                                    This header is disabled by default.
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
+                                xForwardedPort:
+                                  description: |-
+                                    Controls the `X-Forwarded-Port` header. If enabled, the `X-Forwarded-Port` header is header with the port value
+                                    client used to connect to Envoy. It will be ignored if the “x-forwarded-port“ header has been set by any
+                                    trusted proxy in front of Envoy.
+                                    This header is disabled by default.
+                                  properties:
+                                    enabled:
+                                      type: boolean
+                                  type: object
                               type: object
                             proxyMetadata:
                               additionalProperties:
@@ -5311,6 +5339,15 @@ spec:
                                       service defined by the Kubernetes service or ServiceEntry.
 
                                       Example: "zipkin.default.svc.cluster.local" or "bar/zipkin.example.com".
+                                    type: string
+                                  traceContextOption:
+                                    description: |-
+                                      Optional. Determines which trace context format to use for trace header extraction and propagation.
+                                      This controls both downstream request header extraction and upstream request header injection.
+                                      The default value is USE_B3 to maintain backward compatibility.
+                                    enum:
+                                      - USE_B3
+                                      - USE_B3_WITH_W3C_PROPAGATION
                                     type: string
                                 required:
                                   - port
@@ -9757,23 +9794,24 @@ spec:
                       type: object
                   type: object
                 version:
-                  default: v1.27.3
+                  default: v1.28.5
                   description: |-
                     Defines the version of Istio to install.
-                    Must be one of: v1.27-latest, v1.27.3, v1.26-latest, v1.26.6, v1.26.4, v1.26.3, v1.26.2, v1.24-latest, v1.24.6, v1.24.5, v1.24.4, v1.24.3.
+                    Must be one of: v1.28-latest, v1.28.5, v1.28.4, v1.27-latest, v1.27.8, v1.27.5, v1.27.3, v1.26-latest, v1.26.8, v1.26.6, v1.26.4, v1.26.3, v1.26.2.
                   enum:
+                    - v1.28-latest
+                    - v1.28.5
+                    - v1.28.4
                     - v1.27-latest
+                    - v1.27.8
+                    - v1.27.5
                     - v1.27.3
                     - v1.26-latest
+                    - v1.26.8
                     - v1.26.6
                     - v1.26.4
                     - v1.26.3
                     - v1.26.2
-                    - v1.24-latest
-                    - v1.24.6
-                    - v1.24.5
-                    - v1.24.4
-                    - v1.24.3
                   type: string
               required:
                 - namespace

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-peerauthentications-security-istio-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-peerauthentications-security-istio-io.yaml
@@ -171,7 +171,7 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -321,6 +321,6 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-requestauthentications-security-istio-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-requestauthentications-security-istio-io.yaml
@@ -115,267 +115,13 @@ spec:
                       outputPayloadToHeader:
                         description: This field specifies the header name to output a successfully verified JWT payload to the backend.
                         type: string
-                      timeout:
-                        description: The maximum amount of time that the resolver, determined by the PILOT_JWT_ENABLE_REMOTE_JWKS environment variable, will spend waiting for the JWKS to be fetched.
-                        type: string
-                        x-kubernetes-validations:
-                          - message: must be a valid duration greater than 1ms
-                            rule: duration(self) >= duration('1ms')
-                    type: object
-                    x-kubernetes-validations:
-                      - message: only one of jwks or jwksUri can be set
-                        rule: '(has(self.jwksUri) ? 1 : 0) + (has(self.jwks_uri) ? 1 : 0) + (has(self.jwks) ? 1 : 0) <= 1'
-                  maxItems: 4096
-                  type: array
-                selector:
-                  description: Optional.
-                  properties:
-                    matchLabels:
-                      additionalProperties:
-                        maxLength: 63
-                        type: string
-                        x-kubernetes-validations:
-                          - message: wildcard not allowed in label value match
-                            rule: '!self.contains("*")'
-                      description: One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.
-                      maxProperties: 4096
-                      type: object
-                      x-kubernetes-validations:
-                        - message: wildcard not allowed in label key match
-                          rule: self.all(key, !key.contains("*"))
-                        - message: key must not be empty
-                          rule: self.all(key, key.size() != 0)
-                  type: object
-                targetRef:
-                  properties:
-                    group:
-                      description: group is the group of the target resource.
-                      maxLength: 253
-                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                    kind:
-                      description: kind is kind of the target resource.
-                      maxLength: 63
-                      minLength: 1
-                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                      type: string
-                    name:
-                      description: name is the name of the target resource.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: namespace is the namespace of the referent.
-                      type: string
-                      x-kubernetes-validations:
-                        - message: cross namespace referencing is not currently supported
-                          rule: self.size() == 0
-                  required:
-                    - kind
-                    - name
-                  type: object
-                targetRefs:
-                  description: Optional.
-                  items:
-                    properties:
-                      group:
-                        description: group is the group of the target resource.
-                        maxLength: 253
-                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                        type: string
-                      kind:
-                        description: kind is kind of the target resource.
-                        maxLength: 63
-                        minLength: 1
-                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                        type: string
-                      name:
-                        description: name is the name of the target resource.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      namespace:
-                        description: namespace is the namespace of the referent.
-                        type: string
-                        x-kubernetes-validations:
-                          - message: cross namespace referencing is not currently supported
-                            rule: self.size() == 0
-                    required:
-                      - kind
-                      - name
-                    type: object
-                  maxItems: 16
-                  type: array
-              type: object
-              x-kubernetes-validations:
-                - message: only one of targetRefs or selector can be set
-                  rule: '(has(self.selector) ? 1 : 0) + (has(self.targetRef) ? 1 : 0) + (has(self.targetRefs) ? 1 : 0) <= 1'
-            status:
-              properties:
-                conditions:
-                  description: Current service state of the resource.
-                  items:
-                    properties:
-                      lastProbeTime:
-                        description: Last time we probed the condition.
-                        format: date-time
-                        type: string
-                      lastTransitionTime:
-                        description: Last time the condition transitioned from one status to another.
-                        format: date-time
-                        type: string
-                      message:
-                        description: Human-readable message indicating details about last transition.
-                        type: string
-                      observedGeneration:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        description: Resource Generation to which the Condition refers.
-                        x-kubernetes-int-or-string: true
-                      reason:
-                        description: Unique, one-word, CamelCase reason for the condition's last transition.
-                        type: string
-                      status:
-                        description: Status is the status of the condition.
-                        type: string
-                      type:
-                        description: Type is the type of the condition.
-                        type: string
-                    type: object
-                  type: array
-                observedGeneration:
-                  anyOf:
-                    - type: integer
-                    - type: string
-                  x-kubernetes-int-or-string: true
-                validationMessages:
-                  description: Includes any errors or warnings detected by Istio's analyzers.
-                  items:
-                    properties:
-                      documentationUrl:
-                        description: A url pointing to the Istio documentation for this specific error type.
-                        type: string
-                      level:
-                        description: |-
-                          Represents how severe a message is.
-
-                          Valid Options: UNKNOWN, ERROR, WARNING, INFO
-                        enum:
-                          - UNKNOWN
-                          - ERROR
-                          - WARNING
-                          - INFO
-                        type: string
-                      type:
-                        properties:
-                          code:
-                            description: A 7 character code matching `^IST[0-9]{4}$` intended to uniquely identify the message type.
-                            type: string
-                          name:
-                            description: A human-readable name for the message type.
-                            type: string
-                        type: object
-                    type: object
-                  type: array
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          properties:
-            spec:
-              description: 'Request authentication configuration for workloads. See more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
-              properties:
-                jwtRules:
-                  description: Define the list of JWTs that can be validated at the selected workloads' proxy.
-                  items:
-                    properties:
-                      audiences:
-                        description: The list of JWT [audiences](https://tools.ietf.org/html/rfc7519#section-4.1.3) that are allowed to access.
+                      spaceDelimitedClaims:
+                        description: List of JWT claim names that should be treated as space-delimited strings.
                         items:
                           minLength: 1
                           type: string
+                        maxItems: 64
                         type: array
-                      forwardOriginalToken:
-                        description: If set to true, the original token will be kept for the upstream request.
-                        type: boolean
-                      fromCookies:
-                        description: List of cookie names from which JWT is expected.
-                        items:
-                          minLength: 1
-                          type: string
-                        type: array
-                      fromHeaders:
-                        description: List of header locations from which JWT is expected.
-                        items:
-                          properties:
-                            name:
-                              description: The HTTP header name.
-                              minLength: 1
-                              type: string
-                            prefix:
-                              description: The prefix that should be stripped before decoding the token.
-                              type: string
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      fromParams:
-                        description: List of query parameters from which JWT is expected.
-                        items:
-                          minLength: 1
-                          type: string
-                        type: array
-                      issuer:
-                        description: Identifies the issuer that issued the JWT.
-                        minLength: 1
-                        type: string
-                      jwks:
-                        description: JSON Web Key Set of public keys to validate signature of the JWT.
-                        type: string
-                      jwks_uri:
-                        description: URL of the provider's public key set to validate signature of the JWT.
-                        maxLength: 2048
-                        minLength: 1
-                        type: string
-                        x-kubernetes-validations:
-                          - message: url must have scheme http:// or https://
-                            rule: url(self).getScheme() in ["http", "https"]
-                      jwksUri:
-                        description: URL of the provider's public key set to validate signature of the JWT.
-                        maxLength: 2048
-                        minLength: 1
-                        type: string
-                        x-kubernetes-validations:
-                          - message: url must have scheme http:// or https://
-                            rule: url(self).getScheme() in ["http", "https"]
-                      outputClaimToHeaders:
-                        description: This field specifies a list of operations to copy the claim to HTTP headers on a successfully verified token.
-                        items:
-                          properties:
-                            claim:
-                              description: The name of the claim to be copied from.
-                              minLength: 1
-                              type: string
-                            header:
-                              description: The name of the header to be created.
-                              minLength: 1
-                              pattern: ^[-_A-Za-z0-9]+$
-                              type: string
-                          required:
-                            - header
-                            - claim
-                          type: object
-                        type: array
-                      outputPayloadToHeader:
-                        description: This field specifies the header name to output a successfully verified JWT payload to the backend.
-                        type: string
                       timeout:
                         description: The maximum amount of time that the resolver, determined by the PILOT_JWT_ENABLE_REMOTE_JWKS environment variable, will spend waiting for the JWKS to be fetched.
                         type: string
@@ -544,5 +290,273 @@ spec:
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Request authentication configuration for workloads. See more details at: https://istio.io/docs/reference/config/security/request_authentication.html'
+              properties:
+                jwtRules:
+                  description: Define the list of JWTs that can be validated at the selected workloads' proxy.
+                  items:
+                    properties:
+                      audiences:
+                        description: The list of JWT [audiences](https://tools.ietf.org/html/rfc7519#section-4.1.3) that are allowed to access.
+                        items:
+                          minLength: 1
+                          type: string
+                        type: array
+                      forwardOriginalToken:
+                        description: If set to true, the original token will be kept for the upstream request.
+                        type: boolean
+                      fromCookies:
+                        description: List of cookie names from which JWT is expected.
+                        items:
+                          minLength: 1
+                          type: string
+                        type: array
+                      fromHeaders:
+                        description: List of header locations from which JWT is expected.
+                        items:
+                          properties:
+                            name:
+                              description: The HTTP header name.
+                              minLength: 1
+                              type: string
+                            prefix:
+                              description: The prefix that should be stripped before decoding the token.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                      fromParams:
+                        description: List of query parameters from which JWT is expected.
+                        items:
+                          minLength: 1
+                          type: string
+                        type: array
+                      issuer:
+                        description: Identifies the issuer that issued the JWT.
+                        minLength: 1
+                        type: string
+                      jwks:
+                        description: JSON Web Key Set of public keys to validate signature of the JWT.
+                        type: string
+                      jwks_uri:
+                        description: URL of the provider's public key set to validate signature of the JWT.
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                          - message: url must have scheme http:// or https://
+                            rule: url(self).getScheme() in ["http", "https"]
+                      jwksUri:
+                        description: URL of the provider's public key set to validate signature of the JWT.
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                          - message: url must have scheme http:// or https://
+                            rule: url(self).getScheme() in ["http", "https"]
+                      outputClaimToHeaders:
+                        description: This field specifies a list of operations to copy the claim to HTTP headers on a successfully verified token.
+                        items:
+                          properties:
+                            claim:
+                              description: The name of the claim to be copied from.
+                              minLength: 1
+                              type: string
+                            header:
+                              description: The name of the header to be created.
+                              minLength: 1
+                              pattern: ^[-_A-Za-z0-9]+$
+                              type: string
+                          required:
+                            - header
+                            - claim
+                          type: object
+                        type: array
+                      outputPayloadToHeader:
+                        description: This field specifies the header name to output a successfully verified JWT payload to the backend.
+                        type: string
+                      spaceDelimitedClaims:
+                        description: List of JWT claim names that should be treated as space-delimited strings.
+                        items:
+                          minLength: 1
+                          type: string
+                        maxItems: 64
+                        type: array
+                      timeout:
+                        description: The maximum amount of time that the resolver, determined by the PILOT_JWT_ENABLE_REMOTE_JWKS environment variable, will spend waiting for the JWKS to be fetched.
+                        type: string
+                        x-kubernetes-validations:
+                          - message: must be a valid duration greater than 1ms
+                            rule: duration(self) >= duration('1ms')
+                    type: object
+                    x-kubernetes-validations:
+                      - message: only one of jwks or jwksUri can be set
+                        rule: '(has(self.jwksUri) ? 1 : 0) + (has(self.jwks_uri) ? 1 : 0) + (has(self.jwks) ? 1 : 0) <= 1'
+                  maxItems: 4096
+                  type: array
+                selector:
+                  description: Optional.
+                  properties:
+                    matchLabels:
+                      additionalProperties:
+                        maxLength: 63
+                        type: string
+                        x-kubernetes-validations:
+                          - message: wildcard not allowed in label value match
+                            rule: '!self.contains("*")'
+                      description: One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.
+                      maxProperties: 4096
+                      type: object
+                      x-kubernetes-validations:
+                        - message: wildcard not allowed in label key match
+                          rule: self.all(key, !key.contains("*"))
+                        - message: key must not be empty
+                          rule: self.all(key, key.size() != 0)
+                  type: object
+                targetRef:
+                  properties:
+                    group:
+                      description: group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: namespace is the namespace of the referent.
+                      type: string
+                      x-kubernetes-validations:
+                        - message: cross namespace referencing is not currently supported
+                          rule: self.size() == 0
+                  required:
+                    - kind
+                    - name
+                  type: object
+                targetRefs:
+                  description: Optional.
+                  items:
+                    properties:
+                      group:
+                        description: group is the group of the target resource.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: kind is kind of the target resource.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: name is the name of the target resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the referent.
+                        type: string
+                        x-kubernetes-validations:
+                          - message: cross namespace referencing is not currently supported
+                            rule: self.size() == 0
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  maxItems: 16
+                  type: array
+              type: object
+              x-kubernetes-validations:
+                - message: only one of targetRefs or selector can be set
+                  rule: '(has(self.selector) ? 1 : 0) + (has(self.targetRef) ? 1 : 0) + (has(self.targetRefs) ? 1 : 0) <= 1'
+            status:
+              properties:
+                conditions:
+                  description: Current service state of the resource.
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      observedGeneration:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: Resource Generation to which the Condition refers.
+                        x-kubernetes-int-or-string: true
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  type: array
+                observedGeneration:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  x-kubernetes-int-or-string: true
+                validationMessages:
+                  description: Includes any errors or warnings detected by Istio's analyzers.
+                  items:
+                    properties:
+                      documentationUrl:
+                        description: A url pointing to the Istio documentation for this specific error type.
+                        type: string
+                      level:
+                        description: |-
+                          Represents how severe a message is.
+
+                          Valid Options: UNKNOWN, ERROR, WARNING, INFO
+                        enum:
+                          - UNKNOWN
+                          - ERROR
+                          - WARNING
+                          - INFO
+                        type: string
+                      type:
+                        properties:
+                          code:
+                            description: A 7 character code matching `^IST[0-9]{4}$` intended to uniquely identify the message type.
+                            type: string
+                          name:
+                            description: A human-readable name for the message type.
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
       subresources:
         status: {}

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-serviceentries-networking-istio-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-serviceentries-networking-istio-io.yaml
@@ -180,12 +180,13 @@ spec:
                   description: |-
                     Service resolution mode for the hosts.
 
-                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN
+                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN, DYNAMIC_DNS
                   enum:
                     - NONE
                     - STATIC
                     - DNS
                     - DNS_ROUND_ROBIN
+                    - DYNAMIC_DNS
                   type: string
                 subjectAltNames:
                   description: If specified, the proxy will verify that the server certificate's subject alternate name matches one of the specified values.
@@ -452,12 +453,13 @@ spec:
                   description: |-
                     Service resolution mode for the hosts.
 
-                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN
+                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN, DYNAMIC_DNS
                   enum:
                     - NONE
                     - STATIC
                     - DNS
                     - DNS_ROUND_ROBIN
+                    - DYNAMIC_DNS
                   type: string
                 subjectAltNames:
                   description: If specified, the proxy will verify that the server certificate's subject alternate name matches one of the specified values.
@@ -724,12 +726,13 @@ spec:
                   description: |-
                     Service resolution mode for the hosts.
 
-                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN
+                    Valid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN, DYNAMIC_DNS
                   enum:
                     - NONE
                     - STATIC
                     - DNS
                     - DNS_ROUND_ROBIN
+                    - DYNAMIC_DNS
                   type: string
                 subjectAltNames:
                   description: If specified, the proxy will verify that the server certificate's subject alternate name matches one of the specified values.

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-sidecars-networking-istio-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-sidecars-networking-istio-io.yaml
@@ -297,6 +297,9 @@ spec:
                       tls:
                         description: Set of TLS related options that will enable TLS termination on the sidecar for requests originating from outside the mesh.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -804,6 +807,9 @@ spec:
                       tls:
                         description: Set of TLS related options that will enable TLS termination on the sidecar for requests originating from outside the mesh.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
@@ -1311,6 +1317,9 @@ spec:
                       tls:
                         description: Set of TLS related options that will enable TLS termination on the sidecar for requests originating from outside the mesh.
                         properties:
+                          caCertCredentialName:
+                            description: For mutual TLS, the name of the secret or the configmap that holds CA certificates.
+                            type: string
                           caCertificates:
                             description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-workloadgroups-networking-istio-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-workloadgroups-networking-istio-io.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     app: istio-pilot
     chart: istio

--- a/charts/dependencies/sail-operator/crds/customresourcedefinition-ztunnels-sailoperator-io.yaml
+++ b/charts/dependencies/sail-operator/crds/customresourcedefinition-ztunnels-sailoperator-io.yaml
@@ -61,7 +61,7 @@ spec:
             spec:
               default:
                 namespace: ztunnel
-                version: v1.27.3
+                version: v1.28.5
               description: ZTunnelSpec defines the desired state of ZTunnel
               properties:
                 namespace:
@@ -3228,23 +3228,24 @@ spec:
                       type: object
                   type: object
                 version:
-                  default: v1.27.3
+                  default: v1.28.5
                   description: |-
                     Defines the version of Istio to install.
-                    Must be one of: v1.27-latest, v1.27.3, v1.26-latest, v1.26.6, v1.26.4, v1.26.3, v1.26.2, v1.24-latest, v1.24.6, v1.24.5, v1.24.4, v1.24.3.
+                    Must be one of: v1.28-latest, v1.28.5, v1.28.4, v1.27-latest, v1.27.8, v1.27.5, v1.27.3, v1.26-latest, v1.26.8, v1.26.6, v1.26.4, v1.26.3, v1.26.2.
                   enum:
+                    - v1.28-latest
+                    - v1.28.5
+                    - v1.28.4
                     - v1.27-latest
+                    - v1.27.8
+                    - v1.27.5
                     - v1.27.3
                     - v1.26-latest
+                    - v1.26.8
                     - v1.26.6
                     - v1.26.4
                     - v1.26.3
                     - v1.26.2
-                    - v1.24-latest
-                    - v1.24.6
-                    - v1.24.5
-                    - v1.24.4
-                    - v1.24.3
                   type: string
               required:
                 - namespace
@@ -3348,7 +3349,7 @@ spec:
               default:
                 namespace: ztunnel
                 profile: ambient
-                version: v1.27.3
+                version: v1.28.5
               description: ZTunnelSpec defines the desired state of ZTunnel
               properties:
                 namespace:
@@ -6533,23 +6534,24 @@ spec:
                       type: object
                   type: object
                 version:
-                  default: v1.27.3
+                  default: v1.28.5
                   description: |-
                     Defines the version of Istio to install.
-                    Must be one of: v1.27-latest, v1.27.3, v1.26-latest, v1.26.6, v1.26.4, v1.26.3, v1.26.2, v1.24-latest, v1.24.6, v1.24.5, v1.24.4, v1.24.3.
+                    Must be one of: v1.28-latest, v1.28.5, v1.28.4, v1.27-latest, v1.27.8, v1.27.5, v1.27.3, v1.26-latest, v1.26.8, v1.26.6, v1.26.4, v1.26.3, v1.26.2.
                   enum:
+                    - v1.28-latest
+                    - v1.28.5
+                    - v1.28.4
                     - v1.27-latest
+                    - v1.27.8
+                    - v1.27.5
                     - v1.27.3
                     - v1.26-latest
+                    - v1.26.8
                     - v1.26.6
                     - v1.26.4
                     - v1.26.3
                     - v1.26.2
-                    - v1.24-latest
-                    - v1.24.6
-                    - v1.24.5
-                    - v1.24.4
-                    - v1.24.3
                   type: string
               required:
                 - namespace

--- a/charts/dependencies/sail-operator/scripts/update-bundle.sh
+++ b/charts/dependencies/sail-operator/scripts/update-bundle.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-VERSION="${1:-3.2.1}"
+VERSION="${1:-3.3.0}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHART_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 

--- a/charts/dependencies/sail-operator/templates/deployment-servicemesh-operator3.yaml
+++ b/charts/dependencies/sail-operator/templates/deployment-servicemesh-operator3.yaml
@@ -13,6 +13,7 @@ metadata:
   namespace: {{ .Values.namespace }}
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/created-by: servicemeshoperator3
@@ -21,23 +22,6 @@ spec:
   template:
     metadata:
       annotations:
-        images.v1_24_3.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:2b60b0f33affda8b5b2cc30a4b09b2198b053fb1a914d386d35fcf03c09234e6
-        images.v1_24_3.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:d6693c31d6137c4219812cf69097d04654b296e0ab059dc48596a09b9cd124b1
-        images.v1_24_3.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:a020acb4a74040df03077924e10465454092f6c34a902b391fba55563c08f826
-        images.v1_24_3.ztunnel: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:d6693c31d6137c4219812cf69097d04654b296e0ab059dc48596a09b9cd124b1
-        images.v1_24_4.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f592b91a6f28559abdf6546ff6c3ae70a44d8f811592746e9eb02cdb2e5dec9d
-        images.v1_24_4.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:36557fa4817c3d0bac499dc65a4a9d6673500681641943d2f8cec5bfec4355be
-        images.v1_24_4.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:17db00a219de14e5901b5a5eca64d3c6684ca74c1dba3ae3b03787c655fe9c80
-        images.v1_24_4.ztunnel: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:36557fa4817c3d0bac499dc65a4a9d6673500681641943d2f8cec5bfec4355be
-        images.v1_24_5.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:54cada48e5c9824f255f82daa2ef5bea236919e521d3ea49885f2883ced2b7bc
-        images.v1_24_5.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:87b967785d7cc222f9df9cb49f0373a9819bf67910ce523dc3b8345849e881dd
-        images.v1_24_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:7fa655f5efb1175ff1e1c138371fc1233e5d4313c5feb07194428d0d1fdd33a3
-        images.v1_24_5.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:7ea9b82e192402566e69063a4787351be9f1ef50719bfd1a8f5d5940362b3f70
-        images.v1_24_6.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:54508ddeb570a45b5576d4e128fc6f4114e3bb0ed8cf600f2bcbf80d8b4f6b8a
-        images.v1_24_6.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:c018e5c2fe81d6b6577cbf32a9aa3f909c69c24ed411e4fa3fa7b4a891ce017e
-        images.v1_24_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:892c857d7ea35e60e13a277f5ab1268a4068c316353403a2846f116235d52a7b
-        images.v1_24_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:836c53299b170a1ef0bc8ce958da2abe14a48b8d84f9298e7c6b3d940fa8a1cc
-        images.v1_24_6.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:18897281e5ab5198506c4dd5cc0f5a96245794e6b33f63a2a4a3195bf23fbf60
         images.v1_26_2.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:14c5a52faf20267baa43d9a72ee6416f56fbc41dd640adc2aba3c4043802a0e9
         images.v1_26_2.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:028e10651db0d1ddb769a27c9483c6d41be6ac597f253afd9d599f395d9c82d8
         images.v1_26_2.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:366266f10e658c4cea86bddf6ee847e1908ea4dd780cb5f7fb0e466bac8995f1
@@ -58,11 +42,36 @@ spec:
         images.v1_26_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:8a21e30593e51f2fd2e51d9ab1d0ed2fc43eaa9b98173d7fb74f799d6b2f163d
         images.v1_26_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:47100186c27934adeda3002bb04cac28980ca8854eee7d6e4f4b3f85562e9a8e
         images.v1_26_6.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:f39e2c28ef36fce9f808f3946cc4e4126047e142ad84cb18c222cecceae29730
+        images.v1_26_8.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:edb5aab128bc90ba62a9b1d268be82ea8771ff70b0305ad9d85d8f669a995044
+        images.v1_26_8.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:6f9ed59521fab78d5cf576d0519b5aa40ea46963a13772b0a6ecabafbb32778b
+        images.v1_26_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:3e3e4a5f1e644796c13728c6c7f7ca8daab3b9a08d8ffd2a7a8c8f424d47b0b8
+        images.v1_26_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:6558eba168f2cb50aa40394b9ff9e71882c9e4a4c93ca189ba8f71f324c12ab4
+        images.v1_26_8.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:af4076fd0bef20612081bd8b0dbf9434a33a879545bba823cdaeeeb01ad39056
         images.v1_27_3.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:ddadd677161ad8c1077dd156821d6b4e32742ccbb210e9c14696fa66a58c0867
         images.v1_27_3.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:0850242436e88f7d82f0f2126de064c7e0f09844f31d8ff0f53dc8d3908075d9
         images.v1_27_3.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:742bc084c26769ff57cb3aa47b7a35c2b94684c3f67a9388da07a0490a942e5c
         images.v1_27_3.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:7d15cebf9b62f3f235c0eab5158ac8ff2fda86a1d193490dc94c301402c99da8
         images.v1_27_3.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:b2b3216a05f6136ed9ddb71d72d493030c6d6b431682dddffa692c760b6c9ba1
+        images.v1_27_5.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:2929b7df3da8228a728945542647ec5450c0585a2ed5cbdb84f8e3d81ab41806
+        images.v1_27_5.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:2e515a40de141bd4e516bfcf4fd0cbb8d236ac02799a7a35d77ae44f53916bc9
+        images.v1_27_5.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:d1baba8cb454b62d804dc427d4ccfea928348631c384d1ab3d170e1e2a9d1178
+        images.v1_27_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:650da1e2ad1cb93e6a0231dba7ca1f27f4cccac84e5925135281adc629a0caea
+        images.v1_27_5.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:0ae2919cd446e0e1f0a21d0850e7809ba8f44c06d484c023b3bee2787ca4bdd0
+        images.v1_27_8.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f072a10513086f330af8bbd4e70d6922167417cfb15674d4e9834565071f2c20
+        images.v1_27_8.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:2a25d47b4bb3bf346563a0ccea986c0ab0466709ca4cb9d2666ba6a02a8a5f31
+        images.v1_27_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:6eaedfbf16cfc73196e693b97d33e399acf438bce5fd7ec3c91f3f084c87edf0
+        images.v1_27_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:2b5f5aa5ee9974269d8e3666b1bfc58da10c172bf3f1d6defd555fbd1ac9a6ec
+        images.v1_27_8.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:4e085c9b6ca08f950798bf5153579e00e8e65226befe9c9043c19ae53f8a3a2d
+        images.v1_28_4.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f8abbd0d6c7758cf2ccd49dba34921e3ac9b6e4cdbfed4e5fb38dc9a11d30a5d
+        images.v1_28_4.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:978f840ceda7eb00c6f15740bcd60e241bee732cd215e9de464ce431b0156ffa
+        images.v1_28_4.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:d57d23fc8ec4053a3d819ffb87532d6aec6b5874fdf22e22afdd7f0f0712df52
+        images.v1_28_4.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:ba78d718627a0662f61ec633fdd2867ba5c24be6bdbc6df672d46456fb399dba
+        images.v1_28_4.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:2d5a3154e7b6b8d7eadb851a86cc5b7ee556b923843e73ae56197e875c564b03
+        images.v1_28_5.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:6167fbd27225658213894efcad7eaa172415873ef89c2239e5dd1d18ee15e362
+        images.v1_28_5.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:4813bf7ae960860d28b5ab7b493ce10f1879e3276b1b64732299a9750737bcfd
+        images.v1_28_5.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:eb58878893732fb5324ccbd07f2c34f85d977ad7067827dc114c14ed2d50dc57
+        images.v1_28_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:bc34f81266d8b0d2f5a8e71e966098d4edef70ac8dbb077a014a27fe1b71ec0a
+        images.v1_28_5.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:93dddaa0db0510d8c3bbf3376ca49311dd28ac644aa5dfcb3f5888ace89840a4
         kubectl.kubernetes.io/default-container: sail-operator
       labels:
         app.kubernetes.io/created-by: servicemeshoperator3
@@ -93,7 +102,7 @@ spec:
             - --zap-log-level=info
           command:
             - /usr/local/bin/sail-operator
-          image: registry.redhat.io/openshift-service-mesh/istio-rhel9-operator@sha256:656511cdb0683ff7e3336d4f41a672b4063b665e9e6e34d5370640103fd49365
+          image: registry.redhat.io/openshift-service-mesh/istio-rhel9-operator@sha256:2ec806d087a06830107c4dac3725e5de4764e93188cfe41bbaf0f94f83006e36
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/dependencies/sail-operator/test/snapshots/default.snap.yaml
+++ b/charts/dependencies/sail-operator/test/snapshots/default.snap.yaml
@@ -406,6 +406,7 @@ metadata:
   namespace: istio-system
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/created-by: servicemeshoperator3
@@ -414,23 +415,6 @@ spec:
   template:
     metadata:
       annotations:
-        images.v1_24_3.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:2b60b0f33affda8b5b2cc30a4b09b2198b053fb1a914d386d35fcf03c09234e6
-        images.v1_24_3.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:d6693c31d6137c4219812cf69097d04654b296e0ab059dc48596a09b9cd124b1
-        images.v1_24_3.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:a020acb4a74040df03077924e10465454092f6c34a902b391fba55563c08f826
-        images.v1_24_3.ztunnel: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:d6693c31d6137c4219812cf69097d04654b296e0ab059dc48596a09b9cd124b1
-        images.v1_24_4.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f592b91a6f28559abdf6546ff6c3ae70a44d8f811592746e9eb02cdb2e5dec9d
-        images.v1_24_4.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:36557fa4817c3d0bac499dc65a4a9d6673500681641943d2f8cec5bfec4355be
-        images.v1_24_4.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:17db00a219de14e5901b5a5eca64d3c6684ca74c1dba3ae3b03787c655fe9c80
-        images.v1_24_4.ztunnel: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:36557fa4817c3d0bac499dc65a4a9d6673500681641943d2f8cec5bfec4355be
-        images.v1_24_5.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:54cada48e5c9824f255f82daa2ef5bea236919e521d3ea49885f2883ced2b7bc
-        images.v1_24_5.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:87b967785d7cc222f9df9cb49f0373a9819bf67910ce523dc3b8345849e881dd
-        images.v1_24_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:7fa655f5efb1175ff1e1c138371fc1233e5d4313c5feb07194428d0d1fdd33a3
-        images.v1_24_5.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:7ea9b82e192402566e69063a4787351be9f1ef50719bfd1a8f5d5940362b3f70
-        images.v1_24_6.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:54508ddeb570a45b5576d4e128fc6f4114e3bb0ed8cf600f2bcbf80d8b4f6b8a
-        images.v1_24_6.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:c018e5c2fe81d6b6577cbf32a9aa3f909c69c24ed411e4fa3fa7b4a891ce017e
-        images.v1_24_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:892c857d7ea35e60e13a277f5ab1268a4068c316353403a2846f116235d52a7b
-        images.v1_24_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:836c53299b170a1ef0bc8ce958da2abe14a48b8d84f9298e7c6b3d940fa8a1cc
-        images.v1_24_6.ztunnel: registry.redhat.io/openshift-service-mesh-dev-preview-beta/istio-ztunnel-rhel9@sha256:18897281e5ab5198506c4dd5cc0f5a96245794e6b33f63a2a4a3195bf23fbf60
         images.v1_26_2.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:14c5a52faf20267baa43d9a72ee6416f56fbc41dd640adc2aba3c4043802a0e9
         images.v1_26_2.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:028e10651db0d1ddb769a27c9483c6d41be6ac597f253afd9d599f395d9c82d8
         images.v1_26_2.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:366266f10e658c4cea86bddf6ee847e1908ea4dd780cb5f7fb0e466bac8995f1
@@ -451,11 +435,36 @@ spec:
         images.v1_26_6.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:8a21e30593e51f2fd2e51d9ab1d0ed2fc43eaa9b98173d7fb74f799d6b2f163d
         images.v1_26_6.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:47100186c27934adeda3002bb04cac28980ca8854eee7d6e4f4b3f85562e9a8e
         images.v1_26_6.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:f39e2c28ef36fce9f808f3946cc4e4126047e142ad84cb18c222cecceae29730
+        images.v1_26_8.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:edb5aab128bc90ba62a9b1d268be82ea8771ff70b0305ad9d85d8f669a995044
+        images.v1_26_8.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:6f9ed59521fab78d5cf576d0519b5aa40ea46963a13772b0a6ecabafbb32778b
+        images.v1_26_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:3e3e4a5f1e644796c13728c6c7f7ca8daab3b9a08d8ffd2a7a8c8f424d47b0b8
+        images.v1_26_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:6558eba168f2cb50aa40394b9ff9e71882c9e4a4c93ca189ba8f71f324c12ab4
+        images.v1_26_8.ztunnel: registry.redhat.io/openshift-service-mesh-tech-preview/istio-ztunnel-rhel9@sha256:af4076fd0bef20612081bd8b0dbf9434a33a879545bba823cdaeeeb01ad39056
         images.v1_27_3.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:ddadd677161ad8c1077dd156821d6b4e32742ccbb210e9c14696fa66a58c0867
         images.v1_27_3.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:0850242436e88f7d82f0f2126de064c7e0f09844f31d8ff0f53dc8d3908075d9
         images.v1_27_3.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:742bc084c26769ff57cb3aa47b7a35c2b94684c3f67a9388da07a0490a942e5c
         images.v1_27_3.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:7d15cebf9b62f3f235c0eab5158ac8ff2fda86a1d193490dc94c301402c99da8
         images.v1_27_3.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:b2b3216a05f6136ed9ddb71d72d493030c6d6b431682dddffa692c760b6c9ba1
+        images.v1_27_5.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:2929b7df3da8228a728945542647ec5450c0585a2ed5cbdb84f8e3d81ab41806
+        images.v1_27_5.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:2e515a40de141bd4e516bfcf4fd0cbb8d236ac02799a7a35d77ae44f53916bc9
+        images.v1_27_5.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:d1baba8cb454b62d804dc427d4ccfea928348631c384d1ab3d170e1e2a9d1178
+        images.v1_27_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:650da1e2ad1cb93e6a0231dba7ca1f27f4cccac84e5925135281adc629a0caea
+        images.v1_27_5.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:0ae2919cd446e0e1f0a21d0850e7809ba8f44c06d484c023b3bee2787ca4bdd0
+        images.v1_27_8.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f072a10513086f330af8bbd4e70d6922167417cfb15674d4e9834565071f2c20
+        images.v1_27_8.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:2a25d47b4bb3bf346563a0ccea986c0ab0466709ca4cb9d2666ba6a02a8a5f31
+        images.v1_27_8.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:6eaedfbf16cfc73196e693b97d33e399acf438bce5fd7ec3c91f3f084c87edf0
+        images.v1_27_8.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:2b5f5aa5ee9974269d8e3666b1bfc58da10c172bf3f1d6defd555fbd1ac9a6ec
+        images.v1_27_8.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:4e085c9b6ca08f950798bf5153579e00e8e65226befe9c9043c19ae53f8a3a2d
+        images.v1_28_4.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:f8abbd0d6c7758cf2ccd49dba34921e3ac9b6e4cdbfed4e5fb38dc9a11d30a5d
+        images.v1_28_4.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:978f840ceda7eb00c6f15740bcd60e241bee732cd215e9de464ce431b0156ffa
+        images.v1_28_4.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:d57d23fc8ec4053a3d819ffb87532d6aec6b5874fdf22e22afdd7f0f0712df52
+        images.v1_28_4.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:ba78d718627a0662f61ec633fdd2867ba5c24be6bdbc6df672d46456fb399dba
+        images.v1_28_4.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:2d5a3154e7b6b8d7eadb851a86cc5b7ee556b923843e73ae56197e875c564b03
+        images.v1_28_5.cni: registry.redhat.io/openshift-service-mesh/istio-cni-rhel9@sha256:6167fbd27225658213894efcad7eaa172415873ef89c2239e5dd1d18ee15e362
+        images.v1_28_5.istiod: registry.redhat.io/openshift-service-mesh/istio-pilot-rhel9@sha256:4813bf7ae960860d28b5ab7b493ce10f1879e3276b1b64732299a9750737bcfd
+        images.v1_28_5.must-gather: registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:eb58878893732fb5324ccbd07f2c34f85d977ad7067827dc114c14ed2d50dc57
+        images.v1_28_5.proxy: registry.redhat.io/openshift-service-mesh/istio-proxyv2-rhel9@sha256:bc34f81266d8b0d2f5a8e71e966098d4edef70ac8dbb077a014a27fe1b71ec0a
+        images.v1_28_5.ztunnel: registry.redhat.io/openshift-service-mesh/istio-ztunnel-rhel9@sha256:93dddaa0db0510d8c3bbf3376ca49311dd28ac644aa5dfcb3f5888ace89840a4
         kubectl.kubernetes.io/default-container: sail-operator
       labels:
         app.kubernetes.io/created-by: servicemeshoperator3
@@ -486,7 +495,7 @@ spec:
             - --zap-log-level=info
           command:
             - /usr/local/bin/sail-operator
-          image: registry.redhat.io/openshift-service-mesh/istio-rhel9-operator@sha256:656511cdb0683ff7e3336d4f41a672b4063b665e9e6e34d5370640103fd49365
+          image: registry.redhat.io/openshift-service-mesh/istio-rhel9-operator@sha256:2ec806d087a06830107c4dac3725e5de4764e93188cfe41bbaf0f94f83006e36
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/dependencies/sail-operator/values.yaml
+++ b/charts/dependencies/sail-operator/values.yaml
@@ -5,4 +5,4 @@ imagePullSecrets:
   - name: rhaii-pull-secret
 
 bundle:
-  version: "3.2.1"
+  version: "3.3"


### PR DESCRIPTION

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- support range for istio up to 1.28.5
- 3.2.x up to 1.27.x

cc @aneeshkp up to you if you want to keep 3.2 or use 3.3
but to get the fix for multi inferpool we need a bump to 3.2 or 3.2.3 to get the new ossm operator image

Jira task: <!--- Link your JIRA and related links here for reference. -->

## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->

- [ ] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
