### PR TITLE
Add Amazon cloud manager provider support to rhai-on-xks chart

### DIFF
--- a/.github/workflows/rhai-on-xks-chart-test.yaml
+++ b/.github/workflows/rhai-on-xks-chart-test.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cloud_provider: [azure, coreweave]
+        cloud_provider: [azure, coreweave, aws]
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -62,4 +62,7 @@ jobs:
           elif [ "${{ matrix.cloud_provider }}" = "coreweave" ]; then
             echo "=== CoreWeaveKubernetesEngine CR ==="
             kubectl get coreweavekubernetesengines.infrastructure.opendatahub.io -A -o yaml 2>/dev/null || echo "No CoreWeaveKubernetesEngine CRs found"
+          elif [ "${{ matrix.cloud_provider }}" = "aws" ]; then
+            echo "=== AWSKubernetesEngine CR ==="
+            kubectl get awskubernetesengines.infrastructure.opendatahub.io -A -o yaml 2>/dev/null || echo "No AWSKubernetesEngine CRs found"
           fi

--- a/Makefile
+++ b/Makefile
@@ -332,9 +332,11 @@ update-image: yq ## Update xks chart images from Build-Config repo into values-$
 	$(YQ) -i '.hooks.cliImage = load("'"$${patch}"'").hooks.cliImage' "$${override}" && \
 	$(YQ) -i '.azure.cloudManager.image = load("'"$${patch}"'").azure.cloudManager.image' "$${override}" && \
 	$(YQ) -i '.coreweave.cloudManager.image = load("'"$${patch}"'").coreweave.cloudManager.image' "$${override}" && \
+	$(YQ) -i '.aws.cloudManager.image = load("'"$${patch}"'").aws.cloudManager.image' "$${override}" && \
 	echo "Created $${override}:" && \
 	echo "  rhaiOperator.image: $$($(YQ) '.rhaiOperator.image' "$${override}")" && \
 	echo "  relatedImages: $$($(YQ) '.rhaiOperator.relatedImages | length' "$${override}") entries" && \
 	echo "  hooks.cliImage: $$($(YQ) '.hooks.cliImage' "$${override}")" && \
 	echo "  azure.cloudManager.image: $$($(YQ) '.azure.cloudManager.image' "$${override}")" && \
-	echo "  coreweave.cloudManager.image: $$($(YQ) '.coreweave.cloudManager.image' "$${override}")"
+	echo "  coreweave.cloudManager.image: $$($(YQ) '.coreweave.cloudManager.image' "$${override}")" && \
+	echo "  aws.cloudManager.image: $$($(YQ) '.aws.cloudManager.image' "$${override}")"

--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -8,6 +8,19 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| aws.cloudManager.image | string | `"quay.io/opendatahub/opendatahub-operator:latest"` |  |
+| aws.cloudManager.imagePullPolicy | string | `"Always"` |  |
+| aws.cloudManager.namespace | string | `"rhai-cloudmanager-system"` |  |
+| aws.enabled | bool | `false` |  |
+| aws.kubernetesEngine.enabled | bool | `true` |  |
+| aws.kubernetesEngine.spec.dependencies.certManager.configuration | object | `{}` |  |
+| aws.kubernetesEngine.spec.dependencies.certManager.managementPolicy | string | `"Managed"` |  |
+| aws.kubernetesEngine.spec.dependencies.gatewayAPI.configuration | object | `{}` |  |
+| aws.kubernetesEngine.spec.dependencies.gatewayAPI.managementPolicy | string | `"Managed"` |  |
+| aws.kubernetesEngine.spec.dependencies.lws.configuration.namespace | string | `"openshift-lws-operator"` |  |
+| aws.kubernetesEngine.spec.dependencies.lws.managementPolicy | string | `"Managed"` |  |
+| aws.kubernetesEngine.spec.dependencies.sailOperator.configuration.namespace | string | `"istio-system"` |  |
+| aws.kubernetesEngine.spec.dependencies.sailOperator.managementPolicy | string | `"Managed"` |  |
 | azure.cloudManager.image | string | `"quay.io/opendatahub/opendatahub-operator:latest"` |  |
 | azure.cloudManager.imagePullPolicy | string | `"Always"` |  |
 | azure.cloudManager.namespace | string | `"rhai-cloudmanager-system"` |  |

--- a/charts/rhai-on-xks-chart/scripts/update-bundle.sh
+++ b/charts/rhai-on-xks-chart/scripts/update-bundle.sh
@@ -35,6 +35,7 @@ HELMTEMPLATE_GENERATOR_PKG="github.com/davidebianchi/helmtemplate-generator@7d76
 CLOUD_TARGETS=(
     "azure azure cloudmanager/azure"
     "coreweave coreweave cloudmanager/coreweave"
+    "aws aws cloudmanager/aws"
 )
 
 # Defaults
@@ -119,7 +120,7 @@ echo "Generating kustomization.yaml from templates..."
 # Generate main operator kustomization (creates config/rhoai/manager/kustomization.yaml)
 make -C "${ODH_OPERATOR_DIR}" manager-kustomization ODH_PLATFORM_TYPE=rhoai
 # Generate cloudmanager kustomizations
-for cloud in azure coreweave; do
+for cloud in azure coreweave aws; do
     cp -f "${ODH_OPERATOR_DIR}/config/cloudmanager/${cloud}/manager/kustomization.yaml.in" \
           "${ODH_OPERATOR_DIR}/config/cloudmanager/${cloud}/manager/kustomization.yaml"
 done

