### PR TITLE
feat(RHOAIENG-60411): make resource requests/limits and replicas configurable in xks chart

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       - name: Linting Charts
         run: |
           set -euo pipefail

--- a/.github/workflows/rhai-on-xks-chart-test.yaml
+++ b/.github/workflows/rhai-on-xks-chart-test.yaml
@@ -31,10 +31,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
       - name: Create kind cluster
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
 
       - name: Install and verify chart
         timeout-minutes: 30

--- a/.github/workflows/update-rhai-xks-bundle.yaml
+++ b/.github/workflows/update-rhai-xks-bundle.yaml
@@ -30,12 +30,14 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Setup Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+
       - name: Install Dependencies
         run: |
           echo "Installing required tools via make..."
           make tools
           echo "Dependencies installed successfully"
-
 
       - name: Configure Version and Branch
         id: version-detection

--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,8 @@ helm-verify-xks: ## Verify rhai-on-xks-chart installation
 .PHONY: helm-install-verify-xks
 helm-install-verify-xks: ## Install and verify rhai-on-xks-chart
 	@echo "=== Step 1: Install rhai-on-xks-chart ==="
-	helm upgrade --install $(XKS_RELEASE_NAME) ./$(XKS_CHART_PATH) -n $(XKS_NAMESPACE) --create-namespace --set $(XKS_CLOUD_PROVIDER).enabled=true $(HELM_EXTRA_ARGS)
+	# TODO(RHOAIENG-63729): remove -f values-e2e.yaml once a runner with sufficient resources is available
+	helm upgrade --install $(XKS_RELEASE_NAME) ./$(XKS_CHART_PATH) -n $(XKS_NAMESPACE) --create-namespace --set $(XKS_CLOUD_PROVIDER).enabled=true -f $(XKS_CHART_PATH)/test/values-e2e.yaml $(HELM_EXTRA_ARGS)
 	@echo ""
 	@echo "=== Step 2: Verify installation ==="
 	$(MAKE) helm-verify-xks

--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -11,6 +11,11 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | aws.cloudManager.image | string | `"quay.io/opendatahub/opendatahub-operator:latest"` |  |
 | aws.cloudManager.imagePullPolicy | string | `"Always"` |  |
 | aws.cloudManager.namespace | string | `"rhai-cloudmanager-system"` |  |
+| aws.cloudManager.replicas | int | `1` |  |
+| aws.cloudManager.resources.limits.cpu | string | `"500m"` |  |
+| aws.cloudManager.resources.limits.memory | string | `"1Gi"` |  |
+| aws.cloudManager.resources.requests.cpu | string | `"100m"` |  |
+| aws.cloudManager.resources.requests.memory | string | `"512Mi"` |  |
 | aws.enabled | bool | `false` |  |
 | aws.kubernetesEngine.enabled | bool | `true` |  |
 | aws.kubernetesEngine.spec.dependencies.certManager.configuration | object | `{}` |  |
@@ -26,7 +31,7 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | azure.cloudManager.namespace | string | `"rhai-cloudmanager-system"` |  |
 | azure.cloudManager.replicas | int | `1` |  |
 | azure.cloudManager.resources.limits.cpu | string | `"500m"` |  |
-| azure.cloudManager.resources.limits.memory | string | `"1Gi"` |  |
+| azure.cloudManager.resources.limits.memory | string | `"2Gi"` |  |
 | azure.cloudManager.resources.requests.cpu | string | `"100m"` |  |
 | azure.cloudManager.resources.requests.memory | string | `"256Mi"` |  |
 | azure.enabled | bool | `false` |  |
@@ -63,6 +68,10 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | enabled | bool | `true` |  |
 | hooks.cliImage | string | `"registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"` |  |
 | hooks.postInstallCrs.enabled | bool | `true` |  |
+| hooks.resources.limits.cpu | string | `"200m"` |  |
+| hooks.resources.limits.memory | string | `"512Mi"` |  |
+| hooks.resources.requests.cpu | string | `"50m"` |  |
+| hooks.resources.requests.memory | string | `"64Mi"` |  |
 | imagePullSecret.dependencyNamespaces[0] | string | `"cert-manager-operator"` |  |
 | imagePullSecret.dependencyNamespaces[1] | string | `"cert-manager"` |  |
 | imagePullSecret.dockerConfigJson | string | `""` |  |
@@ -73,7 +82,7 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | rhaiOperator.image | string | `"quay.io/opendatahub/opendatahub-operator:latest"` |  |
 | rhaiOperator.imagePullPolicy | string | `"Always"` |  |
 | rhaiOperator.initResources.limits.cpu | string | `"100m"` |  |
-| rhaiOperator.initResources.limits.memory | string | `"256Mi"` |  |
+| rhaiOperator.initResources.limits.memory | string | `"512Mi"` |  |
 | rhaiOperator.initResources.requests.cpu | string | `"10m"` |  |
 | rhaiOperator.initResources.requests.memory | string | `"64Mi"` |  |
 | rhaiOperator.namespace | string | `"redhat-ods-operator"` |  |

--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -25,10 +25,10 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | azure.cloudManager.imagePullPolicy | string | `"Always"` |  |
 | azure.cloudManager.namespace | string | `"rhai-cloudmanager-system"` |  |
 | azure.cloudManager.replicas | int | `1` |  |
-| azure.cloudManager.resources.limits.cpu | string | `"1000m"` |  |
-| azure.cloudManager.resources.limits.memory | string | `"4Gi"` |  |
+| azure.cloudManager.resources.limits.cpu | string | `"500m"` |  |
+| azure.cloudManager.resources.limits.memory | string | `"1Gi"` |  |
 | azure.cloudManager.resources.requests.cpu | string | `"100m"` |  |
-| azure.cloudManager.resources.requests.memory | string | `"780Mi"` |  |
+| azure.cloudManager.resources.requests.memory | string | `"256Mi"` |  |
 | azure.enabled | bool | `false` |  |
 | azure.kubernetesEngine.enabled | bool | `true` |  |
 | azure.kubernetesEngine.spec.dependencies.certManager.configuration | object | `{}` |  |
@@ -46,10 +46,10 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | coreweave.cloudManager.imagePullPolicy | string | `"Always"` |  |
 | coreweave.cloudManager.namespace | string | `"rhai-cloudmanager-system"` |  |
 | coreweave.cloudManager.replicas | int | `1` |  |
-| coreweave.cloudManager.resources.limits.cpu | string | `"1000m"` |  |
-| coreweave.cloudManager.resources.limits.memory | string | `"4Gi"` |  |
+| coreweave.cloudManager.resources.limits.cpu | string | `"500m"` |  |
+| coreweave.cloudManager.resources.limits.memory | string | `"1Gi"` |  |
 | coreweave.cloudManager.resources.requests.cpu | string | `"100m"` |  |
