### PR TITLE
fix: set image pull policy in operator init containers

### DIFF
--- a/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
+++ b/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
@@ -121,8 +121,11 @@ rules:
       # Rename webhook cert secret in volume (rhods-operator to rhai-operator)
       - path: .spec.template.spec.volumes[name=cert].secret.secretName
         value: rhai-operator-controller-webhook-cert
+      # Replace init container image with Helm template value
       - path: .spec.template.spec.initContainers[name=copy-manifests].image
         value: '{{ .Values.rhaiOperator.image }}'
+      - path: .spec.template.spec.initContainers[name=copy-manifests].imagePullPolicy
+        value: '{{ .Values.rhaiOperator.imagePullPolicy }}'
 
   # Rename ServiceAccount
   - match:

--- a/charts/rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
+++ b/charts/rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
@@ -168,7 +168,7 @@ spec:
             - /opt/manifests-template/.
             - /opt/manifests/
           image: {{ .Values.rhaiOperator.image }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.rhaiOperator.imagePullPolicy }}
           name: copy-manifests
           resources:
             limits:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Follow up to #76, to set image pull policy in initContainer

Jira task: <!--- Link your JIRA and related links here for reference. -->

## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->

- [ ] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image pull policy is now configurable via Helm values for the operator deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->