--- a/charts/rhai-on-xks-chart/templates/NOTES.txt
+++ b/charts/rhai-on-xks-chart/templates/NOTES.txt
@@ -4,6 +4,8 @@ RHAI on XKS Helm Chart has been installed.
 Cloud provider: Azure
 {{- else if .Values.coreweave.enabled }}
 Cloud provider: CoreWeave
+{{- else if .Values.aws.enabled }}
+Cloud provider: AWS
 {{- end }}
 
 == Custom Resources ==
@@ -68,6 +70,37 @@ CoreWeaveKubernetesEngine CR is NOT automatically created. To create it manually
    kind: CoreWeaveKubernetesEngine
    metadata:
      name: default-coreweavekubernetesengine
+   spec:
+     dependencies:
+       certManager:
+         configuration: {}
+         managementPolicy: Managed
+       gatewayAPI:
+         configuration: {}
+         managementPolicy: Managed
+       lws:
+         configuration: {}
+         managementPolicy: Managed
+       sailOperator:
+         configuration: {}
+         managementPolicy: Managed
+   EOF
+{{- end }}
+{{- end }}
+
+{{- if .Values.aws.enabled }}
+{{- if .Values.aws.kubernetesEngine.enabled }}
+
+AWSKubernetesEngine CR was automatically created during the installation.
+{{- else }}
+
+AWSKubernetesEngine CR is NOT automatically created. To create it manually:
+
+   kubectl apply -f - <<EOF
+   apiVersion: infrastructure.opendatahub.io/v1alpha1
+   kind: AWSKubernetesEngine
+   metadata:
+     name: default-awskubernetesengine
    spec:
      dependencies:
        certManager:

--- a/charts/rhai-on-xks-chart/templates/_helpers.tpl
+++ b/charts/rhai-on-xks-chart/templates/_helpers.tpl
@@ -52,10 +52,14 @@ imagePullSecrets:
 Validate that exactly one cloud provider is enabled.
 */}}
 {{- define "rhai-on-xks-chart.validateCloudProvider" -}}
-{{- if and .Values.enabled (not (or .Values.azure.enabled .Values.coreweave.enabled)) -}}
-{{- fail "Exactly one cloud provider must be enabled: set azure.enabled=true or coreweave.enabled=true" -}}
+{{- if and .Values.enabled (not (or .Values.azure.enabled .Values.coreweave.enabled .Values.aws.enabled)) -}}
+{{- fail "Exactly one cloud provider must be enabled: set azure.enabled=true, coreweave.enabled=true, or aws.enabled=true" -}}
 {{- end -}}
