### PR TITLE
RHOAIENG-58516 - Rename ODH operator LlamaStack component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,9 +260,9 @@ helm-verify: ## Verify helm chart installation and DSC components
 # Extra arguments to pass to helm commands (e.g., --set olm.source=custom-catalog)
 HELM_EXTRA_ARGS ?=
 HELM_INSTALL_VALUES_FILE ?= docs/examples/values-all-components-managed.yaml
-# Remove llamastackoperator to avoid nfd and nvidiaGPUOperator dependencies installation on tests.
+# Remove ogx to avoid nfd and nvidiaGPUOperator dependencies installation on tests.
 # TODO: Remove modelsAsService as it depends on PostgreSQL, need to support it in the chart
-HELM_INSTALL_ARGS := -f $(HELM_INSTALL_VALUES_FILE) --set components.llamastackoperator.dsc.managementState=Removed --set components.kserve.dsc.modelsAsService.managementState=Removed
+HELM_INSTALL_ARGS := -f $(HELM_INSTALL_VALUES_FILE) --set components.ogx.dsc.managementState=Removed --set components.kserve.dsc.modelsAsService.managementState=Removed
 
 .PHONY: helm-install-verify
 helm-install-verify: ## Install helm chart and verify installation

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ The repository is designed to be applied in **layers**, providing flexibility in
 | **Tempo Operator** | Distributed tracing backend | `openshift-tempo-operator` | Tracing infrastructure | |
 | **Red Hat Connectivity Link** | Multicloud application connectivity and API management | `kuadrant-system` | Model Serving (KServe) | Leader Worker Set, Cert-Manager |
 | **MariaDB Operator** | MariaDB for OpenShift | `mariadb-operator` | TrustyAI (optional, only if using database mode) | |
-| **Node Feature Discovery** | Detects hardware features and capabilities of nodes | `openshift-nfd` | LlamaStack Operator | |
-| **NVIDIA GPU Operator** | Enables GPU-accelerated workloads on NVIDIA hardware | `nvidia-gpu-operator` | Model Serving, LlamaStack Operator | Node Feature Discovery |
+| **Node Feature Discovery** | Detects hardware features and capabilities of nodes | `openshift-nfd` | OGX | |
+| **NVIDIA GPU Operator** | Enables GPU-accelerated workloads on NVIDIA hardware | `nvidia-gpu-operator` | Model Serving, OGX | Node Feature Discovery |
 
 #### Operator Configuration Requirements
 

--- a/charts/rhai-on-openshift-chart/README.md
+++ b/charts/rhai-on-openshift-chart/README.md
@@ -200,21 +200,21 @@ High-level features that:
 | `Unmanaged` | Yes |
 | `Removed` | No |
 
-| Component | Description | Default State | Dependencies |
-|-----------|-------------|---------------|--------------|
-| `aipipelines` | AI Pipelines | Removed | - |
-| `dashboard` | Dashboard | Removed | - |
-| `feastoperator` | Feast feature store operator | Removed | - |
-| `kserve` | KServe model serving | Removed | certManager, leaderWorkerSet, jobSet, rhcl, customMetricsAutoscaler |
-| `kueue` | Kueue job queuing | Removed | certManager, kueue |
-| `llamastackoperator` | LlamaStack Operator | Removed | nfd, nvidiaGPUOperator |
-| `mlflowoperator` | MLflow tracking and model registry | Removed | - |
-| `modelregistry` | Model Registry | Removed | - |
-| `ray` | Ray distributed computing | Removed | certManager |
-| `trainer` | Trainer | Removed | certManager, jobSet |
-| `trainingoperator` | Kubeflow Training Operator | Removed | - |
-| `trustyai` | TrustyAI | Removed | - |
-| `workbenches` | Workbenches | Removed | - |
+| Component          | Description                        | Default State | Dependencies |
+|--------------------|------------------------------------|---------------|--------------|
+| `aipipelines`      | AI Pipelines                       | Removed | - |
+| `dashboard`        | Dashboard                          | Removed | - |
+| `feastoperator`    | Feast feature store operator       | Removed | - |
+| `kserve`           | KServe model serving               | Removed | certManager, leaderWorkerSet, jobSet, rhcl, customMetricsAutoscaler |
+| `kueue`            | Kueue job queuing                  | Removed | certManager, kueue |
+| `ogx`              | OGX                                | Removed | nfd, nvidiaGPUOperator |
+| `mlflowoperator`   | MLflow tracking and model registry | Removed | - |
+| `modelregistry`    | Model Registry                     | Removed | - |
+| `ray`              | Ray distributed computing          | Removed | certManager |
+| `trainer`          | Trainer                            | Removed | certManager, jobSet |
+| `trainingoperator` | Kubeflow Training Operator         | Removed | - |
+| `trustyai`         | TrustyAI                           | Removed | - |
+| `workbenches`      | Workbenches                        | Removed | - |
 
 ### Dependencies
 

