### PR TITLE
fix(RHOAIENG-58507): use cli image from values for both hooks

### DIFF
--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -38,8 +38,8 @@ Red Hat OpenShift AI Operator Helm chart (non-OLM installation)
 | coreweave.kubernetesEngine.spec.dependencies.sailOperator.configuration | object | `{}` |  |
 | coreweave.kubernetesEngine.spec.dependencies.sailOperator.managementPolicy | string | `"Managed"` |  |
 | enabled | bool | `true` |  |
+| hooks.cliImage | string | `"registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"` |  |
 | hooks.postInstallCrs.enabled | bool | `true` |  |
-| hooks.postInstallCrs.image | string | `"registry.redhat.io/openshift4/ose-cli-rhel9@sha256:dcb3f93d34aa0fdab33eb37949adfaa8fdd11ff3479363bb7735c5ba3eb345ce"` |  |
 | imagePullSecret.dependencyNamespaces[0] | string | `"cert-manager-operator"` |  |
 | imagePullSecret.dependencyNamespaces[1] | string | `"cert-manager"` |  |
 | imagePullSecret.dependencyNamespaces[2] | string | `"openshift-lws-operator"` |  |

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: create-crs
-          image: {{ required "hooks.postInstallCrs.image is required" .Values.hooks.postInstallCrs.image | quote }}
+          image: {{ required "hooks.cliImage is required" .Values.hooks.cliImage | quote }}
           resources:
             limits:
               cpu: 200m

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
@@ -31,7 +31,7 @@ spec:
           emptyDir: {}
       containers:
         - name: create-gateway
-          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          image: {{ required "hooks.cliImage is required" .Values.hooks.cliImage | quote }}
           resources:
             limits:
               cpu: 200m

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -2819,7 +2819,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: create-crs
-          image: "registry.redhat.io/openshift4/ose-cli-rhel9@sha256:dcb3f93d34aa0fdab33eb37949adfaa8fdd11ff3479363bb7735c5ba3eb345ce"
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
           resources:
             limits:
               cpu: 200m
@@ -2910,7 +2910,7 @@ spec:
           emptyDir: {}
       containers:
         - name: create-gateway
-          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
           resources:
             limits:
               cpu: 200m

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2683,7 +2683,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: create-crs
-          image: "registry.redhat.io/openshift4/ose-cli-rhel9@sha256:dcb3f93d34aa0fdab33eb37949adfaa8fdd11ff3479363bb7735c5ba3eb345ce"
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
           resources:
             limits:
               cpu: 200m
@@ -2774,7 +2774,7 @@ spec:
           emptyDir: {}
       containers:
         - name: create-gateway
-          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
           resources:
             limits:
               cpu: 200m

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -2819,7 +2819,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: create-crs
-          image: "registry.redhat.io/openshift4/ose-cli-rhel9@sha256:dcb3f93d34aa0fdab33eb37949adfaa8fdd11ff3479363bb7735c5ba3eb345ce"
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
           resources:
             limits:
               cpu: 200m
@@ -2910,7 +2910,7 @@ spec:
           emptyDir: {}
       containers:
         - name: create-gateway
-          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
           resources:
             limits:
               cpu: 200m

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -2681,7 +2681,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: create-crs
-          image: "registry.redhat.io/openshift4/ose-cli-rhel9@sha256:dcb3f93d34aa0fdab33eb37949adfaa8fdd11ff3479363bb7735c5ba3eb345ce"
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
           resources:
             limits:
               cpu: 200m
@@ -2772,7 +2772,7 @@ spec:
           emptyDir: {}
       containers:
         - name: create-gateway
-          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
           resources:
             limits:
               cpu: 200m

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -2681,7 +2681,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: create-crs
-          image: "registry.redhat.io/openshift4/ose-cli-rhel9@sha256:dcb3f93d34aa0fdab33eb37949adfaa8fdd11ff3479363bb7735c5ba3eb345ce"
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
           resources:
             limits:
               cpu: 200m
@@ -2772,7 +2772,7 @@ spec:
           emptyDir: {}
       containers:
         - name: create-gateway
-          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.21.0
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
           resources:
             limits:
               cpu: 200m

--- a/charts/rhai-on-xks-chart/values.schema.json
+++ b/charts/rhai-on-xks-chart/values.schema.json
@@ -41,6 +41,10 @@
       "type": "object",
       "description": "Helm hooks configuration",
       "properties": {
+        "cliImage": {
+          "type": "string",
+          "description": "CLI container image used by all post-install hook jobs"
+        },
         "postInstallCrs": {
           "type": "object",
           "description": "Post-install hook for creating CRs",
@@ -49,16 +53,12 @@
               "type": "boolean",
               "description": "Enable post-install CR creation hook",
               "default": true
-            },
-            "image": {
-              "type": "string",
-              "description": "Container image used by the post-install hook job"
             }
           },
-          "additionalProperties": false,
-          "required": ["image"]
+          "additionalProperties": false
         }
-      }
+      },
+      "required": ["cliImage"]
     },
     "components": {
       "type": "object",

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -24,9 +24,9 @@ rhaiOperator:
   #     value: quay.io/opendatahub/kserve-controller:latest
 
 hooks:
+  cliImage: registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1
   postInstallCrs:
     enabled: true
-    image: registry.redhat.io/openshift4/ose-cli-rhel9@sha256:dcb3f93d34aa0fdab33eb37949adfaa8fdd11ff3479363bb7735c5ba3eb345ce
 
 # Components configuration
 components:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
use cli image from values for both hooks

Jira task: https://redhat.atlassian.net/browse/RHOAIENG-58507

## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->

- [ ] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated post-install hook image into a single required hooks.cliImage setting; removed per-hook image fields.
  * Updated hook job image references to a consistent, digest-pinned CLI image (v4.20) and templated usage.

* **Documentation**
  * Updated chart values docs and schema to add hooks.cliImage and remove old per-hook image entry.

* **Tests**
  * Updated chart snapshot tests to reflect the new image references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->