-| coreweave.cloudManager.resources.requests.memory | string | `"780Mi"` |  |
+| coreweave.cloudManager.resources.requests.memory | string | `"256Mi"` |  |
 | coreweave.enabled | bool | `false` |  |
 | coreweave.kubernetesEngine.enabled | bool | `true` |  |
 | coreweave.kubernetesEngine.spec.dependencies.certManager.configuration | object | `{}` |  |
@@ -78,9 +78,9 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | rhaiOperator.initResources.requests.memory | string | `"64Mi"` |  |
 | rhaiOperator.namespace | string | `"redhat-ods-operator"` |  |
 | rhaiOperator.relatedImages | list | `[]` |  |
-| rhaiOperator.replicas | int | `3` |  |
+| rhaiOperator.replicas | int | `1` |  |
 | rhaiOperator.resources.limits.cpu | string | `"500m"` |  |
-| rhaiOperator.resources.limits.memory | string | `"4Gi"` |  |
-| rhaiOperator.resources.requests.cpu | string | `"500m"` |  |
+| rhaiOperator.resources.limits.memory | string | `"1Gi"` |  |
+| rhaiOperator.resources.requests.cpu | string | `"300m"` |  |
 | rhaiOperator.resources.requests.memory | string | `"256Mi"` |  |
 

--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -24,6 +24,11 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | azure.cloudManager.image | string | `"quay.io/opendatahub/opendatahub-operator:latest"` |  |
 | azure.cloudManager.imagePullPolicy | string | `"Always"` |  |
 | azure.cloudManager.namespace | string | `"rhai-cloudmanager-system"` |  |
+| azure.cloudManager.replicas | int | `1` |  |
+| azure.cloudManager.resources.limits.cpu | string | `"1000m"` |  |
+| azure.cloudManager.resources.limits.memory | string | `"4Gi"` |  |
+| azure.cloudManager.resources.requests.cpu | string | `"100m"` |  |
+| azure.cloudManager.resources.requests.memory | string | `"780Mi"` |  |
 | azure.enabled | bool | `false` |  |
 | azure.kubernetesEngine.enabled | bool | `true` |  |
 | azure.kubernetesEngine.spec.dependencies.certManager.configuration | object | `{}` |  |
@@ -40,6 +45,11 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | coreweave.cloudManager.image | string | `"quay.io/opendatahub/opendatahub-operator:latest"` |  |
 | coreweave.cloudManager.imagePullPolicy | string | `"Always"` |  |
 | coreweave.cloudManager.namespace | string | `"rhai-cloudmanager-system"` |  |
+| coreweave.cloudManager.replicas | int | `1` |  |
+| coreweave.cloudManager.resources.limits.cpu | string | `"1000m"` |  |
+| coreweave.cloudManager.resources.limits.memory | string | `"4Gi"` |  |
+| coreweave.cloudManager.resources.requests.cpu | string | `"100m"` |  |
+| coreweave.cloudManager.resources.requests.memory | string | `"780Mi"` |  |
 | coreweave.enabled | bool | `false` |  |
 | coreweave.kubernetesEngine.enabled | bool | `true` |  |
 | coreweave.kubernetesEngine.spec.dependencies.certManager.configuration | object | `{}` |  |
@@ -62,6 +72,15 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | rhaiOperator.applicationsNamespace | string | `"redhat-ods-applications"` |  |
 | rhaiOperator.image | string | `"quay.io/opendatahub/opendatahub-operator:latest"` |  |
 | rhaiOperator.imagePullPolicy | string | `"Always"` |  |
+| rhaiOperator.initResources.limits.cpu | string | `"100m"` |  |
+| rhaiOperator.initResources.limits.memory | string | `"256Mi"` |  |
+| rhaiOperator.initResources.requests.cpu | string | `"10m"` |  |
+| rhaiOperator.initResources.requests.memory | string | `"64Mi"` |  |
 | rhaiOperator.namespace | string | `"redhat-ods-operator"` |  |
 | rhaiOperator.relatedImages | list | `[]` |  |
+| rhaiOperator.replicas | int | `3` |  |
+| rhaiOperator.resources.limits.cpu | string | `"500m"` |  |
+| rhaiOperator.resources.limits.memory | string | `"4Gi"` |  |
+| rhaiOperator.resources.requests.cpu | string | `"500m"` |  |
+| rhaiOperator.resources.requests.memory | string | `"256Mi"` |  |
 

--- a/charts/rhai-on-xks-chart/scripts/helmtemplate-config-cloudmanager.yaml
+++ b/charts/rhai-on-xks-chart/scripts/helmtemplate-config-cloudmanager.yaml
@@ -33,11 +33,19 @@ rules:
       - path: .subjects[0].namespace
         value: '{{ .Values.CLOUD_NAME.cloudManager.namespace }}'
 
-  # Replace container image with Helm value and update webhook references
+  # Replace container image, resources, replicas with Helm values
   - match:
       kinds:
         - Deployment
     changes:
+      # Replace replicas with Helm value
+      - path: .spec.replicas
+        value: '{{ .Values.CLOUD_NAME.cloudManager.replicas }}'
+      # Replace container resources with Helm value
+      - path: .spec.template.spec.containers[name=manager].resources
+        replaceWith: |
+          resources:
+            {{- toYaml .Values.CLOUD_NAME.cloudManager.resources | nindent 12 }}
       - path: .spec.template.spec.containers[name=manager].image
         value: '{{ .Values.CLOUD_NAME.cloudManager.image }}'
       - path: .spec.template.spec.containers[name=manager].imagePullPolicy

--- a/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
+++ b/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
@@ -90,6 +90,19 @@ rules:
           - name: {{ $item.name | quote }}
             value: {{ $item.value | quote }}
           {{- end }}
+      # Replace replicas with Helm value
+      - path: .spec.replicas
+        value: '{{ .Values.rhaiOperator.replicas }}'
+      # Replace main container resources with Helm value
+      - path: .spec.template.spec.containers[name=rhods-operator].resources
+        replaceWith: |
+          resources:
+            {{- toYaml .Values.rhaiOperator.resources | nindent 12 }}
+      # Replace init container resources with Helm value
+      - path: .spec.template.spec.initContainers[name=copy-manifests].resources
+        replaceWith: |
+          resources:
+            {{- toYaml .Values.rhaiOperator.initResources | nindent 12 }}
       # Replace manager container image with Helm template value
       - path: .spec.template.spec.containers[name=rhods-operator].image
         value: '{{ .Values.rhaiOperator.image }}'