--- a/charts/rhai-on-openshift-chart/api-docs.md
+++ b/charts/rhai-on-openshift-chart/api-docs.md
@@ -44,10 +44,6 @@ A Helm chart for installing ODH/RHOAI dependencies and component configurations
 | components.kueue.dependencies | object | `{"certManager":true,"kueue":true}` | Dependencies required by Kueue |
 | components.kueue.dsc | object | `{"defaultClusterQueueName":"default","defaultLocalQueueName":"default","managementState":null}` | DSC configuration for Kueue |
 | components.kueue.dsc.managementState | string | `nil` | Management state for Kueue. Null uses profile default. |
-| components.llamastackoperator | object | `{"dependencies":{"nfd":true,"nvidiaGPUOperator":true},"dsc":{"managementState":null}}` | LlamaStack Operator component |
-| components.llamastackoperator.dependencies | object | `{"nfd":true,"nvidiaGPUOperator":true}` | Dependencies required by LlamaStack Operator |
-| components.llamastackoperator.dsc | object | `{"managementState":null}` | DSC configuration for LlamaStack Operator |
-| components.llamastackoperator.dsc.managementState | string | `nil` | Management state for LlamaStack Operator. Null uses profile default. |
 | components.mlflowoperator | object | `{"dependencies":{},"dsc":{"managementState":null}}` | MLflow Operator component |
 | components.mlflowoperator.dependencies | object | `{}` | Dependencies required by MLflow Operator |
 | components.mlflowoperator.dsc | object | `{"managementState":null}` | DSC configuration for MLflow Operator |
@@ -58,6 +54,10 @@ A Helm chart for installing ODH/RHOAI dependencies and component configurations
 | components.modelregistry.dsc | object | `{"managementState":null,"registriesNamespace":null}` | DSC configuration for Model Registry |
 | components.modelregistry.dsc.managementState | string | `nil` | Management state for Model Registry. Null uses profile default. |
 | components.modelregistry.dsc.registriesNamespace | string | `nil` | Registries namespace for Model Registry (overrides defaults) |
+| components.ogx | object | `{"dependencies":{"nfd":true,"nvidiaGPUOperator":true},"dsc":{"managementState":null}}` | OGX component |
+| components.ogx.dependencies | object | `{"nfd":true,"nvidiaGPUOperator":true}` | Dependencies required by OGX |
+| components.ogx.dsc | object | `{"managementState":null}` | DSC configuration for OGX |
+| components.ogx.dsc.managementState | string | `nil` | Management state for OGX. Null uses profile default. |
 | components.ray | object | `{"dependencies":{"certManager":true},"dsc":{"managementState":null}}` | Ray component |
 | components.ray.dependencies | object | `{"certManager":true}` | Dependencies required by Ray |
 | components.ray.dsc | object | `{"managementState":null}` | DSC configuration for Ray |

--- a/charts/rhai-on-openshift-chart/test/snapshots/all-components-managed.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/all-components-managed.snap.yaml
@@ -144,13 +144,13 @@ spec:
       defaultClusterQueueName: default
       defaultLocalQueueName: default
       managementState: Unmanaged
-    llamastackoperator:
-      managementState: Managed
     mlflowoperator:
       managementState: Managed
     modelregistry:
       managementState: Managed
       registriesNamespace: odh-model-registry
+    ogx:
+      managementState: Managed
     ray:
       managementState: Managed
     sparkoperator:

--- a/charts/rhai-on-openshift-chart/test/snapshots/enable-llm-d-wva.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/enable-llm-d-wva.snap.yaml
@@ -99,13 +99,13 @@ spec:
       defaultClusterQueueName: default
       defaultLocalQueueName: default
       managementState: Removed
-    llamastackoperator:
-      managementState: Removed
     mlflowoperator:
       managementState: Removed
     modelregistry:
       managementState: Removed
       registriesNamespace: odh-model-registry
+    ogx:
+      managementState: Removed
     ray:
       managementState: Removed
     sparkoperator:

