### PR TITLE
fix(RHOAIENG-59101): Add needed create verb to events.k8s.io RBAC

### DIFF
--- a/charts/rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrole-rhai-azure-cloud-manager-role.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrole-rhai-azure-cloud-manager-role.yaml
@@ -83,6 +83,7 @@ rules:
     resources:
       - events
     verbs:
+      - create
       - get
       - list
       - patch

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrole-rhai-coreweave-cloud-manager-role.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrole-rhai-coreweave-cloud-manager-role.yaml
@@ -83,6 +83,7 @@ rules:
     resources:
       - events
     verbs:
+      - create
       - get
       - list
       - patch

--- a/charts/rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
+++ b/charts/rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
@@ -512,6 +512,7 @@ rules:
     resources:
       - events
     verbs:
+      - create
       - delete
       - get
       - list

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -656,6 +656,7 @@ rules:
     resources:
       - events
     verbs:
+      - create
       - get
       - list
       - patch
@@ -1359,6 +1360,7 @@ rules:
     resources:
       - events
     verbs:
+      - create
       - delete
       - get
       - list

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -518,6 +518,7 @@ rules:
     resources:
       - events
     verbs:
+      - create
       - get
       - list
       - patch
@@ -1221,6 +1222,7 @@ rules:
     resources:
       - events
     verbs:
+      - create
       - delete
       - get
       - list

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -656,6 +656,7 @@ rules:
     resources:
       - events
     verbs:
+      - create
       - get
       - list
       - patch
@@ -1359,6 +1360,7 @@ rules:
     resources:
       - events
     verbs:
+      - create
       - delete
       - get
       - list

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -518,6 +518,7 @@ rules:
     resources:
       - events
     verbs:
+      - create
       - get
       - list
       - patch
@@ -1221,6 +1222,7 @@ rules:
     resources:
       - events
     verbs:
+      - create
       - delete
       - get
       - list

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -518,6 +518,7 @@ rules:
     resources:
       - events
     verbs:
+      - create
       - get
       - list
       - patch
@@ -1221,6 +1222,7 @@ rules:
     resources:
       - events
     verbs:
+      - create
       - delete
       - get
       - list


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Add needed create verb to events.k8s.io RBAC

Jira task: https://redhat.atlassian.net/browse/RHOAIENG-59101

## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->

- [ ] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes RBAC so cloud manager and operator roles can create Kubernetes Events (in addition to existing event read/patch/watch permissions). This enables components to record and emit cluster events across Azure and CoreWeave deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->