### PR TITLE
chore: azure default resources equal to other cluster type

### DIFF
--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -31,7 +31,7 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | azure.cloudManager.namespace | string | `"rhai-cloudmanager-system"` |  |
 | azure.cloudManager.replicas | int | `1` |  |
 | azure.cloudManager.resources.limits.cpu | string | `"500m"` |  |
-| azure.cloudManager.resources.limits.memory | string | `"2Gi"` |  |
+| azure.cloudManager.resources.limits.memory | string | `"1Gi"` |  |
 | azure.cloudManager.resources.requests.cpu | string | `"100m"` |  |
 | azure.cloudManager.resources.requests.memory | string | `"256Mi"` |  |
 | azure.enabled | bool | `false` |  |

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -2595,7 +2595,7 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 2Gi
+              memory: 1Gi
             requests:
               cpu: 100m
               memory: 256Mi

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2456,7 +2456,7 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 2Gi
+              memory: 1Gi
             requests:
               cpu: 100m
               memory: 256Mi

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -2595,7 +2595,7 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 2Gi
+              memory: 1Gi
             requests:
               cpu: 100m
               memory: 256Mi

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -81,7 +81,7 @@ azure:
     resources:
       limits:
         cpu: 500m
-        memory: 2Gi
+        memory: 1Gi
       requests:
         cpu: 100m
         memory: 256Mi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced memory limit for Azure cloud manager component from 2Gi to 1Gi across deployment configuration and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->