--- a/charts/rhai-on-openshift-chart/test/snapshots/inference-only.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/inference-only.snap.yaml
@@ -81,13 +81,13 @@ spec:
       defaultClusterQueueName: default
       defaultLocalQueueName: default
       managementState: Removed
-    llamastackoperator:
-      managementState: Removed
     mlflowoperator:
       managementState: Removed
     modelregistry:
       managementState: Removed
       registriesNamespace: rhoai-model-registries
+    ogx:
+      managementState: Removed
     ray:
       managementState: Removed
     sparkoperator:

--- a/charts/rhai-on-openshift-chart/test/snapshots/install-with-helm-dependencies.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/install-with-helm-dependencies.snap.yaml
@@ -45,13 +45,13 @@ spec:
       defaultClusterQueueName: default
       defaultLocalQueueName: default
       managementState: Removed
-    llamastackoperator:
-      managementState: Removed
     mlflowoperator:
       managementState: Removed
     modelregistry:
       managementState: Removed
       registriesNamespace: odh-model-registry
+    ogx:
+      managementState: Removed
     ray:
       managementState: Removed
     sparkoperator:

--- a/charts/rhai-on-openshift-chart/test/snapshots/profile-with-customization.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/profile-with-customization.snap.yaml
@@ -90,13 +90,13 @@ spec:
       defaultClusterQueueName: default
       defaultLocalQueueName: default
       managementState: Removed
-    llamastackoperator:
-      managementState: Removed
     mlflowoperator:
       managementState: Removed
     modelregistry:
       managementState: Removed
       registriesNamespace: rhoai-model-registries
+    ogx:
+      managementState: Removed
     ray:
       managementState: Removed
     sparkoperator:

--- a/charts/rhai-on-openshift-chart/test/snapshots/skip-crd-check-odh.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/skip-crd-check-odh.snap.yaml
@@ -54,13 +54,13 @@ spec:
       defaultClusterQueueName: default
       defaultLocalQueueName: default
       managementState: Removed
-    llamastackoperator:
-      managementState: Removed
     mlflowoperator:
       managementState: Removed
     modelregistry:
       managementState: Removed
       registriesNamespace: odh-model-registry
+    ogx:
+      managementState: Removed
     ray:
       managementState: Removed
     sparkoperator:

--- a/charts/rhai-on-openshift-chart/test/snapshots/skip-crd-check-rhoai.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/skip-crd-check-rhoai.snap.yaml
@@ -54,13 +54,13 @@ spec:
       defaultClusterQueueName: default
       defaultLocalQueueName: default
       managementState: Removed
-    llamastackoperator:
-      managementState: Removed
     mlflowoperator:
       managementState: Removed
     modelregistry:
       managementState: Removed
       registriesNamespace: rhoai-model-registries
+    ogx:
+      managementState: Removed
     ray:
       managementState: Removed
     sparkoperator:

--- a/charts/rhai-on-openshift-chart/test/snapshots/with-rhcl-config.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/with-rhcl-config.snap.yaml
@@ -90,13 +90,13 @@ spec:
       defaultClusterQueueName: default
       defaultLocalQueueName: default
       managementState: Removed
-    llamastackoperator:
-      managementState: Removed
     mlflowoperator:
       managementState: Removed
     modelregistry:
       managementState: Removed
       registriesNamespace: odh-model-registry
+    ogx:
+      managementState: Removed
     ray:
       managementState: Removed
     sparkoperator:

--- a/charts/rhai-on-openshift-chart/values.schema.json
+++ b/charts/rhai-on-openshift-chart/values.schema.json
@@ -138,7 +138,7 @@
         "workbenches": {
           "$ref": "#/definitions/workbenchesComponent"
         },
