### PR TITLE
feat(RHOAIENG-54928): add e2e test workflow for rhai-on-xks chart

### DIFF
--- a/.github/workflows/rhai-on-xks-chart-test.yaml
+++ b/.github/workflows/rhai-on-xks-chart-test.yaml
@@ -1,0 +1,65 @@
+name: RHAI on XKS Chart E2E Test
+
+on:
+  pull_request_target:
+    types: [opened, labeled, synchronize, reopened]
+    paths:
+      - 'charts/rhai-on-xks-chart/**'
+  push:
+    branches: [main]
+    paths:
+      - 'charts/rhai-on-xks-chart/**'
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-test:
+    if: >-
+      github.event_name == 'push' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run-xks-e2e') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-xks-e2e'))
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cloud_provider: [azure, coreweave]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+
+      - name: Create kind cluster
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+
+      - name: Install and verify chart
+        timeout-minutes: 30
+        env:
+          RHAI_PULL_SECRET: ${{ secrets.RHAI_PULL_SECRET }}
+        run: |
+          set -euo pipefail
+          PULL_SECRET_FILE="$(mktemp)"
+          trap 'rm -f "${PULL_SECRET_FILE}"' EXIT
+          chmod 600 "${PULL_SECRET_FILE}"
+          printf '%s' "${RHAI_PULL_SECRET}" > "${PULL_SECRET_FILE}"
+          make helm-install-verify-xks \
+            XKS_CLOUD_PROVIDER=${{ matrix.cloud_provider }} \
+            HELM_EXTRA_ARGS="--set-file imagePullSecret.dockerConfigJson=${PULL_SECRET_FILE}"
+
+      - name: Dump custom resources on failure
+        if: failure()
+        run: |
+          echo "=== KServe CR ==="
+          kubectl get kserves.components.platform.opendatahub.io -A -o yaml 2>/dev/null || echo "No KServe CRs found"
+          echo ""
+          if [ "${{ matrix.cloud_provider }}" = "azure" ]; then
+            echo "=== AzureKubernetesEngine CR ==="
+            kubectl get azurekubernetesengines.infrastructure.opendatahub.io -A -o yaml 2>/dev/null || echo "No AzureKubernetesEngine CRs found"
+          elif [ "${{ matrix.cloud_provider }}" = "coreweave" ]; then
+            echo "=== CoreWeaveKubernetesEngine CR ==="
+            kubectl get coreweavekubernetesengines.infrastructure.opendatahub.io -A -o yaml 2>/dev/null || echo "No CoreWeaveKubernetesEngine CRs found"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,24 @@ helm-install-verify: ## Install helm chart and verify installation
 	@echo "=== Step 6: Final helm upgrade with wait condition ==="
 	helm upgrade --install odh ./$(CHART_PATH) -n opendatahub-gitops --wait --timeout 10m $(HELM_INSTALL_ARGS) $(HELM_EXTRA_ARGS)
 
+## RHAI on XKS Chart
+XKS_CHART_PATH ?= $(CHARTS_DIR)/rhai-on-xks-chart
+XKS_RELEASE_NAME ?= rhai-on-xks
+XKS_NAMESPACE ?= rhai-on-xks
+XKS_CLOUD_PROVIDER ?= azure
+
+.PHONY: helm-verify-xks
+helm-verify-xks: ## Verify rhai-on-xks-chart installation
+	RELEASE_NAME=$(XKS_RELEASE_NAME) NAMESPACE=$(XKS_NAMESPACE) CLOUD_PROVIDER=$(XKS_CLOUD_PROVIDER) ./charts/rhai-on-xks-chart/scripts/verify.sh
+
+.PHONY: helm-install-verify-xks
+helm-install-verify-xks: ## Install and verify rhai-on-xks-chart
+	@echo "=== Step 1: Install rhai-on-xks-chart ==="
+	helm upgrade --install $(XKS_RELEASE_NAME) ./$(XKS_CHART_PATH) -n $(XKS_NAMESPACE) --create-namespace --set $(XKS_CLOUD_PROVIDER).enabled=true $(HELM_EXTRA_ARGS)
+	@echo ""
+	@echo "=== Step 2: Verify installation ==="
+	$(MAKE) helm-verify-xks
+
 .PHONY: helm-uninstall
 helm-uninstall: ## Uninstall helm chart and all dependencies
 	./scripts/uninstall-helm-chart.sh