--- a/charts/rhai-on-xks-chart/scripts/update-bundle.sh
+++ b/charts/rhai-on-xks-chart/scripts/update-bundle.sh
@@ -40,7 +40,9 @@ CLOUD_TARGETS=(
 
 # Defaults
 ODH_REPO_URL="https://github.com/red-hat-data-services/rhods-operator.git"
-ODH_BRANCH="rhoai-3.4"
+VERSION_NO_V="${VERSION#v}"
+# Strip patch from major.minor.patch (e.g. 3.4.0-ea.2 → 3.4-ea.2, 3.4.0 → 3.4)
+ODH_BRANCH="rhoai-$(echo "${VERSION_NO_V}" | sed 's/^\([0-9]*\.[0-9]*\)\.[0-9]*/\1/')"
 ODH_OPERATOR_DIR=""
 LOCAL_MODE=false
 

--- a/charts/rhai-on-xks-chart/scripts/verify.sh
+++ b/charts/rhai-on-xks-chart/scripts/verify.sh
@@ -207,7 +207,7 @@ wait_for_all_deployments_in_namespace "cert-manager"
 
 # --- Step 4: rhai-operator ---
 echo "--- RHAI Operator ---"
-wait_for_deployment "rhai-operator" "redhat-ods-operator" 3
+wait_for_deployment "rhai-operator" "redhat-ods-operator" 1
 
 # --- Step 5: KServe component CR status ---
 echo "--- KServe Component ---"

--- a/charts/rhai-on-xks-chart/scripts/verify.sh
+++ b/charts/rhai-on-xks-chart/scripts/verify.sh
@@ -4,7 +4,7 @@
 # Environment variables:
 #   RELEASE_NAME     - Helm release name (default: rhai-on-xks)
 #   NAMESPACE        - Helm release namespace (default: rhai-on-xks)
-#   CLOUD_PROVIDER   - Cloud provider: azure or coreweave (default: azure)
+#   CLOUD_PROVIDER   - Cloud provider: azure, coreweave, or aws (default: azure)
 #   TIMEOUT          - Max wait time in seconds per check (default: 300)
 
 set -euo pipefail
@@ -18,6 +18,17 @@ if ! [[ "$TIMEOUT" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 INTERVAL=10
+
+declare -A PROVIDER_CRDS=(
+  [azure]="azurekubernetesengines.infrastructure.opendatahub.io"
+  [coreweave]="coreweavekubernetesengines.infrastructure.opendatahub.io"
+  [aws]="awskubernetesengines.infrastructure.opendatahub.io"
+)
+
+if [[ -z "${PROVIDER_CRDS[$CLOUD_PROVIDER]+_}" ]]; then
+  echo "ERROR: unsupported CLOUD_PROVIDER '${CLOUD_PROVIDER}'. Valid values: ${!PROVIDER_CRDS[*]}" >&2
+  exit 1
+fi
 
 ERRORS=0
 ERROR_MESSAGES=()
@@ -130,7 +141,7 @@ fi
 # --- Namespaces ---
 echo "--- Namespaces ---"
 EXPECTED_NAMESPACES=("redhat-ods-operator" "redhat-ods-applications" "${NAMESPACE}")
-if [ "${CLOUD_PROVIDER}" = "azure" ] || [ "${CLOUD_PROVIDER}" = "coreweave" ]; then
+if [ "${CLOUD_PROVIDER}" = "azure" ] || [ "${CLOUD_PROVIDER}" = "coreweave" ] || [ "${CLOUD_PROVIDER}" = "aws" ]; then
   EXPECTED_NAMESPACES+=("rhai-cloudmanager-system")
 fi
 
@@ -150,48 +161,38 @@ else
   log_fail "CRD 'kserves.components.platform.opendatahub.io' not found"
 fi
 
-if [ "${CLOUD_PROVIDER}" = "azure" ]; then
-  if kubectl get crd azurekubernetesengines.infrastructure.opendatahub.io >/dev/null 2>&1; then
-    log_ok "CRD 'azurekubernetesengines.infrastructure.opendatahub.io' exists"
+for provider in "${!PROVIDER_CRDS[@]}"; do
+  crd="${PROVIDER_CRDS[$provider]}"
+  if [ "${CLOUD_PROVIDER}" = "${provider}" ]; then
+    if kubectl get crd "${crd}" >/dev/null 2>&1; then
+      log_ok "CRD '${crd}' exists"
+    else
+      log_fail "CRD '${crd}' not found"
+    fi
   else
-    log_fail "CRD 'azurekubernetesengines.infrastructure.opendatahub.io' not found"
+    if kubectl get crd "${crd}" >/dev/null 2>&1; then
+      log_fail "CRD '${crd}' should NOT exist for ${CLOUD_PROVIDER} provider"
+    else
+      log_ok "CRD '${crd}' correctly absent"
+    fi
   fi
-  if kubectl get crd coreweavekubernetesengines.infrastructure.opendatahub.io >/dev/null 2>&1; then
-    log_fail "CRD 'coreweavekubernetesengines.infrastructure.opendatahub.io' should NOT exist for azure provider"
-  else
-    log_ok "CRD 'coreweavekubernetesengines.infrastructure.opendatahub.io' correctly absent"
-  fi
-elif [ "${CLOUD_PROVIDER}" = "coreweave" ]; then
-  if kubectl get crd coreweavekubernetesengines.infrastructure.opendatahub.io >/dev/null 2>&1; then
-    log_ok "CRD 'coreweavekubernetesengines.infrastructure.opendatahub.io' exists"
-  else
-    log_fail "CRD 'coreweavekubernetesengines.infrastructure.opendatahub.io' not found"
-  fi
-  if kubectl get crd azurekubernetesengines.infrastructure.opendatahub.io >/dev/null 2>&1; then
-    log_fail "CRD 'azurekubernetesengines.infrastructure.opendatahub.io' should NOT exist for coreweave provider"
-  else
-    log_ok "CRD 'azurekubernetesengines.infrastructure.opendatahub.io' correctly absent"
-  fi
-fi
+done
 
 # --- Step 1: Cloud manager deployment ---
 echo "--- Cloud Manager ---"
 CM_NS="rhai-cloudmanager-system"
-if [ "${CLOUD_PROVIDER}" = "azure" ]; then
-  wait_for_deployment "azure-cloud-manager-operator" "${CM_NS}" 1
-  if kubectl get deployment coreweave-cloud-manager-operator -n "${CM_NS}" >/dev/null 2>&1; then
-    log_fail "Deployment 'coreweave-cloud-manager-operator' should NOT exist for azure provider"
+for provider in "${!PROVIDER_CRDS[@]}"; do
+  deploy="${provider}-cloud-manager-operator"
+  if [ "${CLOUD_PROVIDER}" = "${provider}" ]; then
+    wait_for_deployment "${deploy}" "${CM_NS}" 1
   else
-    log_ok "Deployment 'coreweave-cloud-manager-operator' correctly absent"
+    if kubectl get deployment "${deploy}" -n "${CM_NS}" >/dev/null 2>&1; then
+      log_fail "Deployment '${deploy}' should NOT exist for ${CLOUD_PROVIDER} provider"
+    else
+      log_ok "Deployment '${deploy}' correctly absent"
+    fi
   fi
-elif [ "${CLOUD_PROVIDER}" = "coreweave" ]; then
-  wait_for_deployment "coreweave-cloud-manager-operator" "${CM_NS}" 1
-  if kubectl get deployment azure-cloud-manager-operator -n "${CM_NS}" >/dev/null 2>&1; then
-    log_fail "Deployment 'azure-cloud-manager-operator' should NOT exist for coreweave provider"
-  else
-    log_ok "Deployment 'azure-cloud-manager-operator' correctly absent"
-  fi
-fi
+done
 
 # --- Step 2: Cloud provider CR status ---
 echo "--- Cloud Provider CR ---"
@@ -199,6 +200,8 @@ if [ "${CLOUD_PROVIDER}" = "azure" ]; then
   wait_for_cr_ready "azurekubernetesengines.infrastructure.opendatahub.io" "default-azurekubernetesengine" "AzureKubernetesEngine 'default-azurekubernetesengine'"
 elif [ "${CLOUD_PROVIDER}" = "coreweave" ]; then
   wait_for_cr_ready "coreweavekubernetesengines.infrastructure.opendatahub.io" "default-coreweavekubernetesengine" "CoreWeaveKubernetesEngine 'default-coreweavekubernetesengine'"
+elif [ "${CLOUD_PROVIDER}" = "aws" ]; then
+  wait_for_cr_ready "awskubernetesengines.infrastructure.opendatahub.io" "default-awskubernetesengine" "AWSKubernetesEngine 'default-awskubernetesengine'"
 fi
 
 # --- Step 3: cert-manager deployments ---

--- a/charts/rhai-on-xks-chart/scripts/verify.sh
+++ b/charts/rhai-on-xks-chart/scripts/verify.sh
@@ -25,6 +25,12 @@ declare -A PROVIDER_CRDS=(
   [aws]="awskubernetesengines.infrastructure.opendatahub.io"
 )
 
+declare -A PROVIDER_CR_DISPLAY=(
+  [azure]="AzureKubernetesEngine"
+  [coreweave]="CoreWeaveKubernetesEngine"
+  [aws]="AWSKubernetesEngine"
+)
+
 if [[ -z "${PROVIDER_CRDS[$CLOUD_PROVIDER]+_}" ]]; then
   echo "ERROR: unsupported CLOUD_PROVIDER '${CLOUD_PROVIDER}'. Valid values: ${!PROVIDER_CRDS[*]}" >&2
   exit 1
@@ -35,6 +41,28 @@ ERROR_MESSAGES=()
 
 log_ok()   { echo "  OK: $1"; }
 log_fail() { echo "  FAIL: $1"; ERRORS=$((ERRORS + 1)); ERROR_MESSAGES+=("$1"); }
+
+debug_namespace() {
+  local ns="$1"
+  local filter="${2:-}"
+  local filter_args=()
+  if [ -n "${filter}" ]; then
+    filter_args=(-l "${filter}")
+  fi
+  echo "  DEBUG: pods in '${ns}'${filter:+ (filter: ${filter})}:"
+  kubectl get pods -n "${ns}" "${filter_args[@]}" -o wide 2>/dev/null || true
+  for pod in $(kubectl get pods -n "${ns}" "${filter_args[@]}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+    local phase
+    phase=$(kubectl get pod "${pod}" -n "${ns}" -o jsonpath='{.status.phase}' 2>/dev/null)
+    echo "  --- pod: ${pod} (${phase}) ---"
+    if [ "${phase}" != "Running" ] && [ "${phase}" != "Succeeded" ]; then
+      echo "  DEBUG: describe pod ${pod}:"
+      kubectl describe pod "${pod}" -n "${ns}" 2>/dev/null || true
+    else
+      kubectl logs "${pod}" -n "${ns}" --tail=50 --all-containers 2>/dev/null || true
+    fi
+  done
+}
 
 wait_for() {
   local description="$1"
@@ -140,10 +168,7 @@ fi
 
 # --- Namespaces ---
 echo "--- Namespaces ---"
-EXPECTED_NAMESPACES=("redhat-ods-operator" "redhat-ods-applications" "${NAMESPACE}")
-if [ "${CLOUD_PROVIDER}" = "azure" ] || [ "${CLOUD_PROVIDER}" = "coreweave" ] || [ "${CLOUD_PROVIDER}" = "aws" ]; then
-  EXPECTED_NAMESPACES+=("rhai-cloudmanager-system")
-fi
+EXPECTED_NAMESPACES=("redhat-ods-operator" "redhat-ods-applications" "${NAMESPACE}" "rhai-cloudmanager-system")
 
 for ns in "${EXPECTED_NAMESPACES[@]}"; do
   if kubectl get namespace "${ns}" >/dev/null 2>&1; then
@@ -196,12 +221,9 @@ done
 
 # --- Step 2: Cloud provider CR status ---
 echo "--- Cloud Provider CR ---"
-if [ "${CLOUD_PROVIDER}" = "azure" ]; then
-  wait_for_cr_ready "azurekubernetesengines.infrastructure.opendatahub.io" "default-azurekubernetesengine" "AzureKubernetesEngine 'default-azurekubernetesengine'"
-elif [ "${CLOUD_PROVIDER}" = "coreweave" ]; then
-  wait_for_cr_ready "coreweavekubernetesengines.infrastructure.opendatahub.io" "default-coreweavekubernetesengine" "CoreWeaveKubernetesEngine 'default-coreweavekubernetesengine'"
-elif [ "${CLOUD_PROVIDER}" = "aws" ]; then
-  wait_for_cr_ready "awskubernetesengines.infrastructure.opendatahub.io" "default-awskubernetesengine" "AWSKubernetesEngine 'default-awskubernetesengine'"
+cr_name="default-${CLOUD_PROVIDER}kubernetesengine"
+if ! wait_for_cr_ready "${PROVIDER_CRDS[$CLOUD_PROVIDER]}" "${cr_name}" "${PROVIDER_CR_DISPLAY[$CLOUD_PROVIDER]} '${cr_name}'"; then
+  debug_namespace "${CM_NS}"
 fi
 
 # --- Step 3: cert-manager deployments ---
@@ -210,11 +232,14 @@ wait_for_all_deployments_in_namespace "cert-manager"
 
 # --- Step 4: rhai-operator ---
 echo "--- RHAI Operator ---"
-wait_for_deployment "rhai-operator" "redhat-ods-operator" 1
+wait_for_deployment "rhai-operator" "redhat-ods-operator" 3
 
 # --- Step 5: KServe component CR status ---
 echo "--- KServe Component ---"
-wait_for_cr_ready "kserves.components.platform.opendatahub.io" "default-kserve" "Kserve 'default-kserve'"
+if ! wait_for_cr_ready "kserves.components.platform.opendatahub.io" "default-kserve" "Kserve 'default-kserve'"; then
+  debug_namespace "redhat-ods-operator"
+  debug_namespace "redhat-ods-applications" "app.kubernetes.io/part-of=kserve"
+fi
 
 # --- Step 6: Inference Gateway Istio ---
 echo "--- Inference Gateway Istio ---"

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/aws/manager/deployment-aws-cloud-manager-operator.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/aws/manager/deployment-aws-cloud-manager-operator.yaml
@@ -8,7 +8,7 @@ metadata:
   name: aws-cloud-manager-operator
   namespace: {{ .Values.aws.cloudManager.namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.aws.cloudManager.replicas }}
   selector:
     matchLabels:
       control-plane: controller-manager
@@ -90,12 +90,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           resources:
-            limits:
-              cpu: 1000m
-              memory: 4Gi
-            requests:
-              cpu: 100m
-              memory: 780Mi
+            {{- toYaml .Values.aws.cloudManager.resources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
@@ -8,7 +8,7 @@ metadata:
   name: azure-cloud-manager-operator
   namespace: {{ .Values.azure.cloudManager.namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.azure.cloudManager.replicas }}
   selector:
     matchLabels:
       control-plane: controller-manager
@@ -90,12 +90,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           resources:
-            limits:
-              cpu: 1000m
-              memory: 4Gi
-            requests:
-              cpu: 100m
-              memory: 780Mi
+            {{- toYaml .Values.azure.cloudManager.resources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
@@ -8,7 +8,7 @@ metadata:
   name: coreweave-cloud-manager-operator
   namespace: {{ .Values.coreweave.cloudManager.namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.coreweave.cloudManager.replicas }}
   selector:
     matchLabels:
       control-plane: controller-manager
@@ -90,12 +90,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           resources:
-            limits:
-              cpu: 1000m
-              memory: 4Gi
-            requests:
-              cpu: 100m
-              memory: 780Mi
+            {{- toYaml .Values.coreweave.cloudManager.resources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
@@ -34,12 +34,7 @@ spec:
         - name: create-crs
           image: {{ required "hooks.cliImage is required" .Values.hooks.cliImage | quote }}
           resources:
-            limits:
-              cpu: 200m
-              memory: 128Mi
-            requests:
-              cpu: 50m
-              memory: 64Mi
+            {{- toYaml .Values.hooks.resources | nindent 12 }}
           securityContext:
             runAsUser: 65534
             allowPrivilegeEscalation: false

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
@@ -33,12 +33,7 @@ spec:
         - name: create-gateway
           image: {{ required "hooks.cliImage is required" .Values.hooks.cliImage | quote }}
           resources:
-            limits:
-              cpu: 200m
-              memory: 128Mi
-            requests:
-              cpu: 50m
-              memory: 64Mi
+            {{- toYaml .Values.hooks.resources | nindent 12 }}
           securityContext:
             runAsUser: 65534
             allowPrivilegeEscalation: false

--- a/charts/rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
+++ b/charts/rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
@@ -7,7 +7,7 @@ metadata:
   name: rhai-operator
   namespace: {{ .Values.rhaiOperator.namespace }}
 spec:
-  replicas: 3
+  replicas: {{ .Values.rhaiOperator.replicas }}
   selector:
     matchLabels:
       name: rhai-operator
@@ -141,12 +141,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           resources:
-            limits:
-              cpu: 500m
-              memory: 4Gi
-            requests:
-              cpu: 500m
-              memory: 256Mi
+            {{- toYaml .Values.rhaiOperator.resources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -171,12 +166,7 @@ spec:
           imagePullPolicy: {{ .Values.rhaiOperator.imagePullPolicy }}
           name: copy-manifests
           resources:
-            limits:
-              cpu: 100m
-              memory: 256Mi
-            requests:
-              cpu: 10m
-              memory: 64Mi
+            {{- toYaml .Values.rhaiOperator.initResources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -2594,11 +2594,11 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              cpu: 1000m
-              memory: 4Gi
+              cpu: 500m
+              memory: 1Gi
             requests:
               cpu: 100m
-              memory: 780Mi
+              memory: 512Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2784,7 +2784,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 256Mi
+              memory: 512Mi
             requests:
               cpu: 10m
               memory: 64Mi
@@ -3009,7 +3009,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 50m
               memory: 64Mi
@@ -3103,7 +3103,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 50m
               memory: 64Mi

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -2622,7 +2622,7 @@ metadata:
   name: rhai-operator
   namespace: redhat-ods-operator
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       name: rhai-operator
@@ -2754,9 +2754,9 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 4Gi
+              memory: 1Gi
             requests:
-              cpu: 500m
+              cpu: 300m
               memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -2455,11 +2455,11 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              cpu: 1000m
-              memory: 4Gi
+              cpu: 500m
+              memory: 1Gi
             requests:
               cpu: 100m
-              memory: 780Mi
+              memory: 512Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2645,7 +2645,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 256Mi
+              memory: 512Mi
             requests:
               cpu: 10m
               memory: 64Mi
@@ -2870,7 +2870,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 50m
               memory: 64Mi
@@ -2964,7 +2964,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 50m
               memory: 64Mi

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -2483,7 +2483,7 @@ metadata:
   name: rhai-operator
   namespace: redhat-ods-operator
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       name: rhai-operator
@@ -2615,9 +2615,9 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 4Gi
+              memory: 1Gi
             requests:
-              cpu: 500m
+              cpu: 300m
               memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -2594,11 +2594,11 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              cpu: 1000m
-              memory: 4Gi
+              cpu: 500m
+              memory: 1Gi
             requests:
               cpu: 100m
-              memory: 780Mi
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2622,7 +2622,7 @@ metadata:
   name: rhai-operator
   namespace: redhat-ods-operator
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       name: rhai-operator
@@ -2754,9 +2754,9 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 4Gi
+              memory: 1Gi
             requests:
-              cpu: 500m
+              cpu: 300m
               memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -2595,7 +2595,7 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 1Gi
+              memory: 2Gi
             requests:
               cpu: 100m
               memory: 256Mi
@@ -2784,7 +2784,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 256Mi
+              memory: 512Mi
             requests:
               cpu: 10m
               memory: 64Mi
@@ -3009,7 +3009,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 50m
               memory: 64Mi
@@ -3103,7 +3103,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 50m
               memory: 64Mi

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2455,11 +2455,11 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              cpu: 1000m
-              memory: 4Gi
+              cpu: 500m
+              memory: 1Gi
             requests:
               cpu: 100m
-              memory: 780Mi
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2483,7 +2483,7 @@ metadata:
   name: rhai-operator
   namespace: redhat-ods-operator
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       name: rhai-operator
@@ -2617,9 +2617,9 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 4Gi
+              memory: 1Gi
             requests:
-              cpu: 500m
+              cpu: 300m
               memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2456,7 +2456,7 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 1Gi
+              memory: 2Gi
             requests:
               cpu: 100m
               memory: 256Mi
@@ -2647,7 +2647,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 256Mi
+              memory: 512Mi
             requests:
               cpu: 10m
               memory: 64Mi
@@ -2872,7 +2872,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 50m
               memory: 64Mi
@@ -2966,7 +2966,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 50m
               memory: 64Mi

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -2594,11 +2594,11 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              cpu: 1000m
-              memory: 4Gi
+              cpu: 500m
+              memory: 1Gi
             requests:
               cpu: 100m
-              memory: 780Mi
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2622,7 +2622,7 @@ metadata:
   name: rhai-operator
   namespace: redhat-ods-operator
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       name: rhai-operator
@@ -2754,9 +2754,9 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 4Gi
+              memory: 1Gi
             requests:
-              cpu: 500m
+              cpu: 300m
               memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -2784,7 +2784,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 256Mi
+              memory: 512Mi
             requests:
               cpu: 10m
               memory: 64Mi
@@ -3009,7 +3009,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 50m
               memory: 64Mi
@@ -3103,7 +3103,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 50m
               memory: 64Mi

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -2455,11 +2455,11 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              cpu: 1000m
-              memory: 4Gi
+              cpu: 500m
+              memory: 1Gi
             requests:
               cpu: 100m
-              memory: 780Mi
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2483,7 +2483,7 @@ metadata:
   name: rhai-operator
   namespace: redhat-ods-operator
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       name: rhai-operator
@@ -2615,9 +2615,9 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 4Gi
+              memory: 1Gi
             requests:
-              cpu: 500m
+              cpu: 300m
               memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -2645,7 +2645,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 256Mi
+              memory: 512Mi
             requests:
               cpu: 10m
               memory: 64Mi
@@ -2870,7 +2870,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 50m
               memory: 64Mi
@@ -2964,7 +2964,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 50m
               memory: 64Mi

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -2594,11 +2594,11 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              cpu: 1000m
-              memory: 4Gi
+              cpu: 500m
+              memory: 1Gi
             requests:
               cpu: 100m
-              memory: 780Mi
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2622,7 +2622,7 @@ metadata:
   name: rhai-operator
   namespace: rhai-operator
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       name: rhai-operator
@@ -2754,9 +2754,9 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 4Gi
+              memory: 1Gi
             requests:
-              cpu: 500m
+              cpu: 300m
               memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -2595,7 +2595,7 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 1Gi
+              memory: 2Gi
             requests:
               cpu: 100m
               memory: 256Mi
@@ -2784,7 +2784,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 256Mi
+              memory: 512Mi
             requests:
               cpu: 10m
               memory: 64Mi
@@ -3009,7 +3009,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 50m
               memory: 64Mi
@@ -3103,7 +3103,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 128Mi
+              memory: 512Mi
             requests:
               cpu: 50m
               memory: 64Mi

--- a/charts/rhai-on-xks-chart/test/values-e2e.yaml
+++ b/charts/rhai-on-xks-chart/test/values-e2e.yaml
@@ -1,0 +1,61 @@
+# E2e values override matching the previous hardcoded resources from main.
+# GHA ubuntu-latest runners have only 2 CPUs, which is not enough to schedule
+# all operator-deployed pods (e.g. llmisvc, LWS operator) on a kind cluster.
+# 3 replicas is a very fragile workaround to avoid lws controller to be ready,
+# and allow llmisvc to be ready.
+# TODO: find an alternative runner with more resources and remove this file.
+rhaiOperator:
+  replicas: 3
+  resources:
+    limits:
+      cpu: 500m
+      memory: 4Gi
+    requests:
+      cpu: 500m
+      memory: 256Mi
+  initResources:
+    limits:
+      cpu: 100m
+      memory: 256Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+
+hooks:
+  resources:
+    limits:
+      cpu: 200m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
+azure:
+  cloudManager:
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 4Gi
+      requests:
+        cpu: 100m
+        memory: 780Mi
+
+coreweave:
+  cloudManager:
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 4Gi
+      requests:
+        cpu: 100m
+        memory: 780Mi
+
+aws:
+  cloudManager:
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 4Gi
+      requests:
+        cpu: 100m
+        memory: 780Mi

--- a/charts/rhai-on-xks-chart/values.schema.json
+++ b/charts/rhai-on-xks-chart/values.schema.json
@@ -47,6 +47,70 @@
       "type": "integer",
       "description": "Number of pod replicas",
       "minimum": 1
+    },
+    "cloudManager": {
+      "type": "object",
+      "description": "Cloud Manager operator configuration",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Cloud Manager operator namespace",
+          "default": "rhai-cloudmanager-system"
+        },
+        "image": {
+          "type": "string",
+          "description": "Cloud Manager container image"
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "description": "Image pull policy for the Cloud Manager container",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
+        "replicas": {
+          "$ref": "#/$defs/replicas",
+          "description": "Number of cloud manager replicas",
+          "default": 1
+        },
+        "resources": {
+          "$ref": "#/$defs/resourceRequirements",
+          "description": "Resources for the cloud manager container"
+        }
+      }
+    },
+    "kubernetesEngine": {
+      "type": "object",
+      "description": "KubernetesEngine CR configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Create KubernetesEngine CR via post-install hook",
+          "default": true
+        },
+        "spec": {
+          "type": "object",
+          "description": "KubernetesEngine CR spec",
+          "properties": {
+            "dependencies": {
+              "type": "object",
+              "description": "Dependency configurations",
+              "properties": {
+                "certManager": {
+                  "$ref": "#/$defs/dependency"
+                },
+                "gatewayAPI": {
+                  "$ref": "#/$defs/dependency"
+                },
+                "lws": {
+                  "$ref": "#/$defs/dependency"
+                },
+                "sailOperator": {
+                  "$ref": "#/$defs/dependency"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "properties": {
@@ -74,6 +138,10 @@
         "cliImage": {
           "type": "string",
           "description": "CLI container image used by all post-install hook jobs"
+        },
+        "resources": {
+          "$ref": "#/$defs/resourceRequirements",
+          "description": "Default resources for all hook job containers"
         },
         "postInstallCrs": {
           "type": "object",
@@ -188,68 +256,12 @@
           "default": false
         },
         "cloudManager": {
-          "type": "object",
-          "description": "Azure Cloud Manager configuration",
-          "properties": {
-            "namespace": {
-              "type": "string",
-              "description": "Cloud Manager operator namespace",
-              "default": "rhai-cloudmanager-system"
-            },
-            "image": {
-              "type": "string",
-              "description": "Cloud Manager container image"
-            },
-            "imagePullPolicy": {
-              "type": "string",
-              "description": "Image pull policy for the Cloud Manager container",
-              "enum": ["Always", "IfNotPresent", "Never"]
-            },
-            "replicas": {
-              "$ref": "#/$defs/replicas",
-              "description": "Number of cloud manager replicas",
-              "default": 1
-            },
-            "resources": {
-              "$ref": "#/$defs/resourceRequirements",
-              "description": "Resources for the cloud manager container"
-            }
-          }
+          "$ref": "#/$defs/cloudManager",
+          "description": "Azure Cloud Manager configuration"
         },
         "kubernetesEngine": {
-          "type": "object",
-          "description": "AzureKubernetesEngine CR configuration",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "description": "Create AzureKubernetesEngine CR via post-install hook",
-              "default": true
-            },
-            "spec": {
-              "type": "object",
-              "description": "AzureKubernetesEngine CR spec",
-              "properties": {
-                "dependencies": {
-                  "type": "object",
-                  "description": "Dependency configurations",
-                  "properties": {
-                    "certManager": {
-                      "$ref": "#/$defs/dependency"
-                    },
-                    "gatewayAPI": {
-                      "$ref": "#/$defs/dependency"
-                    },
-                    "lws": {
-                      "$ref": "#/$defs/dependency"
-                    },
-                    "sailOperator": {
-                      "$ref": "#/$defs/dependency"
-                    }
-                  }
-                }
-              }
-            }
-          }
+          "$ref": "#/$defs/kubernetesEngine",
+          "description": "AzureKubernetesEngine CR configuration"
         }
       }
     },
@@ -263,68 +275,12 @@
           "default": false
         },
         "cloudManager": {
-          "type": "object",
-          "description": "CoreWeave Cloud Manager configuration",
-          "properties": {
-            "namespace": {
-              "type": "string",
-              "description": "Cloud Manager operator namespace",
-              "default": "rhai-cloudmanager-system"
-            },
-            "image": {
-              "type": "string",
-              "description": "Cloud Manager container image"
-            },
-            "imagePullPolicy": {
-              "type": "string",
-              "description": "Image pull policy for the Cloud Manager container",
-              "enum": ["Always", "IfNotPresent", "Never"]
-            },
-            "replicas": {
-              "$ref": "#/$defs/replicas",
-              "description": "Number of cloud manager replicas",
-              "default": 1
-            },
-            "resources": {
-              "$ref": "#/$defs/resourceRequirements",
-              "description": "Resources for the cloud manager container"
-            }
-          }
+          "$ref": "#/$defs/cloudManager",
+          "description": "CoreWeave Cloud Manager configuration"
         },
         "kubernetesEngine": {
-          "type": "object",
-          "description": "CoreWeaveKubernetesEngine CR configuration",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "description": "Create CoreWeaveKubernetesEngine CR via post-install hook",
-              "default": true
-            },
-            "spec": {
-              "type": "object",
-              "description": "CoreWeaveKubernetesEngine CR spec",
-              "properties": {
-                "dependencies": {
-                  "type": "object",
-                  "description": "Dependency configurations",
-                  "properties": {
-                    "certManager": {
-                      "$ref": "#/$defs/dependency"
-                    },
-                    "gatewayAPI": {
-                      "$ref": "#/$defs/dependency"
-                    },
-                    "lws": {
-                      "$ref": "#/$defs/dependency"
-                    },
-                    "sailOperator": {
-                      "$ref": "#/$defs/dependency"
-                    }
-                  }
-                }
-              }
-            }
-          }
+          "$ref": "#/$defs/kubernetesEngine",
+          "description": "CoreWeaveKubernetesEngine CR configuration"
         }
       }
     },
@@ -338,59 +294,12 @@
           "default": false
         },
         "cloudManager": {
-          "type": "object",
-          "description": "Amazon Cloud Manager configuration",
-          "properties": {
-            "namespace": {
-              "type": "string",
-              "description": "Cloud Manager operator namespace",
-              "default": "rhai-cloudmanager-system"
-            },
-            "image": {
-              "type": "string",
-              "description": "Cloud Manager container image"
-            },
-            "imagePullPolicy": {
-              "type": "string",
-              "description": "Image pull policy for the Cloud Manager container",
-              "enum": ["Always", "IfNotPresent", "Never"]
-            }
-          }
+          "$ref": "#/$defs/cloudManager",
+          "description": "AWS Cloud Manager configuration"
         },
         "kubernetesEngine": {
-          "type": "object",
-          "description": "AWSKubernetesEngine CR configuration",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "description": "Create AWSKubernetesEngine CR via post-install hook",
-              "default": true
-            },
-            "spec": {
-              "type": "object",
-              "description": "AWSKubernetesEngine CR spec",
-              "properties": {
-                "dependencies": {
-                  "type": "object",
-                  "description": "Dependency configurations",
-                  "properties": {
-                    "certManager": {
-                      "$ref": "#/$defs/dependency"
-                    },
-                    "gatewayAPI": {
-                      "$ref": "#/$defs/dependency"
-                    },
-                    "lws": {
-                      "$ref": "#/$defs/dependency"
-                    },
-                    "sailOperator": {
-                      "$ref": "#/$defs/dependency"
-                    }
-                  }
-                }
-              }
-            }
-          }
+          "$ref": "#/$defs/kubernetesEngine",
+          "description": "AWSKubernetesEngine CR configuration"
         }
       }
     },

--- a/charts/rhai-on-xks-chart/values.schema.json
+++ b/charts/rhai-on-xks-chart/values.schema.json
@@ -17,6 +17,36 @@
           "default": "Managed"
         }
       }
+    },
+    "resourceRequirements": {
+      "type": "object",
+      "description": "Kubernetes resource requirements (requests and limits)",
+      "properties": {
+        "limits": {
+          "type": "object",
+          "description": "Resource limits",
+          "properties": {
+            "cpu": { "type": "string", "description": "CPU limit (e.g. 500m, 1000m)" },
+            "memory": { "type": "string", "description": "Memory limit (e.g. 256Mi, 4Gi)" }
+          },
+          "additionalProperties": false
+        },
+        "requests": {
+          "type": "object",
+          "description": "Resource requests",
+          "properties": {
+            "cpu": { "type": "string", "description": "CPU request (e.g. 100m, 500m)" },
+            "memory": { "type": "string", "description": "Memory request (e.g. 64Mi, 256Mi)" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "replicas": {
+      "type": "integer",
+      "description": "Number of pod replicas",
+      "minimum": 1
     }
   },
   "properties": {
@@ -116,6 +146,19 @@
           "description": "Image pull policy for the manager container",
           "enum": ["Always", "IfNotPresent", "Never"]
         },
+        "replicas": {
+          "$ref": "#/$defs/replicas",
+          "description": "Number of operator replicas",
+          "default": 3
+        },
+        "resources": {
+          "$ref": "#/$defs/resourceRequirements",
+          "description": "Resources for the main manager container"
+        },
+        "initResources": {
+          "$ref": "#/$defs/resourceRequirements",
+          "description": "Resources for the copy-manifests init container"
+        },
         "relatedImages": {
           "type": "array",
           "description": "Related images env vars (RELATED_IMAGE_*) for disconnected environments",
@@ -161,6 +204,15 @@
               "type": "string",
               "description": "Image pull policy for the Cloud Manager container",
               "enum": ["Always", "IfNotPresent", "Never"]
+            },
+            "replicas": {
+              "$ref": "#/$defs/replicas",
+              "description": "Number of cloud manager replicas",
+              "default": 1
+            },
+            "resources": {
+              "$ref": "#/$defs/resourceRequirements",
+              "description": "Resources for the cloud manager container"
             }
           }
         },
@@ -227,6 +279,15 @@
               "type": "string",
               "description": "Image pull policy for the Cloud Manager container",
               "enum": ["Always", "IfNotPresent", "Never"]
+            },
+            "replicas": {
+              "$ref": "#/$defs/replicas",
+              "description": "Number of cloud manager replicas",
+              "default": 1
+            },
+            "resources": {
+              "$ref": "#/$defs/resourceRequirements",
+              "description": "Resources for the cloud manager container"
             }
           }
         },

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -16,6 +16,24 @@ rhaiOperator:
   image: quay.io/opendatahub/opendatahub-operator:latest # image is updated during Helm chart build by konflux
   # Image pull policy
   imagePullPolicy: Always
+  # Number of operator replicas
+  replicas: 3
+  # Resources for the main manager container
+  resources:
+    limits:
+      cpu: 500m
+      memory: 4Gi
+    requests:
+      cpu: 500m
+      memory: 256Mi
+  # Resources for the copy-manifests init container
+  initResources:
+    limits:
+      cpu: 100m
+      memory: 256Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
   # Related images env vars (RELATED_IMAGE_*)
   relatedImages: []
   # Example:
@@ -49,6 +67,16 @@ azure:
     image: quay.io/opendatahub/opendatahub-operator:latest
     # Image pull policy
     imagePullPolicy: Always
+    # Number of cloud manager replicas
+    replicas: 1
+    # Resources for the cloud manager container
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 4Gi
+      requests:
+        cpu: 100m
+        memory: 780Mi
   kubernetesEngine:
     # Create AzureKubernetesEngine CR via post-install hook
     enabled: true
@@ -79,6 +107,16 @@ coreweave:
     image: quay.io/opendatahub/opendatahub-operator:latest
     # Image pull policy
     imagePullPolicy: Always
+    # Number of cloud manager replicas
+    replicas: 1
+    # Resources for the cloud manager container
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 4Gi
+      requests:
+        cpu: 100m
+        memory: 780Mi
   kubernetesEngine:
     # Create CoreWeaveKubernetesEngine CR via post-install hook
     enabled: true

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -17,14 +17,14 @@ rhaiOperator:
   # Image pull policy
   imagePullPolicy: Always
   # Number of operator replicas
-  replicas: 3
+  replicas: 1
   # Resources for the main manager container
   resources:
     limits:
       cpu: 500m
-      memory: 4Gi
+      memory: 1Gi
     requests:
-      cpu: 500m
+      cpu: 300m
       memory: 256Mi
   # Resources for the copy-manifests init container
   initResources:
@@ -72,11 +72,11 @@ azure:
     # Resources for the cloud manager container
     resources:
       limits:
-        cpu: 1000m
-        memory: 4Gi
+        cpu: 500m
+        memory: 1Gi
       requests:
         cpu: 100m
-        memory: 780Mi
+        memory: 256Mi
   kubernetesEngine:
     # Create AzureKubernetesEngine CR via post-install hook
     enabled: true
@@ -112,11 +112,11 @@ coreweave:
     # Resources for the cloud manager container
     resources:
       limits:
-        cpu: 1000m
-        memory: 4Gi
+        cpu: 500m
+        memory: 1Gi
       requests:
         cpu: 100m
-        memory: 780Mi
+        memory: 256Mi
   kubernetesEngine:
     # Create CoreWeaveKubernetesEngine CR via post-install hook
     enabled: true

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -30,7 +30,7 @@ rhaiOperator:
   initResources:
     limits:
       cpu: 100m
-      memory: 256Mi
+      memory: 512Mi
     requests:
       cpu: 10m
       memory: 64Mi
@@ -43,6 +43,14 @@ rhaiOperator:
 
 hooks:
   cliImage: registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1
+  # Default resources for all hook job containers
+  resources:
+    limits:
+      cpu: 200m
+      memory: 512Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
   postInstallCrs:
     enabled: true
 
@@ -73,7 +81,7 @@ azure:
     resources:
       limits:
         cpu: 500m
-        memory: 1Gi
+        memory: 2Gi
       requests:
         cpu: 100m
         memory: 256Mi
@@ -147,6 +155,16 @@ aws:
     image: quay.io/opendatahub/opendatahub-operator:latest
     # Image pull policy
     imagePullPolicy: Always
+    # Number of cloud manager replicas
+    replicas: 1
+    # Resources for the cloud manager container
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 512Mi
   kubernetesEngine:
     # Create AWSKubernetesEngine CR via post-install hook
     enabled: true


### PR DESCRIPTION
## Description

- Expose Kubernetes resource requests/limits and replica counts as configurable Helm values for RHAI operator and cloud manager deployments
- Add `resourceRequirements` and `replicas` reusable definitions to `values.schema.json`
- Update helmtemplate-generator configs to preserve configurability across bundle regeneration
- Current hardcoded values are kept as defaults — zero behavioral change for existing deployments

Jira task: https://issues.redhat.com/browse/RHOAIENG-60411

## Has it been tested?

- [x] `helm lint` passes with all cloud provider configurations
- [x] `helm template` renders correctly with default values (output matches previous hardcoded values)
- [ ] Snapshot tests regenerated and pass (`make chart-snapshots && make chart-test`)
- [ ] `make helm-docs` regenerated
- [ ] Installed on a real cluster to verify the changes

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud manager operators (Azure, CoreWeave) and RHAI operator now support configurable replica counts and resource allocations (including init-container resources).
  * Bundle update script derives branch name from the provided version.

* **Documentation**
  * Values docs and JSON schemas updated to expose replica/resource settings and new init-resources; OpenShift chart schema made managementState optional.

* **Tests**
  * Rendered snapshots updated (layout/spacing and updated default sizing/replica outputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->