-        "llamastackoperator": {
+        "ogx": {
           "$ref": "#/definitions/component"
         },
         "sparkoperator": {

--- a/charts/rhai-on-openshift-chart/values.yaml
+++ b/charts/rhai-on-openshift-chart/values.yaml
@@ -338,15 +338,15 @@ components:
       # -- Management state for MLflow Operator. Null uses profile default.
       managementState:
 
-  # -- LlamaStack Operator component
-  llamastackoperator:
-    # -- Dependencies required by LlamaStack Operator
+  # -- OGX component
+  ogx:
+    # -- Dependencies required by OGX
     dependencies:
       nfd: true
       nvidiaGPUOperator: true
-    # -- DSC configuration for LlamaStack Operator
+    # -- DSC configuration for OGX
     dsc:
-      # -- Management state for LlamaStack Operator. Null uses profile default.
+      # -- Management state for OGX. Null uses profile default.
       managementState:
 
   # -- Spark Operator component

--- a/charts/rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
+++ b/charts/rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
@@ -60,7 +60,7 @@ spec:
               value: "true"
             - name: RHAI_DISABLE_KUEUE_COMPONENT
               value: "true"
-            - name: RHAI_DISABLE_LLAMASTACKOPERATOR_COMPONENT
+            - name: RHAI_DISABLE_OGX_COMPONENT
               value: "true"
             - name: RHAI_DISABLE_MLFLOWOPERATOR_COMPONENT
               value: "true"

--- a/charts/rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
+++ b/charts/rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
@@ -285,7 +285,7 @@ rules:
       - feastoperators
       - kserves
       - kueues
-      - llamastackoperators
+      - ogxs
       - mlflowoperators
       - modelcontrollers
       - modelmeshservings
@@ -325,7 +325,7 @@ rules:
       - feastoperators/status
       - kserves/status
       - kueues/status
-      - llamastackoperators/status
+      - ogxs/status
       - mlflowoperators/status
       - modelcontrollers/status
       - modelmeshservings/status
@@ -348,7 +348,7 @@ rules:
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
-      - llamastackoperators/finalizers
+      - ogxs/finalizers
       - mlflowoperators/finalizers
       - modelcontrollers/finalizers
       - modelmeshservings/finalizers

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -1155,7 +1155,7 @@ rules:
       - feastoperators
       - kserves
       - kueues
-      - llamastackoperators
+      - ogxs
       - mlflowoperators
       - modelcontrollers
       - modelmeshservings
@@ -1195,7 +1195,7 @@ rules:
       - feastoperators/status
       - kserves/status
       - kueues/status
-      - llamastackoperators/status
+      - ogxs/status
       - mlflowoperators/status
       - modelcontrollers/status
       - modelmeshservings/status
@@ -1218,7 +1218,7 @@ rules:
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
-      - llamastackoperators/finalizers
+      - ogxs/finalizers
       - mlflowoperators/finalizers
       - modelcontrollers/finalizers
       - modelmeshservings/finalizers
@@ -2516,7 +2516,7 @@ spec:
               value: "true"
             - name: RHAI_DISABLE_KUEUE_COMPONENT
               value: "true"
-            - name: RHAI_DISABLE_LLAMASTACKOPERATOR_COMPONENT
+            - name: RHAI_DISABLE_OGX_COMPONENT
               value: "true"
             - name: RHAI_DISABLE_MLFLOWOPERATOR_COMPONENT
               value: "true"

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -1017,7 +1017,7 @@ rules:
       - feastoperators
       - kserves
       - kueues
-      - llamastackoperators
+      - ogxs
       - mlflowoperators
       - modelcontrollers
       - modelmeshservings
@@ -1057,7 +1057,7 @@ rules:
       - feastoperators/status
       - kserves/status
       - kueues/status
-      - llamastackoperators/status
+      - ogxs/status
       - mlflowoperators/status
       - modelcontrollers/status
       - modelmeshservings/status
@@ -1080,7 +1080,7 @@ rules:
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
-      - llamastackoperators/finalizers
+      - ogxs/finalizers
       - mlflowoperators/finalizers
       - modelcontrollers/finalizers
       - modelmeshservings/finalizers
@@ -2378,7 +2378,7 @@ spec:
               value: "true"
             - name: RHAI_DISABLE_KUEUE_COMPONENT
               value: "true"
-            - name: RHAI_DISABLE_LLAMASTACKOPERATOR_COMPONENT
+            - name: RHAI_DISABLE_OGX_COMPONENT
               value: "true"
             - name: RHAI_DISABLE_MLFLOWOPERATOR_COMPONENT
               value: "true"

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -1155,7 +1155,7 @@ rules:
       - feastoperators
       - kserves
       - kueues
-      - llamastackoperators
+      - ogxs
       - mlflowoperators
       - modelcontrollers
       - modelmeshservings
@@ -1195,7 +1195,7 @@ rules:
       - feastoperators/status
       - kserves/status
       - kueues/status
-      - llamastackoperators/status
+      - ogxs/status
       - mlflowoperators/status
       - modelcontrollers/status
       - modelmeshservings/status
@@ -1218,7 +1218,7 @@ rules:
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
-      - llamastackoperators/finalizers
+      - ogxs/finalizers
       - mlflowoperators/finalizers
       - modelcontrollers/finalizers
       - modelmeshservings/finalizers
@@ -2516,7 +2516,7 @@ spec:
               value: "true"
             - name: RHAI_DISABLE_KUEUE_COMPONENT
               value: "true"
-            - name: RHAI_DISABLE_LLAMASTACKOPERATOR_COMPONENT
+            - name: RHAI_DISABLE_OGX_COMPONENT
               value: "true"
             - name: RHAI_DISABLE_MLFLOWOPERATOR_COMPONENT
               value: "true"

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -1017,7 +1017,7 @@ rules:
       - feastoperators
       - kserves
       - kueues
-      - llamastackoperators
+      - ogxs
       - mlflowoperators
       - modelcontrollers
       - modelmeshservings
@@ -1057,7 +1057,7 @@ rules:
       - feastoperators/status
       - kserves/status
       - kueues/status
-      - llamastackoperators/status
+      - ogxs/status
       - mlflowoperators/status
       - modelcontrollers/status
       - modelmeshservings/status
@@ -1080,7 +1080,7 @@ rules:
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
-      - llamastackoperators/finalizers
+      - ogxs/finalizers
       - mlflowoperators/finalizers
       - modelcontrollers/finalizers
       - modelmeshservings/finalizers
@@ -2378,7 +2378,7 @@ spec:
               value: "true"
             - name: RHAI_DISABLE_KUEUE_COMPONENT
               value: "true"
-            - name: RHAI_DISABLE_LLAMASTACKOPERATOR_COMPONENT
+            - name: RHAI_DISABLE_OGX_COMPONENT
               value: "true"
             - name: RHAI_DISABLE_MLFLOWOPERATOR_COMPONENT
               value: "true"

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -1155,7 +1155,7 @@ rules:
       - feastoperators
       - kserves
       - kueues
-      - llamastackoperators
+      - ogxs
       - mlflowoperators
       - modelcontrollers
       - modelmeshservings
@@ -1195,7 +1195,7 @@ rules:
       - feastoperators/status
       - kserves/status
       - kueues/status
-      - llamastackoperators/status
+      - ogxs/status
       - mlflowoperators/status
       - modelcontrollers/status
       - modelmeshservings/status
@@ -1218,7 +1218,7 @@ rules:
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
-      - llamastackoperators/finalizers
+      - ogxs/finalizers
       - mlflowoperators/finalizers
       - modelcontrollers/finalizers
       - modelmeshservings/finalizers
@@ -2516,7 +2516,7 @@ spec:
               value: "true"
             - name: RHAI_DISABLE_KUEUE_COMPONENT
               value: "true"
-            - name: RHAI_DISABLE_LLAMASTACKOPERATOR_COMPONENT
+            - name: RHAI_DISABLE_OGX_COMPONENT
               value: "true"
             - name: RHAI_DISABLE_MLFLOWOPERATOR_COMPONENT
               value: "true"

--- a/dependencies/operators/kustomization.yaml
+++ b/dependencies/operators/kustomization.yaml
@@ -11,7 +11,7 @@ components:
   - ../../components/operators/tempo-product
   - ../../components/operators/openshift-custom-metrics-autoscaler
   - ../../components/operators/rhcl-operator
-  # TODO: The following operators need a manual configuration. It needs to be added if used llamastackoperator.
+  # TODO: The following operators need a manual configuration. It needs to be added if used ogx.
   # - ../../components/operators/nfd
   # - ../../components/operators/nvidia-gpu-operator
   # MariaDB operator is an optional dependency for TrustyAI in Database mode, check README.md for more details

--- a/docs/examples/values-all-components-managed.yaml
+++ b/docs/examples/values-all-components-managed.yaml
@@ -86,6 +86,6 @@ components:
     dsc:
       managementState: Managed
 
-  llamastackoperator:
+  ogx:
     dsc:
       managementState: Managed


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
To be merged after https://github.com/opendatahub-io/opendatahub-operator/pull/3531 
JIRA: [RHOAIENG-58516](https://redhat.atlassian.net/browse/RHOAIENG-58516)

`llamastackoperator` field in values.yaml is not needed (contrary to DSC). Helm chart correctly sends all components with ogx, but without llamastackoperator field in DSC.
This will correctly create DSC as intended with llamastackoperator not visible in spec, just in status as `llamastackoperator: {}`

## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->

- [x] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated component documentation to reflect the introduction of OGX as an available operator component.

* **Chores**
  * Replaced LlamaStack Operator component with OGX component across configuration, deployment templates, and schema definitions. OGX includes the same dependencies (Node Feature Discovery, NVIDIA GPU Operator) and can be managed through existing configuration mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->