--- a/charts/rhai-on-xks-chart/scripts/verify.sh
+++ b/charts/rhai-on-xks-chart/scripts/verify.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+# Verify rhai-on-xks-chart installation in a Kubernetes cluster.
+#
+# Environment variables:
+#   RELEASE_NAME     - Helm release name (default: rhai-on-xks)
+#   NAMESPACE        - Helm release namespace (default: rhai-on-xks)
+#   CLOUD_PROVIDER   - Cloud provider: azure or coreweave (default: azure)
+#   TIMEOUT          - Max wait time in seconds per check (default: 300)
+
+set -euo pipefail
+
+RELEASE_NAME="${RELEASE_NAME:-rhai-on-xks}"
+NAMESPACE="${NAMESPACE:-rhai-on-xks}"
+CLOUD_PROVIDER="${CLOUD_PROVIDER:-azure}"
+TIMEOUT="${TIMEOUT:-300}"
+if ! [[ "$TIMEOUT" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: TIMEOUT must be a positive integer" >&2
+  exit 1
+fi
+INTERVAL=10
+
+ERRORS=0
+
+log_ok()   { echo "  OK: $1"; }
+log_fail() { echo "  FAIL: $1"; ERRORS=$((ERRORS + 1)); }
+
+wait_for() {
+  local description="$1"
+  shift
+  local elapsed=0
+  while [ $elapsed -lt "$TIMEOUT" ]; do
+    if "$@" >/dev/null 2>&1; then
+      return 0
+    fi
+    echo "  Waiting for ${description}... (${elapsed}s/${TIMEOUT}s)"
+    sleep "$INTERVAL"
+    elapsed=$((elapsed + INTERVAL))
+  done
+  return 1
+}
+
+wait_for_deployment() {
+  local name="$1"
+  local ns="$2"
+  local expected_replicas="${3:-}"
+
+  if ! wait_for "deployment ${name} in ${ns}" kubectl get deployment "${name}" -n "${ns}"; then
+    log_fail "Deployment '${name}' not found in '${ns}'"
+    return 1
+  fi
+
+  if ! wait_for "deployment ${name} rollout" kubectl rollout status deployment "${name}" -n "${ns}" --timeout=0s; then
+    log_fail "Deployment '${name}' in '${ns}' did not become ready within ${TIMEOUT}s"
+    kubectl get deployment "${name}" -n "${ns}" -o wide 2>/dev/null || true
+    kubectl get pods -n "${ns}" 2>/dev/null || true
+    return 1
+  fi
+
+  if [ -n "${expected_replicas}" ]; then
+    actual=$(kubectl get deployment "${name}" -n "${ns}" -o jsonpath='{.status.availableReplicas}' 2>/dev/null || echo "0")
+    if [ "${actual:-0}" -ne "${expected_replicas}" ]; then
+      log_fail "Deployment '${name}' in '${ns}': expected ${expected_replicas} replicas, got ${actual:-0}"
+      return 1
+    fi
+  fi
+
+  log_ok "Deployment '${name}' in '${ns}' is ready"
+  return 0
+}
+
+wait_for_all_deployments_in_namespace() {
+  local ns="$1"
+  local deployments
+  if ! wait_for "deployments in ${ns}" kubectl get deployments -n "${ns}" -o name; then
+    log_fail "No deployments found in namespace '${ns}'"
+    return 1
+  fi
+
+  deployments=$(kubectl get deployments -n "${ns}" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null)
+  if [ -z "${deployments}" ]; then
+    log_fail "No deployments found in namespace '${ns}'"
+    return 1
+  fi
+
+  while IFS= read -r deploy; do
+    [ -z "${deploy}" ] && continue
+    wait_for_deployment "${deploy}" "${ns}"
+  done <<< "${deployments}"
+}
+
+echo "=== Verifying rhai-on-xks-chart Installation ==="
+echo "Release: ${RELEASE_NAME} | Namespace: ${NAMESPACE} | Cloud: ${CLOUD_PROVIDER}"
+echo ""
+
+# --- Helm release ---
+echo "--- Helm Release ---"
+if helm list -n "${NAMESPACE}" 2>/dev/null | grep -qF "${RELEASE_NAME}"; then
+  log_ok "Helm release '${RELEASE_NAME}' found"
+else
+  log_fail "Helm release '${RELEASE_NAME}' not found in namespace '${NAMESPACE}'"
+fi
+
+# --- Namespaces ---
+echo "--- Namespaces ---"
+EXPECTED_NAMESPACES=("redhat-ods-operator" "redhat-ods-applications" "${NAMESPACE}")
+if [ "${CLOUD_PROVIDER}" = "azure" ] || [ "${CLOUD_PROVIDER}" = "coreweave" ]; then
+  EXPECTED_NAMESPACES+=("rhai-cloudmanager-system")
+fi
+
+for ns in "${EXPECTED_NAMESPACES[@]}"; do
+  if kubectl get namespace "${ns}" >/dev/null 2>&1; then
+    log_ok "Namespace '${ns}' exists"
+  else
+    log_fail "Namespace '${ns}' not found"
+  fi
+done
+
+# --- CRDs ---
+echo "--- CRDs ---"
+if kubectl get crd kserves.components.platform.opendatahub.io >/dev/null 2>&1; then
+  log_ok "CRD 'kserves.components.platform.opendatahub.io' exists"
+else
+  log_fail "CRD 'kserves.components.platform.opendatahub.io' not found"
+fi
+
+if [ "${CLOUD_PROVIDER}" = "azure" ]; then
+  if kubectl get crd azurekubernetesengines.infrastructure.opendatahub.io >/dev/null 2>&1; then
+    log_ok "CRD 'azurekubernetesengines.infrastructure.opendatahub.io' exists"
+  else
+    log_fail "CRD 'azurekubernetesengines.infrastructure.opendatahub.io' not found"
+  fi
+  if kubectl get crd coreweavekubernetesengines.infrastructure.opendatahub.io >/dev/null 2>&1; then
+    log_fail "CRD 'coreweavekubernetesengines.infrastructure.opendatahub.io' should NOT exist for azure provider"
+  else
+    log_ok "CRD 'coreweavekubernetesengines.infrastructure.opendatahub.io' correctly absent"
+  fi
+elif [ "${CLOUD_PROVIDER}" = "coreweave" ]; then
+  if kubectl get crd coreweavekubernetesengines.infrastructure.opendatahub.io >/dev/null 2>&1; then
+    log_ok "CRD 'coreweavekubernetesengines.infrastructure.opendatahub.io' exists"
+  else
+    log_fail "CRD 'coreweavekubernetesengines.infrastructure.opendatahub.io' not found"
+  fi
+  if kubectl get crd azurekubernetesengines.infrastructure.opendatahub.io >/dev/null 2>&1; then
+    log_fail "CRD 'azurekubernetesengines.infrastructure.opendatahub.io' should NOT exist for coreweave provider"
+  else
+    log_ok "CRD 'azurekubernetesengines.infrastructure.opendatahub.io' correctly absent"
+  fi
+fi
+
+# --- Step 1: Cloud manager deployment ---
+echo "--- Cloud Manager ---"
+CM_NS="rhai-cloudmanager-system"
+if [ "${CLOUD_PROVIDER}" = "azure" ]; then
+  wait_for_deployment "azure-cloud-manager-operator" "${CM_NS}" 1
+  if kubectl get deployment coreweave-cloud-manager-operator -n "${CM_NS}" >/dev/null 2>&1; then
+    log_fail "Deployment 'coreweave-cloud-manager-operator' should NOT exist for azure provider"
+  else
+    log_ok "Deployment 'coreweave-cloud-manager-operator' correctly absent"
+  fi
+elif [ "${CLOUD_PROVIDER}" = "coreweave" ]; then
+  wait_for_deployment "coreweave-cloud-manager-operator" "${CM_NS}" 1
+  if kubectl get deployment azure-cloud-manager-operator -n "${CM_NS}" >/dev/null 2>&1; then
+    log_fail "Deployment 'azure-cloud-manager-operator' should NOT exist for coreweave provider"
+  else
+    log_ok "Deployment 'azure-cloud-manager-operator' correctly absent"
+  fi
+fi
+
+# --- Step 2: Infrastructure deployments ---
+echo "--- Infrastructure Deployments ---"
+infra_deployments=$(kubectl get deployments -A -l infrastructure.opendatahub.io/part-of -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}' 2>/dev/null || echo "")
+if [ -z "${infra_deployments}" ]; then
+  echo "  No deployments with label 'infrastructure.opendatahub.io/part-of' found yet, waiting..."
+  if wait_for "infrastructure deployments" bash -c "kubectl get deployments -A -l infrastructure.opendatahub.io/part-of -o name 2>/dev/null | grep -q ."; then
+    infra_deployments=$(kubectl get deployments -A -l infrastructure.opendatahub.io/part-of -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}' 2>/dev/null)
+  fi
+fi
+
+if [ -n "${infra_deployments}" ]; then
+  while IFS= read -r entry; do
+    [ -z "${entry}" ] && continue
+    ns="${entry%%/*}"
+    name="${entry##*/}"
+    wait_for_deployment "${name}" "${ns}"
+  done <<< "${infra_deployments}"
+else
+  log_fail "No infrastructure deployments found"
+fi
+
+# --- Step 3: cert-manager deployments ---
+echo "--- cert-manager ---"
+wait_for_all_deployments_in_namespace "cert-manager"
+
+# --- Step 4: rhai-operator ---
+echo "--- RHAI Operator ---"
+wait_for_deployment "rhai-operator" "redhat-ods-operator" 3
+
+# --- Step 5: Applications namespace deployments ---
+echo "--- Applications ---"
+wait_for_all_deployments_in_namespace "redhat-ods-applications"
+
+# --- Summary ---
+echo ""
+echo "==============================="
+if [ $ERRORS -eq 0 ]; then
+  echo "All checks passed"
+  exit 0
+else
+  echo "${ERRORS} check(s) failed"
+  exit 1
+fi

--- a/charts/rhai-on-xks-chart/values.schema.json
+++ b/charts/rhai-on-xks-chart/values.schema.json
@@ -99,6 +99,11 @@
           "type": "string",
           "description": "Manager container image"
         },
+        "imagePullPolicy": {
+          "type": "string",
+          "description": "Image pull policy for the manager container",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
         "relatedImages": {
           "type": "array",
           "description": "Related images env vars (RELATED_IMAGE_*) for disconnected environments",


### PR DESCRIPTION
## Description

- Add a GitHub Actions workflow (`rhai-on-xks-chart-test.yaml`) to run e2e tests for the `rhai-on-xks-chart` on PRs and pushes affecting that chart, gated by the `run-xks-e2e` label
- Add `helm-install-verify-xks` and `helm-verify-xks` Makefile targets for installing and verifying the xks chart on a kind cluster (matrix: azure, coreweave)
- Add `charts/rhai-on-xks-chart/scripts/verify.sh`, a comprehensive verification script that checks namespaces, CRDs, cloud manager deployments, infrastructure deployments, cert-manager, RHAI operator, and application deployments
- Add `imagePullPolicy` field to the xks chart's `values.schema.json`

Jira task: https://issues.redhat.com/browse/RHOAIENG-54928

## Has it been tested?

- [x] Installed on a real cluster to verify the changes

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Automated end-to-end tests for the XKS Helm chart (multi-cloud) with CI workflow triggers.
* **New Features**
  * Install-and-verify tooling to install the XKS chart and run post-install checks with configurable parameters.
  * Added image pull policy option for the operator image (Always, IfNotPresent, Never) to improve deployment control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->