-{{- if and .Values.enabled .Values.azure.enabled .Values.coreweave.enabled -}}
-{{- fail "Only one cloud provider can be enabled at a time: set either azure.enabled=true or coreweave.enabled=true, not both" -}}
+{{- $enabledCount := 0 -}}
+{{- if .Values.azure.enabled }}{{- $enabledCount = add $enabledCount 1 -}}{{- end -}}
+{{- if .Values.coreweave.enabled }}{{- $enabledCount = add $enabledCount 1 -}}{{- end -}}
+{{- if .Values.aws.enabled }}{{- $enabledCount = add $enabledCount 1 -}}{{- end -}}
+{{- if and .Values.enabled (gt (int $enabledCount) 1) -}}
+{{- fail "Only one cloud provider can be enabled at a time: set either azure.enabled=true, coreweave.enabled=true, or aws.enabled=true, not multiple" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/aws/crds/customresourcedefinition-awskubernetesengines.infrastructure.opendatahub.io.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/aws/crds/customresourcedefinition-awskubernetesengines.infrastructure.opendatahub.io.yaml
@@ -1,0 +1,226 @@
+{{- if .Values.aws.enabled }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+    helm.sh/resource-policy: keep
+  name: awskubernetesengines.infrastructure.opendatahub.io
+spec:
+  group: infrastructure.opendatahub.io
+  names:
+    kind: AWSKubernetesEngine
+    listKind: AWSKubernetesEngineList
+    plural: awskubernetesengines
+    singular: awskubernetesengine
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+        - description: DependenciesAvailable
+          jsonPath: .status.conditions[?(@.type=="DependenciesAvailable")].status
+          name: Deps Available
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            AWSKubernetesEngine is the Schema for the awskubernetesengines API.
+            It represents the configuration for an AWS Kubernetes Service cluster.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AWSKubernetesEngineSpec defines the desired state of AWSKubernetesEngine.
+              properties:
+                dependencies:
+                  description: Dependencies defines the dependency configurations for the AWS Kubernetes Engine.
+                  properties:
+                    certManager:
+                      description: CertManager defines the cert-manager operator dependency.
+                      properties:
+                        configuration:
+                          description: Configuration for the cert-manager operator.
+                          type: object
+                        managementPolicy:
+                          default: Managed
+                          description: |-
+                            ManagementPolicy determines whether the operator manages this dependency.
+                            Managed: the operator installs and reconciles the dependency.
+                            Unmanaged: the operator does not manage the dependency; the user is responsible.
+                          enum:
+                            - Managed
+                            - Unmanaged
+                          type: string
+                      type: object
+                    gatewayAPI:
+                      description: GatewayAPI defines the Gateway API dependency.
+                      properties:
+                        configuration:
+                          description: Configuration for the Gateway API.
+                          type: object
+                        managementPolicy:
+                          default: Managed
+                          description: |-
+                            ManagementPolicy determines whether the operator manages this dependency.
+                            Managed: the operator installs and reconciles the dependency.
+                            Unmanaged: the operator does not manage the dependency; the user is responsible.
+                          enum:
+                            - Managed
+                            - Unmanaged
+                          type: string
+                      type: object
+                    lws:
+                      description: LWS defines the LeaderWorkerSet operator dependency.
+                      properties:
+                        configuration:
+                          default: {}
+                          description: Configuration for the LWS operator.
+                          properties:
+                            namespace:
+                              default: openshift-lws-operator
+                              description: Namespace is the namespace where the LWS operator is deployed.
+                              maxLength: 63
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: namespace is immutable
+                                  rule: self == oldSelf
+                          type: object
+                        managementPolicy:
+                          default: Managed
+                          description: |-
+                            ManagementPolicy determines whether the operator manages this dependency.
+                            Managed: the operator installs and reconciles the dependency.
+                            Unmanaged: the operator does not manage the dependency; the user is responsible.
+                          enum:
+                            - Managed
+                            - Unmanaged
+                          type: string
+                      type: object
+                    sailOperator:
+                      description: SailOperator defines the Sail operator (Istio) dependency.
+                      properties:
+                        configuration:
+                          default: {}
+                          description: Configuration for the Sail operator.
+                          properties:
+                            namespace:
+                              default: istio-system
+                              description: Namespace is the namespace where the Sail operator (Istio) is deployed.
+                              maxLength: 63
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: namespace is immutable
+                                  rule: self == oldSelf
+                          type: object
+                        managementPolicy:
+                          default: Managed
+                          description: |-
+                            ManagementPolicy determines whether the operator manages this dependency.
+                            Managed: the operator installs and reconciles the dependency.
+                            Unmanaged: the operator does not manage the dependency; the user is responsible.
+                          enum:
+                            - Managed
+                            - Unmanaged
+                          type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              description: AWSKubernetesEngineStatus defines the observed state of AWSKubernetesEngine.
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: AWSKubernetesEngine name must be default-awskubernetesengine
+              rule: self.metadata.name == 'default-awskubernetesengine'
+      served: true
+      storage: true
+      subresources:
+        status: {}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/aws/manager/deployment-aws-cloud-manager-operator.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/aws/manager/deployment-aws-cloud-manager-operator.yaml
@@ -1,0 +1,111 @@
+{{- if .Values.aws.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+    name: aws-cloud-manager-operator
+  name: aws-cloud-manager-operator
+  namespace: {{ .Values.aws.cloudManager.namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      name: aws-cloud-manager-operator
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+        name: aws-cloud-manager-operator
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: name
+                      operator: In
+                      values:
+                        - aws-cloud-manager-operator
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      containers:
+        - args:
+            - aws
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=0.0.0.0:8080
+            - --leader-elect
+          command:
+            - /cloudmanager
+          env:
+            - name: RHAI_OPERATOR_NAMESPACE
+              value: {{ .Values.rhaiOperator.namespace }}
+            - name: RHAI_WEBHOOK_CERT_SECRET_NAME
+              value: rhai-operator-controller-webhook-cert
+            - name: RHAI_WEBHOOK_SERVICE_NAME
+              value: rhai-operator-webhook-service
+            - name: RHAI_WEBHOOK_CERT_NAME
+              value: rhai-operator-webhook-cert
+            - name: RHAI_CA_SECRET_NAME
+              value: rhai-ca
+            - name: RHAI_CA_SECRET_NAMESPACE
+              value: cert-manager
+            - name: RHAI_ISSUER_REF_NAME
+              value: rhai-ca-issuer
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DEFAULT_CHARTS_PATH
+              value: /opt/charts
+          image: {{ .Values.aws.cloudManager.image }}
+          imagePullPolicy: {{ .Values.aws.cloudManager.imagePullPolicy }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 4Gi
+            requests:
+              cpu: 100m
+              memory: 780Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: aws-cloud-manager-operator
+      terminationGracePeriodSeconds: 10
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/aws/manager/namespace-rhai-cloudmanager-system.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/aws/manager/namespace-rhai-cloudmanager-system.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.aws.enabled }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.aws.cloudManager.namespace }}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrole-rhai-aws-cloud-manager-role.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrole-rhai-aws-cloud-manager-role.yaml
@@ -1,0 +1,264 @@
+{{- if .Values.aws.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-aws-cloud-manager-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - namespaces
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+      - clusterissuers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - awskubernetesengines
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - awskubernetesengines/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - awskubernetesengines/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - certmanagers
+      - leaderworkersetoperators
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - rolebindings
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - cert-manager-operator-controller-manager-clusterrole
+      - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
+      - servicemesh-operator3-clusterrole
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - openshift-lws-operator-clusterrole
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - cert-manager-operator-controller-manager-role
+    resources:
+      - roles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - openshift-lws-operator-role
+    resources:
+      - roles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - servicemesh-operator3-role
+    resources:
+      - roles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - sailoperator.io
+    resources:
+      - istios
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrolebinding-rhai-aws-cloud-manager-rolebinding.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrolebinding-rhai-aws-cloud-manager-rolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.aws.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-aws-cloud-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-aws-cloud-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: aws-cloud-manager-operator
+    namespace: {{ .Values.aws.cloudManager.namespace }}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/aws/rbac/role-aws-cloud-manager-leader-election-role.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/aws/rbac/role-aws-cloud-manager-leader-election-role.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.aws.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: aws-cloud-manager-leader-election-role
+  namespace: {{ .Values.aws.cloudManager.namespace }}
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/aws/rbac/rolebinding-aws-cloud-manager-leader-election-rolebinding.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/aws/rbac/rolebinding-aws-cloud-manager-leader-election-rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.aws.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aws-cloud-manager-leader-election-rolebinding
+  namespace: {{ .Values.aws.cloudManager.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: aws-cloud-manager-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: aws-cloud-manager-operator
+    namespace: {{ .Values.aws.cloudManager.namespace }}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.aws.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-cloud-manager-operator
+  namespace: {{ .Values.aws.cloudManager.namespace }}
+{{ include "rhai-on-xks-chart.imagePullSecrets" . }}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
@@ -3,7 +3,8 @@
 {{- $createKserve := .Values.components.kserve.enabled }}
 {{- $createAzureKE := and .Values.azure.enabled .Values.azure.kubernetesEngine.enabled }}
 {{- $createCoreweaveKE := and .Values.coreweave.enabled .Values.coreweave.kubernetesEngine.enabled }}
-{{- if or $createKserve $createAzureKE $createCoreweaveKE }}
+{{- $createAwsKE := and .Values.aws.enabled .Values.aws.kubernetesEngine.enabled }}
+{{- if or $createKserve $createAzureKE $createCoreweaveKE $createAwsKE }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -97,6 +98,23 @@ spec:
               {{- if .Values.coreweave.kubernetesEngine.spec }}
               spec:
                 {{- .Values.coreweave.kubernetesEngine.spec | toYaml | nindent 16 }}
+              {{- else }}
+              spec: {}
+              {{- end }}
+              EOF
+              {{- end }}
+              {{- if $createAwsKE }}
+              echo "Creating AWSKubernetesEngine CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: infrastructure.opendatahub.io/v1alpha1
+              kind: AWSKubernetesEngine
+              metadata:
+                name: default-awskubernetesengine
+                labels:
+                  {{- include "rhai-on-xks-chart.labels" . | nindent 18 }}
+              {{- if .Values.aws.kubernetesEngine.spec }}
+              spec:
+                {{- .Values.aws.kubernetesEngine.spec | toYaml | nindent 16 }}
               {{- else }}
               spec: {}
               {{- end }}

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -3,8 +3,9 @@
 {{- $createKserve := .Values.components.kserve.enabled }}
 {{- $createAzureKE := and .Values.azure.enabled .Values.azure.kubernetesEngine.enabled }}
 {{- $createCoreweaveKE := and .Values.coreweave.enabled .Values.coreweave.kubernetesEngine.enabled }}
+{{- $createAwsKE := and .Values.aws.enabled .Values.aws.kubernetesEngine.enabled }}
 {{- $createGateway := and .Values.components.kserve.enabled .Values.components.kserve.gateway.create }}
-{{- if or $createKserve $createAzureKE $createCoreweaveKE $createGateway }}
+{{- if or $createKserve $createAzureKE $createCoreweaveKE $createAwsKE $createGateway }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -42,6 +43,7 @@ rules:
     resources:
       - azurekubernetesengines
       - coreweavekubernetesengines
+      - awskubernetesengines
     verbs:
       - get
       - create

--- a/charts/rhai-on-xks-chart/templates/pull-secret.yaml
+++ b/charts/rhai-on-xks-chart/templates/pull-secret.yaml
@@ -6,8 +6,11 @@
 {{- if .Values.coreweave.enabled }}
 {{- $namespaces = append $namespaces .Values.coreweave.cloudManager.namespace }}
 {{- end }}
+{{- if .Values.aws.enabled }}
+{{- $namespaces = append $namespaces .Values.aws.cloudManager.namespace }}
+{{- end }}
 {{- $dependencyNamespaces := .Values.imagePullSecret.dependencyNamespaces | default list }}
-{{- range $provider := list $.Values.azure $.Values.coreweave }}
+{{- range $provider := list $.Values.azure $.Values.coreweave $.Values.aws }}
   {{- if $provider.enabled }}
     {{- range $depName, $dep := (dig "kubernetesEngine" "spec" "dependencies" (dict) $provider) }}
       {{- if eq (dig "managementPolicy" "" $dep) "Managed" }}

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/manager/namespace-rhai-cloudmanager-system.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/namespace-rhai-cloudmanager-system.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -41,11 +41,11 @@ kind: Namespace
 metadata:
   name: istio-system
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: azure-cloud-manager-operator
+  name: aws-cloud-manager-operator
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
@@ -173,21 +173,21 @@ type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: dGVzdGF1dGg=
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/crds/customresourcedefinition-azurekubernetesengines.infrastructure.opendatahub.io.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/crds/customresourcedefinition-awskubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
     helm.sh/resource-policy: keep
-  name: azurekubernetesengines.infrastructure.opendatahub.io
+  name: awskubernetesengines.infrastructure.opendatahub.io
 spec:
   group: infrastructure.opendatahub.io
   names:
-    kind: AzureKubernetesEngine
-    listKind: AzureKubernetesEngineList
-    plural: azurekubernetesengines
-    singular: azurekubernetesengine
+    kind: AWSKubernetesEngine
+    listKind: AWSKubernetesEngineList
+    plural: awskubernetesengines
+    singular: awskubernetesengine
   scope: Cluster
   versions:
     - additionalPrinterColumns:
@@ -207,8 +207,8 @@ spec:
       schema:
         openAPIV3Schema:
           description: |-
-            AzureKubernetesEngine is the Schema for the azurekubernetesengines API.
-            It represents the configuration for an Azure Kubernetes Service (AKS) cluster.
+            AWSKubernetesEngine is the Schema for the awskubernetesengines API.
+            It represents the configuration for an AWS Kubernetes Service cluster.
           properties:
             apiVersion:
               description: |-
@@ -228,10 +228,10 @@ spec:
             metadata:
               type: object
             spec:
-              description: AzureKubernetesEngineSpec defines the desired state of AzureKubernetesEngine.
+              description: AWSKubernetesEngineSpec defines the desired state of AWSKubernetesEngine.
               properties:
                 dependencies:
-                  description: Dependencies defines the dependency configurations for the Azure Kubernetes Engine.
+                  description: Dependencies defines the dependency configurations for the AWS Kubernetes Engine.
                   properties:
                     certManager:
                       description: CertManager defines the cert-manager operator dependency.
@@ -326,7 +326,7 @@ spec:
                   type: object
               type: object
             status:
-              description: AzureKubernetesEngineStatus defines the observed state of AzureKubernetesEngine.
+              description: AWSKubernetesEngineStatus defines the observed state of AWSKubernetesEngine.
               properties:
                 conditions:
                   items:
@@ -392,8 +392,8 @@ spec:
               type: object
           type: object
           x-kubernetes-validations:
-            - message: AzureKubernetesEngine name must be default-azurekubernetesengine
-              rule: self.metadata.name == 'default-azurekubernetesengine'
+            - message: AWSKubernetesEngine name must be default-awskubernetesengine
+              rule: self.metadata.name == 'default-awskubernetesengine'
       served: true
       storage: true
       subresources:
@@ -593,11 +593,11 @@ spec:
       subresources:
         status: {}
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrole-rhai-azure-cloud-manager-role.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrole-rhai-aws-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhai-azure-cloud-manager-role
+  name: rhai-aws-cloud-manager-role
 rules:
   - apiGroups:
       - ""
@@ -686,7 +686,7 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines
+      - awskubernetesengines
     verbs:
       - create
       - delete
@@ -698,13 +698,13 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/finalizers
+      - awskubernetesengines/finalizers
     verbs:
       - update
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/status
+      - awskubernetesengines/status
     verbs:
       - get
       - patch
@@ -2238,18 +2238,18 @@ rules:
       - update
       - watch
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrolebinding-rhai-azure-cloud-manager-rolebinding.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrolebinding-rhai-aws-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhai-azure-cloud-manager-rolebinding
+  name: rhai-aws-cloud-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhai-azure-cloud-manager-role
+  name: rhai-aws-cloud-manager-role
 subjects:
   - kind: ServiceAccount
-    name: azure-cloud-manager-operator
+    name: aws-cloud-manager-operator
     namespace: rhai-cloudmanager-system
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
@@ -2266,11 +2266,11 @@ subjects:
     name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/role-aws-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: azure-cloud-manager-leader-election-role
+  name: aws-cloud-manager-leader-election-role
   namespace: rhai-cloudmanager-system
 rules:
   - apiGroups:
@@ -2290,19 +2290,19 @@ rules:
       - create
       - patch
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/rolebinding-azure-cloud-manager-leader-election-rolebinding.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/rolebinding-aws-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: azure-cloud-manager-leader-election-rolebinding
+  name: aws-cloud-manager-leader-election-rolebinding
   namespace: rhai-cloudmanager-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: azure-cloud-manager-leader-election-role
+  name: aws-cloud-manager-leader-election-role
 subjects:
   - kind: ServiceAccount
-    name: azure-cloud-manager-operator
+    name: aws-cloud-manager-operator
     namespace: rhai-cloudmanager-system
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
@@ -2343,28 +2343,28 @@ spec:
   selector:
     name: rhai-operator
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/deployment-aws-cloud-manager-operator.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
-    name: azure-cloud-manager-operator
-  name: azure-cloud-manager-operator
+    name: aws-cloud-manager-operator
+  name: aws-cloud-manager-operator
   namespace: rhai-cloudmanager-system
 spec:
   replicas: 1
   selector:
     matchLabels:
       control-plane: controller-manager
-      name: azure-cloud-manager-operator
+      name: aws-cloud-manager-operator
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
-        name: azure-cloud-manager-operator
+        name: aws-cloud-manager-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2383,12 +2383,12 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - azure-cloud-manager-operator
+                        - aws-cloud-manager-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
         - args:
-            - azure
+            - aws
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=0.0.0.0:8080
             - --leader-elect
@@ -2451,7 +2451,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: azure-cloud-manager-operator
+      serviceAccountName: aws-cloud-manager-operator
       terminationGracePeriodSeconds: 10
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
@@ -2875,12 +2875,12 @@ spec:
                   app.kubernetes.io/managed-by: Helm
               spec: {}
               EOF
-              echo "Creating AzureKubernetesEngine CR..."
+              echo "Creating AWSKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
-              kind: AzureKubernetesEngine
+              kind: AWSKubernetesEngine
               metadata:
-                name: default-azurekubernetesengine
+                name: default-awskubernetesengine
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm
@@ -3020,10 +3020,6 @@ spec:
                           - name: rhai-ca-bundle
                             mountPath: /var/run/secrets/rhai
                             readOnly: true
-                service: |
-                  metadata:
-                    annotations:
-                      service.beta.kubernetes.io/port_80_health-probe_protocol: tcp
               EOF
               echo "ConfigMap used by Gateway CR 'inference-gateway' created."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/manager/namespace-rhai-cloudmanager-system.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/namespace-rhai-cloudmanager-system.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -17,46 +17,12 @@ kind: Namespace
 metadata:
   name: redhat-ods-operator
 ---
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: cert-manager-operator
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: cert-manager
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-lws-operator
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system
----
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: azure-cloud-manager-operator
+  name: aws-cloud-manager-operator
   namespace: rhai-cloudmanager-system
-imagePullSecrets:
-  - name: rhai-pull-secret
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-# TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: llmisvc-controller-manager
-  namespace: redhat-ods-applications
 imagePullSecrets:
   - name: rhai-pull-secret
 ---
@@ -69,125 +35,21 @@ metadata:
 imagePullSecrets:
   - name: rhai-pull-secret
 ---
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rhai-pull-secret
-  namespace: redhat-ods-operator
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: dGVzdGF1dGg=
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rhai-pull-secret
-  namespace: redhat-ods-applications
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: dGVzdGF1dGg=
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rhai-pull-secret
-  namespace: default
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: dGVzdGF1dGg=
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rhai-pull-secret
-  namespace: rhai-cloudmanager-system
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: dGVzdGF1dGg=
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rhai-pull-secret
-  namespace: cert-manager-operator
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: dGVzdGF1dGg=
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rhai-pull-secret
-  namespace: cert-manager
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: dGVzdGF1dGg=
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rhai-pull-secret
-  namespace: openshift-lws-operator
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: dGVzdGF1dGg=
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rhai-pull-secret
-  namespace: istio-system
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: dGVzdGF1dGg=
----
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/crds/customresourcedefinition-azurekubernetesengines.infrastructure.opendatahub.io.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/crds/customresourcedefinition-awskubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
     helm.sh/resource-policy: keep
-  name: azurekubernetesengines.infrastructure.opendatahub.io
+  name: awskubernetesengines.infrastructure.opendatahub.io
 spec:
   group: infrastructure.opendatahub.io
   names:
-    kind: AzureKubernetesEngine
-    listKind: AzureKubernetesEngineList
-    plural: azurekubernetesengines
-    singular: azurekubernetesengine
+    kind: AWSKubernetesEngine
+    listKind: AWSKubernetesEngineList
+    plural: awskubernetesengines
+    singular: awskubernetesengine
   scope: Cluster
   versions:
     - additionalPrinterColumns:
@@ -207,8 +69,8 @@ spec:
       schema:
         openAPIV3Schema:
           description: |-
-            AzureKubernetesEngine is the Schema for the azurekubernetesengines API.
-            It represents the configuration for an Azure Kubernetes Service (AKS) cluster.
+            AWSKubernetesEngine is the Schema for the awskubernetesengines API.
+            It represents the configuration for an AWS Kubernetes Service cluster.
           properties:
             apiVersion:
               description: |-
@@ -228,10 +90,10 @@ spec:
             metadata:
               type: object
             spec:
-              description: AzureKubernetesEngineSpec defines the desired state of AzureKubernetesEngine.
+              description: AWSKubernetesEngineSpec defines the desired state of AWSKubernetesEngine.
               properties:
                 dependencies:
-                  description: Dependencies defines the dependency configurations for the Azure Kubernetes Engine.
+                  description: Dependencies defines the dependency configurations for the AWS Kubernetes Engine.
                   properties:
                     certManager:
                       description: CertManager defines the cert-manager operator dependency.
@@ -326,7 +188,7 @@ spec:
                   type: object
               type: object
             status:
-              description: AzureKubernetesEngineStatus defines the observed state of AzureKubernetesEngine.
+              description: AWSKubernetesEngineStatus defines the observed state of AWSKubernetesEngine.
               properties:
                 conditions:
                   items:
@@ -392,8 +254,8 @@ spec:
               type: object
           type: object
           x-kubernetes-validations:
-            - message: AzureKubernetesEngine name must be default-azurekubernetesengine
-              rule: self.metadata.name == 'default-azurekubernetesengine'
+            - message: AWSKubernetesEngine name must be default-awskubernetesengine
+              rule: self.metadata.name == 'default-awskubernetesengine'
       served: true
       storage: true
       subresources:
@@ -593,11 +455,11 @@ spec:
       subresources:
         status: {}
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrole-rhai-azure-cloud-manager-role.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrole-rhai-aws-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhai-azure-cloud-manager-role
+  name: rhai-aws-cloud-manager-role
 rules:
   - apiGroups:
       - ""
@@ -686,7 +548,7 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines
+      - awskubernetesengines
     verbs:
       - create
       - delete
@@ -698,13 +560,13 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/finalizers
+      - awskubernetesengines/finalizers
     verbs:
       - update
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines/status
+      - awskubernetesengines/status
     verbs:
       - get
       - patch
@@ -2238,18 +2100,18 @@ rules:
       - update
       - watch
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrolebinding-rhai-azure-cloud-manager-rolebinding.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrolebinding-rhai-aws-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhai-azure-cloud-manager-rolebinding
+  name: rhai-aws-cloud-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhai-azure-cloud-manager-role
+  name: rhai-aws-cloud-manager-role
 subjects:
   - kind: ServiceAccount
-    name: azure-cloud-manager-operator
+    name: aws-cloud-manager-operator
     namespace: rhai-cloudmanager-system
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
@@ -2266,11 +2128,11 @@ subjects:
     name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/role-aws-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: azure-cloud-manager-leader-election-role
+  name: aws-cloud-manager-leader-election-role
   namespace: rhai-cloudmanager-system
 rules:
   - apiGroups:
@@ -2290,19 +2152,19 @@ rules:
       - create
       - patch
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/rolebinding-azure-cloud-manager-leader-election-rolebinding.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/rolebinding-aws-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: azure-cloud-manager-leader-election-rolebinding
+  name: aws-cloud-manager-leader-election-rolebinding
   namespace: rhai-cloudmanager-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: azure-cloud-manager-leader-election-role
+  name: aws-cloud-manager-leader-election-role
 subjects:
   - kind: ServiceAccount
-    name: azure-cloud-manager-operator
+    name: aws-cloud-manager-operator
     namespace: rhai-cloudmanager-system
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
@@ -2343,28 +2205,28 @@ spec:
   selector:
     name: rhai-operator
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/deployment-aws-cloud-manager-operator.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
-    name: azure-cloud-manager-operator
-  name: azure-cloud-manager-operator
+    name: aws-cloud-manager-operator
+  name: aws-cloud-manager-operator
   namespace: rhai-cloudmanager-system
 spec:
   replicas: 1
   selector:
     matchLabels:
       control-plane: controller-manager
-      name: azure-cloud-manager-operator
+      name: aws-cloud-manager-operator
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
-        name: azure-cloud-manager-operator
+        name: aws-cloud-manager-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2383,12 +2245,12 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - azure-cloud-manager-operator
+                        - aws-cloud-manager-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
         - args:
-            - azure
+            - aws
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=0.0.0.0:8080
             - --leader-elect
@@ -2451,7 +2313,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: azure-cloud-manager-operator
+      serviceAccountName: aws-cloud-manager-operator
       terminationGracePeriodSeconds: 10
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
@@ -2875,12 +2737,12 @@ spec:
                   app.kubernetes.io/managed-by: Helm
               spec: {}
               EOF
-              echo "Creating AzureKubernetesEngine CR..."
+              echo "Creating AWSKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
-              kind: AzureKubernetesEngine
+              kind: AWSKubernetesEngine
               metadata:
-                name: default-azurekubernetesengine
+                name: default-awskubernetesengine
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm
@@ -3020,10 +2882,6 @@ spec:
                           - name: rhai-ca-bundle
                             mountPath: /var/run/secrets/rhai
                             readOnly: true
-                service: |
-                  metadata:
-                    annotations:
-                      service.beta.kubernetes.io/port_80_health-probe_protocol: tcp
               EOF
               echo "ConfigMap used by Gateway CR 'inference-gateway' created."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2613,6 +2613,7 @@ rules:
     resources:
       - azurekubernetesengines
       - coreweavekubernetesengines
+      - awskubernetesengines
     verbs:
       - get
       - create

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -2749,6 +2749,7 @@ rules:
     resources:
       - azurekubernetesengines
       - coreweavekubernetesengines
+      - awskubernetesengines
     verbs:
       - get
       - create

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -2611,6 +2611,7 @@ rules:
     resources:
       - azurekubernetesengines
       - coreweavekubernetesengines
+      - awskubernetesengines
     verbs:
       - get
       - create

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -2749,6 +2749,7 @@ rules:
     resources:
       - azurekubernetesengines
       - coreweavekubernetesengines
+      - awskubernetesengines
     verbs:
       - get
       - create

--- a/charts/rhai-on-xks-chart/values.schema.json
+++ b/charts/rhai-on-xks-chart/values.schema.json
@@ -267,6 +267,72 @@
         }
       }
     },
+    "aws": {
+      "type": "object",
+      "description": "Amazon cloud configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable AWS cloud manager resources",
+          "default": false
+        },
+        "cloudManager": {
+          "type": "object",
+          "description": "Amazon Cloud Manager configuration",
+          "properties": {
+            "namespace": {
+              "type": "string",
+              "description": "Cloud Manager operator namespace",
+              "default": "rhai-cloudmanager-system"
+            },
+            "image": {
+              "type": "string",
+              "description": "Cloud Manager container image"
+            },
+            "imagePullPolicy": {
+              "type": "string",
+              "description": "Image pull policy for the Cloud Manager container",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          }
+        },
+        "kubernetesEngine": {
+          "type": "object",
+          "description": "AWSKubernetesEngine CR configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Create AWSKubernetesEngine CR via post-install hook",
+              "default": true
+            },
+            "spec": {
+              "type": "object",
+              "description": "AWSKubernetesEngine CR spec",
+              "properties": {
+                "dependencies": {
+                  "type": "object",
+                  "description": "Dependency configurations",
+                  "properties": {
+                    "certManager": {
+                      "$ref": "#/$defs/dependency"
+                    },
+                    "gatewayAPI": {
+                      "$ref": "#/$defs/dependency"
+                    },
+                    "lws": {
+                      "$ref": "#/$defs/dependency"
+                    },
+                    "sailOperator": {
+                      "$ref": "#/$defs/dependency"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "imagePullSecret": {
       "type": "object",
       "description": "Pull secret configuration for private registries. Use --set-file imagePullSecret.dockerConfigJson=path/to/auth.json",

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -99,6 +99,36 @@ coreweave:
           configuration:
             namespace: istio-system
 
+# AWS cloud configuration
+aws:
+  enabled: false
+  cloudManager:
+    # Cloud Manager operator namespace
+    namespace: rhai-cloudmanager-system
+    # Cloud Manager container image
+    image: quay.io/opendatahub/opendatahub-operator:latest
+    # Image pull policy
+    imagePullPolicy: Always
+  kubernetesEngine:
+    # Create AWSKubernetesEngine CR via post-install hook
+    enabled: true
+    spec:
+      dependencies:
+        certManager:
+          managementPolicy: Managed
+          configuration: {}
+        gatewayAPI:
+          managementPolicy: Managed
+          configuration: {}
+        lws:
+          managementPolicy: Managed
+          configuration:
+            namespace: openshift-lws-operator
+        sailOperator:
+          managementPolicy: Managed
+          configuration:
+            namespace: istio-system
+
 # Pull secret for private registries
 # Use --set-file imagePullSecret.dockerConfigJson=path/to/auth.json
 imagePullSecret:

--- a/scripts/snapshot-config.yaml
+++ b/scripts/snapshot-config.yaml
@@ -109,3 +109,12 @@ charts:
         setFlags:
           - coreweave.enabled=true
           - imagePullSecret.dockerConfigJson=testauth
+
+      - name: aws
+        setFlags:
+          - aws.enabled=true
+
+      - name: aws-with-pull-secret
+        setFlags:
+          - aws.enabled=true
+          - imagePullSecret.dockerConfigJson=testauth


### PR DESCRIPTION
  Adds AWS as a third cloud manager provider in the rhai-on-xks Helm chart, following the existing Azure and CoreWeave  
  patterns.            
                                                                                                                        
  Depends on: opendatahub-io/opendatahub-operator#3477                                                                  
   
  ### New files (8 — copy/rename from Azure)                                                                            
                       
  - `templates/cloudmanager/aws/crds/` — AWSKubernetesEngine CRD                                                        
  - `templates/cloudmanager/aws/manager/` — Deployment + Namespace
  - `templates/cloudmanager/aws/rbac/` — ClusterRole, ClusterRoleBinding, Role, RoleBinding, ServiceAccount             
                                                                                                                        
  ### Modified files                                                                                                    
                                                                                                                        
  - `values.yaml` — Added `aws` configuration block
  - `values.schema.json` — Added AWS provider schema
  - `api-docs.md` — Regenerated via `make helm-docs`
  - `templates/_helpers.tpl` — Updated provider validation to include AWS in exactly-one-enabled check                  
  - `templates/pull-secret.yaml` — Added AWS namespace to pull secret injection                                         
  - `templates/hooks/post-install-crs-job.yaml` — Added AWSKubernetesEngine CR creation in post-install hook            
  - `templates/hooks/post-install-crs-rbac.yaml` — Added awskubernetesengines RBAC for post-install hook                
  - `templates/NOTES.txt` — Added AWS provider notes and manual CR example                                              
  - `scripts/update-bundle.sh` — Added AWS to CLOUD_TARGETS and kustomization loop                                      
  - `scripts/snapshot-config.yaml` — Added AWS snapshot test entries                                                    
  - `.github/workflows/rhai-on-xks-chart-test.yaml` — Added AWS to E2E test matrix                                      
  - `Makefile` — Added AWS to image override logic                                                                      
                                                                                                                        
  ### How it works                                                                                                      
                                                      
  Deploy with `--set aws.enabled=true`:
                                                                                                                        
  ```bash
  helm upgrade rhaii ./charts/rhai-on-xks-chart/ \                                                                      
    --install --create-namespace \                                                                                      
    --namespace rhaii \
    --set aws.enabled=true \                                                                                            
    --set-file imagePullSecret.dockerConfigJson=/path/to/auth.json
                                                                                                                        
  The AWS provider manages the same dependencies as Azure/CoreWeave:
  - Gateway API                                                                                                         
  - cert-manager                                      
  - LeaderWorkerSet (LWS)
  - Sail Operator (Istio)
                                                                                                                        
  Validation                                                                                                            
                                                                                                                        
  - helm lint passes for all three providers                                                                            
  - Mutual exclusivity enforced (aws+azure fails, no-provider fails)
  - Existing Azure and CoreWeave functionality unchanged                                                                
  - make helm-docs regenerated api-docs.md            
  - make chart-snapshots and make chart-test pass (7/7 snapshots)                                                       
   
  Test plan                                                                                                             
                                                      
  - helm lint charts/rhai-on-xks-chart/ --set aws.enabled=true passes                                                   
  - helm template test charts/rhai-on-xks-chart/ --set aws.enabled=true renders AWS resources
  - helm template test charts/rhai-on-xks-chart/ --set aws.enabled=true --set azure.enabled=true fails with mutual      
  exclusivity error                                                                                                     
  - helm lint charts/rhai-on-xks-chart/ --set azure.enabled=true still passes (no regression)                           
  - Deploy to AWS EKS cluster with operator image from opendatahub-io/opendatahub-operator#3477 