### PR TITLE
 feat: add support for limit allowedRoute in GW

### DIFF
--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -45,7 +45,7 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | azure.kubernetesEngine.spec.dependencies.sailOperator.configuration.namespace | string | `"istio-system"` |  |
 | azure.kubernetesEngine.spec.dependencies.sailOperator.managementPolicy | string | `"Managed"` |  |
 | components.kserve.enabled | bool | `true` |  |
-| components.kserve.gateway.allowedRoutes.namespaces.from | string | `""` |  |
+| components.kserve.gateway.allowedRoutes.namespaces.from | string | `"All"` |  |
 | components.kserve.gateway.create | bool | `true` |  |
 | components.kserve.spec | object | `{}` |  |
 | coreweave.cloudManager.image | string | `"quay.io/opendatahub/opendatahub-operator:latest"` |  |

--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -45,6 +45,7 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | azure.kubernetesEngine.spec.dependencies.sailOperator.configuration.namespace | string | `"istio-system"` |  |
 | azure.kubernetesEngine.spec.dependencies.sailOperator.managementPolicy | string | `"Managed"` |  |
 | components.kserve.enabled | bool | `true` |  |
+| components.kserve.gateway.allowedRoutes.namespaces.from | string | `"All"` |  |
 | components.kserve.gateway.create | bool | `true` |  |
 | components.kserve.spec | object | `{}` |  |
 | coreweave.cloudManager.image | string | `"quay.io/opendatahub/opendatahub-operator:latest"` |  |

--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -45,7 +45,7 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | azure.kubernetesEngine.spec.dependencies.sailOperator.configuration.namespace | string | `"istio-system"` |  |
 | azure.kubernetesEngine.spec.dependencies.sailOperator.managementPolicy | string | `"Managed"` |  |
 | components.kserve.enabled | bool | `true` |  |
-| components.kserve.gateway.allowedRoutes.namespaces.from | string | `"All"` |  |
+| components.kserve.gateway.allowedRoutes.namespaces.from | string | `""` |  |
 | components.kserve.gateway.create | bool | `true` |  |
 | components.kserve.spec | object | `{}` |  |
 | coreweave.cloudManager.image | string | `"quay.io/opendatahub/opendatahub-operator:latest"` |  |

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
@@ -145,6 +145,9 @@ spec:
                     port: 80
                     protocol: HTTP
               {{- if .Values.components.kserve.gateway.allowedRoutes.namespaces.from }}
+              {{- if and (eq .Values.components.kserve.gateway.allowedRoutes.namespaces.from "Selector") (not .Values.components.kserve.gateway.allowedRoutes.namespaces.selector) }}
+              {{- fail "allowedRoutes.namespaces.selector is required when from is set to Selector" }}
+              {{- end }}
                     allowedRoutes:
                       namespaces:
                         from: {{ .Values.components.kserve.gateway.allowedRoutes.namespaces.from }}
@@ -157,6 +160,9 @@ spec:
                     port: 443
                     protocol: HTTPS
               {{- if .Values.components.kserve.gateway.allowedRoutes.namespaces.from }}
+              {{- if and (eq .Values.components.kserve.gateway.allowedRoutes.namespaces.from "Selector") (not .Values.components.kserve.gateway.allowedRoutes.namespaces.selector) }}
+              {{- fail "allowedRoutes.namespaces.selector is required when from is set to Selector" }}
+              {{- end }}
                     allowedRoutes:
                       namespaces:
                         from: {{ .Values.components.kserve.gateway.allowedRoutes.namespaces.from }}

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
@@ -146,7 +146,11 @@ spec:
                     protocol: HTTP
                     allowedRoutes:
                       namespaces:
-                        from: All
+                        from: {{ .Values.components.kserve.gateway.allowedRoutes.namespaces.from }}
+              {{- if and (eq .Values.components.kserve.gateway.allowedRoutes.namespaces.from "Selector") .Values.components.kserve.gateway.allowedRoutes.namespaces.selector }}
+                        selector:
+                          {{- toYaml .Values.components.kserve.gateway.allowedRoutes.namespaces.selector | nindent 26 }}
+              {{- end }}
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
@@ -144,12 +144,26 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
+              {{- if .Values.components.kserve.gateway.allowedRoutes.namespaces.from }}
                     allowedRoutes:
                       namespaces:
                         from: {{ .Values.components.kserve.gateway.allowedRoutes.namespaces.from }}
               {{- if and (eq .Values.components.kserve.gateway.allowedRoutes.namespaces.from "Selector") .Values.components.kserve.gateway.allowedRoutes.namespaces.selector }}
                         selector:
                           {{- toYaml .Values.components.kserve.gateway.allowedRoutes.namespaces.selector | nindent 26 }}
+              {{- end }}
+              {{- end }}
+                  - name: https
+                    port: 443
+                    protocol: HTTPS
+              {{- if .Values.components.kserve.gateway.allowedRoutes.namespaces.from }}
+                    allowedRoutes:
+                      namespaces:
+                        from: {{ .Values.components.kserve.gateway.allowedRoutes.namespaces.from }}
+              {{- if and (eq .Values.components.kserve.gateway.allowedRoutes.namespaces.from "Selector") .Values.components.kserve.gateway.allowedRoutes.namespaces.selector }}
+                        selector:
+                          {{- toYaml .Values.components.kserve.gateway.allowedRoutes.namespaces.selector | nindent 26 }}
+              {{- end }}
               {{- end }}
                 infrastructure:
                   labels:

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
@@ -3072,9 +3072,15 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                   - name: https
                     port: 443
                     protocol: HTTPS
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
@@ -1,0 +1,3093 @@
+---
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/namespace-rhai-cloudmanager-system.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rhai-cloudmanager-system
+
+---
+# Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: redhat-ods-applications
+
+---
+# Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: redhat-ods-operator
+
+---
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-cloud-manager-operator
+  namespace: rhai-cloudmanager-system
+imagePullSecrets:
+  - name: rhai-pull-secret
+
+---
+# Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-operator-controller-manager
+  namespace: redhat-ods-operator
+imagePullSecrets:
+  - name: rhai-pull-secret
+
+---
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/crds/customresourcedefinition-awskubernetesengines.infrastructure.opendatahub.io.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+    helm.sh/resource-policy: keep
+  name: awskubernetesengines.infrastructure.opendatahub.io
+spec:
+  group: infrastructure.opendatahub.io
+  names:
+    kind: AWSKubernetesEngine
+    listKind: AWSKubernetesEngineList
+    plural: awskubernetesengines
+    singular: awskubernetesengine
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+        - description: DependenciesAvailable
+          jsonPath: .status.conditions[?(@.type=="DependenciesAvailable")].status
+          name: Deps Available
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            AWSKubernetesEngine is the Schema for the awskubernetesengines API.
+            It represents the configuration for an AWS Kubernetes Service cluster.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AWSKubernetesEngineSpec defines the desired state of AWSKubernetesEngine.
+              properties:
+                dependencies:
+                  description: Dependencies defines the dependency configurations for the AWS Kubernetes Engine.
+                  properties:
+                    certManager:
+                      description: CertManager defines the cert-manager operator dependency.
+                      properties:
+                        configuration:
+                          description: Configuration for the cert-manager operator.
+                          type: object
+                        managementPolicy:
+                          default: Managed
+                          description: |-
+                            ManagementPolicy determines whether the operator manages this dependency.
+                            Managed: the operator installs and reconciles the dependency.
+                            Unmanaged: the operator does not manage the dependency; the user is responsible.
+                          enum:
+                            - Managed
+                            - Unmanaged
+                          type: string
+                      type: object
+                    gatewayAPI:
+                      description: GatewayAPI defines the Gateway API dependency.
+                      properties:
+                        configuration:
+                          description: Configuration for the Gateway API.
+                          type: object
+                        managementPolicy:
+                          default: Managed
+                          description: |-
+                            ManagementPolicy determines whether the operator manages this dependency.
+                            Managed: the operator installs and reconciles the dependency.
+                            Unmanaged: the operator does not manage the dependency; the user is responsible.
+                          enum:
+                            - Managed
+                            - Unmanaged
+                          type: string
+                      type: object
+                    lws:
+                      description: LWS defines the LeaderWorkerSet operator dependency.
+                      properties:
+                        configuration:
+                          default: {}
+                          description: Configuration for the LWS operator.
+                          properties:
+                            namespace:
+                              default: openshift-lws-operator
+                              description: Namespace is the namespace where the LWS operator is deployed.
+                              maxLength: 63
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: namespace is immutable
+                                  rule: self == oldSelf
+                          type: object
+                        managementPolicy:
+                          default: Managed
+                          description: |-
+                            ManagementPolicy determines whether the operator manages this dependency.
+                            Managed: the operator installs and reconciles the dependency.
+                            Unmanaged: the operator does not manage the dependency; the user is responsible.
+                          enum:
+                            - Managed
+                            - Unmanaged
+                          type: string
+                      type: object
+                    sailOperator:
+                      description: SailOperator defines the Sail operator (Istio) dependency.
+                      properties:
+                        configuration:
+                          default: {}
+                          description: Configuration for the Sail operator.
+                          properties:
+                            namespace:
+                              default: istio-system
+                              description: Namespace is the namespace where the Sail operator (Istio) is deployed.
+                              maxLength: 63
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: namespace is immutable
+                                  rule: self == oldSelf
+                          type: object
+                        managementPolicy:
+                          default: Managed
+                          description: |-
+                            ManagementPolicy determines whether the operator manages this dependency.
+                            Managed: the operator installs and reconciles the dependency.
+                            Unmanaged: the operator does not manage the dependency; the user is responsible.
+                          enum:
+                            - Managed
+                            - Unmanaged
+                          type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              description: AWSKubernetesEngineStatus defines the observed state of AWSKubernetesEngine.
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: AWSKubernetesEngine name must be default-awskubernetesengine
+              rule: self.metadata.name == 'default-awskubernetesengine'
+      served: true
+      storage: true
+      subresources:
+        status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kserves.components.platform.opendatahub.io.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+    helm.sh/resource-policy: keep
+  name: kserves.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: Kserve
+    listKind: KserveList
+    plural: kserves
+    singular: kserve
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Ready
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Reason
+          jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Kserve is the Schema for the kserves API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KserveSpec defines the desired state of Kserve
+              properties:
+                modelCache:
+                  description: Configures and enables Model Cache integration
+                  properties:
+                    cacheSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        CacheSize specifies the storage capacity for the model cache PersistentVolume
+                        and PersistentVolumeClaim (e.g., "100Gi", "500Gi", "1Ti").
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    managementState:
+                      default: Removed
+                      enum:
+                        - Managed
+                        - Removed
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                    nodeNames:
+                      description: |-
+                        NodeNames is a list of specific node names to enable model caching on.
+                        The operator will label these nodes with kserve/localmodel=worker.
+                        Mutually exclusive with NodeSelector.
+                      items:
+                        type: string
+                      minItems: 1
+                      type: array
+                    nodeSelector:
+                      description: |-
+                        NodeSelector is a label selector that identifies nodes for model caching
+                        using pre-existing node labels (e.g., nvidia.com/gpu).
+                        The operator will label matching nodes with kserve/localmodel=worker.
+                        Mutually exclusive with NodeNames.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                  x-kubernetes-validations:
+                    - message: cacheSize is required when managementState is Managed
+                      rule: self.managementState != 'Managed' || has(self.cacheSize)
+                    - message: one non-empty nodeNames or nodeSelector is required when managementState is Managed
+                      rule: self.managementState != 'Managed' || (has(self.nodeNames) && size(self.nodeNames) > 0) || (has(self.nodeSelector) && ((has(self.nodeSelector.matchLabels) && size(self.nodeSelector.matchLabels) > 0) || (has(self.nodeSelector.matchExpressions) && size(self.nodeSelector.matchExpressions) > 0)))
+                    - message: nodeNames and nodeSelector are mutually exclusive
+                      rule: '!(has(self.nodeNames) && has(self.nodeSelector))'
+                modelsAsService:
+                  description: Configures and enables Models as a Service integration
+                  properties:
+                    managementState:
+                      default: Removed
+                      enum:
+                        - Managed
+                        - Removed
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                  type: object
+                nim:
+                  description: Configures and enables NVIDIA NIM integration
+                  properties:
+                    airGapped:
+                      default: false
+                      description: |-
+                        When true, NIM integration assumes an air-gapped cluster. External API calls
+                        and the NIM model list ConfigMap creation are skipped, while status conditions
+                        are marked successful with an air-gapped message.
+                      type: boolean
+                    managementState:
+                      default: Managed
+                      enum:
+                        - Managed
+                        - Removed
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                  type: object
+                oauthProxy:
+                  description: |-
+                    Configures the OAuth proxy sidecar container resources in the
+                    'inferenceservice-config' ConfigMap for KServe. Only non-nil fields
+                    override the defaults shipped with the operator manifests.
+                  properties:
+                    resources:
+                      description: Resources describes the compute resource requirements for the OAuth proxy sidecar container.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Limits describes the maximum amount of resources allowed.
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Requests describes the minimum amount of resources required.
+                          type: object
+                      type: object
+                  type: object
+                rawDeploymentServiceConfig:
+                  default: Headless
+                  description: |-
+                    Configures the type of service that is created for InferenceServices using RawDeployment.
+                    The values for RawDeploymentServiceConfig can be "Headless" (default value) or "Headed".
+                    Headless: to set "ServiceClusterIPNone = true" in the 'inferenceservice-config' configmap for Kserve.
+                    Headed: to set "ServiceClusterIPNone = false" in the 'inferenceservice-config' configmap for Kserve.
+                  enum:
+                    - Headless
+                    - Headed
+                  type: string
+                wva:
+                  description: Configures and enables workload-variant-autoscaler (WVA) integration
+                  properties:
+                    managementState:
+                      default: Removed
+                      enum:
+                        - Managed
+                        - Removed
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                  type: object
+              type: object
+            status:
+              description: KserveStatus defines the observed state of Kserve
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastHeartbeatTime:
+                        description: |-
+                          The last time we got an update on a given condition, this should not be set and is
+                          present only for backward compatibility reasons
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human-readable message indicating details about the transition.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          The value should be a CamelCase string.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                observedGeneration:
+                  description: The generation observed by the resource controller.
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                releases:
+                  items:
+                    description: ComponentRelease represents the detailed status of a component release.
+                    properties:
+                      name:
+                        type: string
+                      repoUrl:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: Kserve name must be default-kserve
+              rule: self.metadata.name == 'default-kserve'
+      served: true
+      storage: true
+      subresources:
+        status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrole-rhai-aws-cloud-manager-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-aws-cloud-manager-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - namespaces
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+      - clusterissuers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - awskubernetesengines
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - awskubernetesengines/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - awskubernetesengines/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - certmanagers
+      - leaderworkersetoperators
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - rolebindings
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - cert-manager-operator-controller-manager-clusterrole
+      - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
+      - servicemesh-operator3-clusterrole
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - openshift-lws-operator-clusterrole
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - cert-manager-operator-controller-manager-role
+    resources:
+      - roles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - openshift-lws-operator-role
+    resources:
+      - roles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - servicemesh-operator3-role
+    resources:
+      - roles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - sailoperator.io
+    resources:
+      - istios
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+
+---
+# Source: rhai-on-xks-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-operator-metrics-reader
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+
+---
+# Source: rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-operator-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - clusterversions
+      - rhmis
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - deployments
+      - events
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - secrets
+      - secrets/finalizers
+      - serviceaccounts
+      - services
+      - services/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps/status
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces/finalizers
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups:
+      - '*'
+    resources:
+      - deployments
+      - services
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - '*'
+      - apps
+      - extensions
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
+      - validatingwebhookconfigurations
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - deployments/finalizers
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflows
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - autoscaling.openshift.io
+      - machine.openshift.io
+    resources:
+      - machineautoscalers
+      - machinesets
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+      - jobs/status
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - build.openshift.io
+    resources:
+      - buildconfigs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - build.openshift.io
+    resources:
+      - buildconfigs/instantiate
+      - builds
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - issuers
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - codeflares
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - codeflares/status
+    verbs:
+      - get
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - dashboards
+      - datasciencepipelines
+      - feastoperators
+      - kserves
+      - kueues
+      - mlflowoperators
+      - modelcontrollers
+      - modelmeshservings
+      - modelregistries
+      - modelsasservices
+      - ogxs
+      - rays
+      - sparkoperators
+      - trainers
+      - trainingoperators
+      - trustyais
+      - workbenches
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - dashboards/finalizers
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - use
+      - watch
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - dashboards/status
+      - datasciencepipelines/status
+      - feastoperators/status
+      - kserves/status
+      - kueues/status
+      - mlflowoperators/status
+      - modelcontrollers/status
+      - modelmeshservings/status
+      - modelregistries/status
+      - modelsasservices/status
+      - ogxs/status
+      - rays/status
+      - sparkoperators/status
+      - trainers/status
+      - trainingoperators/status
+      - trustyais/status
+      - workbenches/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - datasciencepipelines/finalizers
+      - feastoperators/finalizers
+      - kserves/finalizers
+      - kueues/finalizers
+      - mlflowoperators/finalizers
+      - modelcontrollers/finalizers
+      - modelmeshservings/finalizers
+      - modelregistries/finalizers
+      - modelsasservices/finalizers
+      - ogxs/finalizers
+      - rays/finalizers
+      - sparkoperators/finalizers
+      - trainers/finalizers
+      - trainingoperators/finalizers
+      - trustyais/finalizers
+      - workbenches/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - authentications
+      - clusterversions
+      - infrastructures
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+  - apiGroups:
+      - console.openshift.io
+    resources:
+      - consolelinks
+      - odhquickstarts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - controller-runtime.sigs.k8s.io
+    resources:
+      - controllermanagerconfigs
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - dashboard.opendatahub.io
+    resources:
+      - acceleratorprofiles
+      - odhapplications
+      - odhdocuments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - dashboard.opendatahub.io
+    resources:
+      - hardwareprofiles
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - datasciencecluster.opendatahub.io
+    resources:
+      - datascienceclusters
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datasciencecluster.opendatahub.io
+    resources:
+      - datascienceclusters/finalizers
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - datasciencecluster.opendatahub.io
+    resources:
+      - datascienceclusters/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - datasciencepipelinesapplications.opendatahub.io
+    resources:
+      - datasciencepipelinesapplications
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - datasciencepipelinesapplications.opendatahub.io
+    resources:
+      - datasciencepipelinesapplications/finalizers
+      - datasciencepipelinesapplications/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - dscinitialization.opendatahub.io
+    resources:
+      - dscinitializations
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - dscinitialization.opendatahub.io
+    resources:
+      - dscinitializations/finalizers
+      - dscinitializations/status
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - extensions.kuadrant.io
+    resources:
+      - telemetrypolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - features.opendatahub.io
+    resources:
+      - featuretrackers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - features.opendatahub.io
+    resources:
+      - featuretrackers/finalizers
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - features.opendatahub.io
+    resources:
+      - featuretrackers/status
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - image.openshift.io
+    resources:
+      - imagestreams
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - image.openshift.io
+    resources:
+      - imagestreamtags
+      - registry/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - inference.networking.k8s.io
+    resources:
+      - inferencepools
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - inference.networking.x-k8s.io
+    resources:
+      - inferencemodels
+      - inferencepools
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - hardwareprofiles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - hardwareprofiles/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - hardwareprofiles/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - integreatly.org
+    resources:
+      - rhmis
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - keda.sh
+    resources:
+      - kedacontrollers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - keda.sh
+    resources:
+      - triggerauthentications
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kuadrant.io
+    resources:
+      - authpolicies
+      - ratelimitpolicies
+      - telemetrypolicies
+      - tokenratelimitpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kuadrant.io
+    resources:
+      - kuadrants
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - notebooks
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kueue.openshift.io
+    resources:
+      - kueues
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kueue.openshift.io
+    resources:
+      - kueues/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - clusterqueues
+      - localqueues
+      - resourceflavors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - clusterqueues/status
+      - localqueues/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - maas.opendatahub.io
+    resources:
+      - configs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - maas.opendatahub.io
+    resources:
+      - configs/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - maas.opendatahub.io
+    resources:
+      - configs/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - maas.opendatahub.io
+    resources:
+      - tenants
+    verbs:
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - maas.opendatahub.io
+    resources:
+      - tenants/status
+    verbs:
+      - get
+  - apiGroups:
+      - machinelearning.seldon.io
+    resources:
+      - seldondeployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - mlflow.opendatahub.io
+    resources:
+      - mlflows
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - mlflow.opendatahub.io
+    resources:
+      - mlflows/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - mlflow.opendatahub.io
+    resources:
+      - mlflows/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - modelregistry.opendatahub.io
+    resources:
+      - modelregistries
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - modelregistry.opendatahub.io
+    resources:
+      - modelregistries/finalizers
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - modelregistry.opendatahub.io
+    resources:
+      - modelregistries/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - alertmanagerconfigs
+      - alertmanagers
+      - alertmanagers/finalizers
+      - alertmanagers/status
+      - probes
+      - prometheuses
+      - prometheuses/finalizers
+      - prometheuses/status
+      - thanosrulers
+      - thanosrulers/finalizers
+      - thanosrulers/status
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - patch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - podmonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+      - servicemonitors
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.rhobs
+    resources:
+      - monitoringstacks
+      - prometheusrules
+      - servicemonitors
+      - thanosqueriers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.rhobs
+    resources:
+      - monitoringstacks/finalizers
+      - prometheusrules/finalizers
+      - servicemonitors/finalizers
+      - thanosqueriers/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - monitoring.rhobs
+    resources:
+      - monitoringstacks/status
+      - prometheusrules/status
+      - servicemonitors/status
+      - thanosqueriers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - destinationrules
+      - envoyfilters
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - oauth.openshift.io
+    resources:
+      - oauthclients
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opendatahub.io
+    resources:
+      - odhdashboardconfigs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - instrumentations
+      - opentelemetrycollectors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - instrumentations/finalizers
+      - opentelemetrycollectors/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - opentelemetry.io
+    resources:
+      - instrumentations/status
+      - opentelemetrycollectors/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - operator.authorino.kuadrant.io
+    resources:
+      - authorinos
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - consoles
+      - ingresscontrollers
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - jobsetoperators
+      - leaderworkersetoperators
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - catalogsources
+      - operatorconditions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+    verbs:
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - subscriptions
+    verbs:
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - perses.dev
+    resources:
+      - perses
+      - persesdashboards
+      - persesdatasources
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - perses.dev
+    resources:
+      - perses/finalizers
+      - persesdashboards/finalizers
+      - persesdatasources/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - perses.dev
+    resources:
+      - perses/status
+      - persesdashboards/status
+      - persesdatasources/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ray.io
+    resources:
+      - rayclusters
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+  - apiGroups:
+      - ray.io
+    resources:
+      - rayjobs
+      - rayservices
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+      - roles
+    verbs:
+      - '*'
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routers/federate
+      - routers/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes/custom-host
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - use
+      - watch
+  - apiGroups:
+      - services.platform.opendatahub.io
+    resources:
+      - auths
+      - gatewayconfigs
+      - monitorings
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - services.platform.opendatahub.io
+    resources:
+      - auths/finalizers
+      - gatewayconfigs/finalizers
+      - monitorings/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - services.platform.opendatahub.io
+    resources:
+      - auths/status
+      - gatewayconfigs/status
+      - monitorings/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterservingruntimes
+      - clusterservingruntimes/finalizers
+      - clusterstoragecontainers
+      - clusterstoragecontainers/finalizers
+      - inferencegraphs
+      - inferenceservices
+      - inferenceservices/finalizers
+      - llminferenceserviceconfigs
+      - localmodelnodegroups
+      - predictors
+      - servingruntimes
+      - servingruntimes/finalizers
+      - trainedmodels
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - clusterservingruntimes/status
+      - clusterstoragecontainers/status
+      - inferencegraphs/status
+      - inferenceservices/status
+      - predictors/status
+      - trainedmodels/status
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - llminferenceserviceconfigs/status
+      - predictors/finalizers
+      - servingruntimes/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - llminferenceservices
+      - llminferenceservices/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshots
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - telemetry.istio.io
+    resources:
+      - telemetries
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - template.openshift.io
+    resources:
+      - templates
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - tempo.grafana.com
+    resources:
+      - tempomonolithics
+      - tempostacks
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - trainer.kubeflow.org
+    resources:
+      - clustertrainingruntimes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - user.openshift.io
+    resources:
+      - groups
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - user.openshift.io
+    resources:
+      - users
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+
+---
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrolebinding-rhai-aws-cloud-manager-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-aws-cloud-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-aws-cloud-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: aws-cloud-manager-operator
+    namespace: rhai-cloudmanager-system
+
+---
+# Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-operator-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-operator-role
+subjects:
+  - kind: ServiceAccount
+    name: rhai-operator-controller-manager
+    namespace: redhat-ods-operator
+
+---
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/role-aws-cloud-manager-leader-election-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: aws-cloud-manager-leader-election-role
+  namespace: rhai-cloudmanager-system
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+
+---
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/rolebinding-aws-cloud-manager-leader-election-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aws-cloud-manager-leader-election-rolebinding
+  namespace: rhai-cloudmanager-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: aws-cloud-manager-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: aws-cloud-manager-operator
+    namespace: rhai-cloudmanager-system
+
+---
+# Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: rhods-operator
+  name: rhai-operator-controller-manager-metrics-service
+  namespace: redhat-ods-operator
+spec:
+  ports:
+    - name: http
+      port: 8443
+      protocol: TCP
+      targetPort: http
+  selector:
+    name: rhai-operator
+
+---
+# Source: rhai-on-xks-chart/templates/webhooks/service-rhai-operator-webhook-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: rhai-operator
+    app.kubernetes.io/instance: rhai-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rhai-operator-webhook-service
+    app.kubernetes.io/part-of: rhai-operator
+  name: rhai-operator-webhook-service
+  namespace: redhat-ods-operator
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    name: rhai-operator
+
+---
+# Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/deployment-aws-cloud-manager-operator.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+    name: aws-cloud-manager-operator
+  name: aws-cloud-manager-operator
+  namespace: rhai-cloudmanager-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      name: aws-cloud-manager-operator
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+        name: aws-cloud-manager-operator
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: name
+                      operator: In
+                      values:
+                        - aws-cloud-manager-operator
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      containers:
+        - args:
+            - aws
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=0.0.0.0:8080
+            - --leader-elect
+          command:
+            - /cloudmanager
+          env:
+            - name: RHAI_OPERATOR_NAMESPACE
+              value: redhat-ods-operator
+            - name: RHAI_WEBHOOK_CERT_SECRET_NAME
+              value: rhai-operator-controller-webhook-cert
+            - name: RHAI_WEBHOOK_SERVICE_NAME
+              value: rhai-operator-webhook-service
+            - name: RHAI_WEBHOOK_CERT_NAME
+              value: rhai-operator-webhook-cert
+            - name: RHAI_CA_SECRET_NAME
+              value: rhai-ca
+            - name: RHAI_CA_SECRET_NAMESPACE
+              value: cert-manager
+            - name: RHAI_ISSUER_REF_NAME
+              value: rhai-ca-issuer
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DEFAULT_CHARTS_PATH
+              value: /opt/charts
+          image: quay.io/opendatahub/opendatahub-operator:latest
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: aws-cloud-manager-operator
+      terminationGracePeriodSeconds: 10
+
+---
+# Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    name: rhai-operator
+  name: rhai-operator
+  namespace: redhat-ods-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: rhai-operator
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: rhai-operator
+      labels:
+        name: rhai-operator
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: name
+                      operator: In
+                      values:
+                        - rhai-operator
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      containers:
+        - args:
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=0.0.0.0:8080
+            - --leader-elect
+          command:
+            - /manager
+          env:
+            - name: DISABLE_DSC_CONFIG
+              value: "true"
+            - name: RHAI_DISABLE_DSC_RESOURCE
+              value: "true"
+            - name: RHAI_DISABLE_DSCI_RESOURCE
+              value: "true"
+            - name: RHAI_DISABLE_DASHBOARD_COMPONENT
+              value: "true"
+            - name: RHAI_DISABLE_DATASCIENCEPIPELINES_COMPONENT
+              value: "true"
+            - name: RHAI_DISABLE_FEASTOPERATOR_COMPONENT
+              value: "true"
+            - name: RHAI_DISABLE_KUEUE_COMPONENT
+              value: "true"
+            - name: RHAI_DISABLE_OGX_COMPONENT
+              value: "true"
+            - name: RHAI_DISABLE_MLFLOWOPERATOR_COMPONENT
+              value: "true"
+            - name: RHAI_DISABLE_MODELCONTROLLER_COMPONENT
+              value: "true"
+            - name: RHAI_DISABLE_MODELREGISTRY_COMPONENT
+              value: "true"
+            - name: RHAI_DISABLE_MODELSASSERVICE_COMPONENT
+              value: "true"
+            - name: RHAI_DISABLE_RAY_COMPONENT
+              value: "true"
+            - name: RHAI_DISABLE_SPARKOPERATOR_COMPONENT
+              value: "true"
+            - name: RHAI_DISABLE_TRAINER_COMPONENT
+              value: "true"
+            - name: RHAI_DISABLE_TRAININGOPERATOR_COMPONENT
+              value: "true"
+            - name: RHAI_DISABLE_TRUSTYAI_COMPONENT
+              value: "true"
+            - name: RHAI_DISABLE_WORKBENCHES_COMPONENT
+              value: "true"
+            - name: RHAI_DISABLE_AUTH_SERVICE
+              value: "true"
+            - name: RHAI_DISABLE_CERTCONFIGMAPGENERATOR_SERVICE
+              value: "true"
+            - name: RHAI_DISABLE_GATEWAY_SERVICE
+              value: "true"
+            - name: RHAI_DISABLE_MONITORING_SERVICE
+              value: "true"
+            - name: RHAI_DISABLE_SETUPCONTROLLER_SERVICE
+              value: "true"
+            - name: RHAI_APPLICATIONS_NAMESPACE
+              value: "redhat-ods-applications"
+            - name: RHAI_VERSION
+              value: "3.5.0-ea.1"
+            - name: ODH_PLATFORM_TYPE
+              value: XKS
+            - name: RHAI_CA_SECRET_NAME
+              value: rhai-ca
+            - name: RHAI_CA_SECRET_NAMESPACE
+              value: cert-manager
+            - name: RHAI_ISSUER_REF_NAME
+              value: rhai-ca-issuer
+            - name: RHAI_ISTIO_CA_CERTIFICATE_PATH
+              value: /var/run/secrets/rhai/ca.crt
+            - name: OPERATOR_NAME
+              value: rhai-operator
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DEFAULT_MANIFESTS_PATH
+              value: /opt/manifests
+          image: quay.io/opendatahub/opendatahub-operator:latest
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: rhai-operator
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 300m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+            - mountPath: /opt/manifests
+              name: manifests
+            - mountPath: /tmp
+              name: tmp
+      initContainers:
+        - command:
+            - cp
+            - -r
+            - /opt/manifests-template/.
+            - /opt/manifests/
+          image: quay.io/opendatahub/opendatahub-operator:latest
+          imagePullPolicy: Always
+          name: copy-manifests
+          resources:
+            limits:
+              cpu: 100m
+              memory: 512Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /opt/manifests
+              name: manifests
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: rhai-operator-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: rhai-operator-controller-webhook-cert
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: manifests
+        - emptyDir:
+            medium: Memory
+            sizeLimit: 10Mi
+          name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhai-operator-mutating-webhook-configuration.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: redhat-ods-operator/rhai-operator-webhook-cert
+  name: rhai-operator-mutating-webhook-configuration
+  namespace: redhat-ods-operator
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: rhai-operator-webhook-service
+        namespace: redhat-ods-operator
+        path: /platform-connection-isvc
+    failurePolicy: Fail
+    name: connection-isvc.opendatahub.io
+    rules:
+      - apiGroups:
+          - serving.kserve.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - inferenceservices
+    sideEffects: NoneOnDryRun
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: rhai-operator-webhook-service
+        namespace: redhat-ods-operator
+        path: /platform-connection-llmisvc
+    failurePolicy: Fail
+    name: connection-llmisvc.opendatahub.io
+    rules:
+      - apiGroups:
+          - serving.kserve.io
+        apiVersions:
+          - v1alpha1
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - llminferenceservices
+    sideEffects: NoneOnDryRun
+---
+# Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-post-install-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-post-install-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - kserves
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - azurekubernetesengines
+      - coreweavekubernetesengines
+      - awskubernetesengines
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+    verbs:
+      - get
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+---
+# Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-post-install-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-post-install-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-post-install-hook
+    namespace: default
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-post-install-crs
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-post-install-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: create-crs
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Creating AWSKubernetesEngine CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: infrastructure.opendatahub.io/v1alpha1
+              kind: AWSKubernetesEngine
+              metadata:
+                name: default-awskubernetesengine
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec:
+                dependencies:
+                  certManager:
+                    configuration: {}
+                    managementPolicy: Managed
+                  gatewayAPI:
+                    configuration: {}
+                    managementPolicy: Managed
+                  lws:
+                    configuration:
+                      namespace: openshift-lws-operator
+                    managementPolicy: Managed
+                  sailOperator:
+                    configuration:
+                      namespace: istio-system
+                    managementPolicy: Managed
+              EOF
+              echo "Done."
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-post-create-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-post-install-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: create-gateway
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              TIMEOUT=300
+              INTERVAL=5
+              ELAPSED=0
+
+              echo "Step 1: Waiting for Gateway API CRDs required by Gateway CR 'inference-gateway'..."
+              until kubectl get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for Gateway API CRDs after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "CRD not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "Gateway API CRDs are available."
+
+              echo "Step 2: Waiting for cert-manager CA secret required by Gateway CR 'inference-gateway'..."
+              ELAPSED=0
+              until kubectl get secret rhai-ca -n cert-manager >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for CA secret after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "CA secret not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "CA secret is available."
+
+              echo "Step 3: Creating CA bundle ConfigMap for Gateway CR 'inference-gateway'..."
+              kubectl get secret rhai-ca -n cert-manager \
+                -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
+              kubectl create configmap rhai-ca-bundle \
+                --from-file=ca.crt=/tmp/ca.crt \
+                -n redhat-ods-applications \
+                --dry-run=client -o yaml | kubectl apply -f -
+              echo "CA bundle ConfigMap created."
+
+              echo "Step 4: Create ConfigMap used by Gateway CR 'inference-gateway'..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: inference-gateway-config
+                namespace: redhat-ods-applications
+              data:
+                deployment: |
+                  spec:
+                    template:
+                      spec:
+                        volumes:
+                        - name: rhai-ca-bundle
+                          configMap:
+                            name: rhai-ca-bundle
+                        containers:
+                        - name: istio-proxy
+                          volumeMounts:
+                          - name: rhai-ca-bundle
+                            mountPath: /var/run/secrets/rhai
+                            readOnly: true
+              EOF
+              echo "ConfigMap used by Gateway CR 'inference-gateway' created."
+
+              echo "Step 5: Waiting for GatewayClass 'istio' required by Gateway CR 'inference-gateway'..."
+              ELAPSED=0
+              until kubectl get gatewayclass istio >/dev/null 2>&1; do
+                if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+                  echo "ERROR: Timed out waiting for GatewayClass 'istio' after ${TIMEOUT}s"
+                  exit 1
+                fi
+                echo "GatewayClass 'istio' not yet available, retrying in ${INTERVAL}s... (${ELAPSED}/${TIMEOUT}s)"
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+              done
+              echo "GatewayClass 'istio' is available."
+
+              echo "Step 6: Creating Gateway CR 'inference-gateway'..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: inference-gateway
+                namespace: redhat-ods-applications
+              spec:
+                gatewayClassName: istio
+                listeners:
+                  - name: http
+                    port: 80
+                    protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: Same
+                  - name: https
+                    port: 443
+                    protocol: HTTPS
+                    allowedRoutes:
+                      namespaces:
+                        from: Same
+                infrastructure:
+                  labels:
+                    serving.kserve.io/gateway: kserve-ingress-gateway
+                  parametersRef:
+                    group: ""
+                    kind: ConfigMap
+                    name: inference-gateway-config
+              EOF
+              echo "Gateway CR 'inference-gateway' created successfully."
+

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -4,21 +4,18 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -52,7 +49,6 @@ metadata:
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 # TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
@@ -63,7 +59,6 @@ metadata:
   namespace: redhat-ods-applications
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -73,7 +68,6 @@ metadata:
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -404,7 +398,6 @@ spec:
       storage: true
       subresources:
         status: {}
-
 ---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kserves.components.platform.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -712,7 +705,6 @@ spec:
       storage: true
       subresources:
         status: {}
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrole-rhai-aws-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -977,7 +969,6 @@ rules:
       - patch
       - update
       - watch
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -989,7 +980,6 @@ rules:
       - /metrics
     verbs:
       - get
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2388,7 +2378,6 @@ rules:
       - patch
       - update
       - watch
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrolebinding-rhai-aws-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2403,7 +2392,6 @@ subjects:
   - kind: ServiceAccount
     name: aws-cloud-manager-operator
     namespace: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2418,7 +2406,6 @@ subjects:
   - kind: ServiceAccount
     name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/role-aws-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2443,7 +2430,6 @@ rules:
     verbs:
       - create
       - patch
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/rolebinding-aws-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2459,7 +2445,6 @@ subjects:
   - kind: ServiceAccount
     name: aws-cloud-manager-operator
     namespace: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
 apiVersion: v1
@@ -2477,7 +2462,6 @@ spec:
       targetPort: http
   selector:
     name: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/service-rhai-operator-webhook-service.yaml
 apiVersion: v1
@@ -2499,7 +2483,6 @@ spec:
       targetPort: 9443
   selector:
     name: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/deployment-aws-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2611,7 +2594,6 @@ spec:
           type: RuntimeDefault
       serviceAccountName: aws-cloud-manager-operator
       terminationGracePeriodSeconds: 10
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
 apiVersion: apps/v1
@@ -2815,7 +2797,6 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
-
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhai-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -2972,7 +2953,6 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
-
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
@@ -3063,7 +3043,6 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
-
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
 apiVersion: batch/v1
@@ -3223,4 +3202,3 @@ spec:
                     name: inference-gateway-config
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
-

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -3211,9 +3211,15 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                   - name: https
                     port: 443
                     protocol: HTTPS
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -3211,9 +3211,9 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
-                    allowedRoutes:
-                      namespaces:
-                        from: All
+                  - name: https
+                    port: 443
+                    protocol: HTTPS
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -4,18 +4,21 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -49,6 +52,7 @@ metadata:
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 # TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
@@ -59,6 +63,7 @@ metadata:
   namespace: redhat-ods-applications
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -68,6 +73,7 @@ metadata:
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -398,6 +404,7 @@ spec:
       storage: true
       subresources:
         status: {}
+
 ---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kserves.components.platform.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -705,6 +712,7 @@ spec:
       storage: true
       subresources:
         status: {}
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrole-rhai-aws-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -969,6 +977,7 @@ rules:
       - patch
       - update
       - watch
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -980,6 +989,7 @@ rules:
       - /metrics
     verbs:
       - get
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2378,6 +2388,7 @@ rules:
       - patch
       - update
       - watch
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrolebinding-rhai-aws-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2392,6 +2403,7 @@ subjects:
   - kind: ServiceAccount
     name: aws-cloud-manager-operator
     namespace: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2406,6 +2418,7 @@ subjects:
   - kind: ServiceAccount
     name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/role-aws-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2430,6 +2443,7 @@ rules:
     verbs:
       - create
       - patch
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/rolebinding-aws-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2445,6 +2459,7 @@ subjects:
   - kind: ServiceAccount
     name: aws-cloud-manager-operator
     namespace: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
 apiVersion: v1
@@ -2462,6 +2477,7 @@ spec:
       targetPort: http
   selector:
     name: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/service-rhai-operator-webhook-service.yaml
 apiVersion: v1
@@ -2483,6 +2499,7 @@ spec:
       targetPort: 9443
   selector:
     name: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/deployment-aws-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2594,6 +2611,7 @@ spec:
           type: RuntimeDefault
       serviceAccountName: aws-cloud-manager-operator
       terminationGracePeriodSeconds: 10
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
 apiVersion: apps/v1
@@ -2797,6 +2815,7 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhai-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -2953,6 +2972,7 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
@@ -3043,6 +3063,7 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
 apiVersion: batch/v1
@@ -3202,3 +3223,4 @@ spec:
                     name: inference-gateway-config
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
+

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -3072,9 +3072,15 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                   - name: https
                     port: 443
                     protocol: HTTPS
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -4,18 +4,21 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml
 apiVersion: v1
@@ -25,6 +28,7 @@ metadata:
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -34,6 +38,7 @@ metadata:
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/crds/customresourcedefinition-awskubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -260,6 +265,7 @@ spec:
       storage: true
       subresources:
         status: {}
+
 ---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kserves.components.platform.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -567,6 +573,7 @@ spec:
       storage: true
       subresources:
         status: {}
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrole-rhai-aws-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -831,6 +838,7 @@ rules:
       - patch
       - update
       - watch
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -842,6 +850,7 @@ rules:
       - /metrics
     verbs:
       - get
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2240,6 +2249,7 @@ rules:
       - patch
       - update
       - watch
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrolebinding-rhai-aws-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2254,6 +2264,7 @@ subjects:
   - kind: ServiceAccount
     name: aws-cloud-manager-operator
     namespace: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2268,6 +2279,7 @@ subjects:
   - kind: ServiceAccount
     name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/role-aws-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2292,6 +2304,7 @@ rules:
     verbs:
       - create
       - patch
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/rolebinding-aws-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2307,6 +2320,7 @@ subjects:
   - kind: ServiceAccount
     name: aws-cloud-manager-operator
     namespace: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
 apiVersion: v1
@@ -2324,6 +2338,7 @@ spec:
       targetPort: http
   selector:
     name: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/service-rhai-operator-webhook-service.yaml
 apiVersion: v1
@@ -2345,6 +2360,7 @@ spec:
       targetPort: 9443
   selector:
     name: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/deployment-aws-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2456,6 +2472,7 @@ spec:
           type: RuntimeDefault
       serviceAccountName: aws-cloud-manager-operator
       terminationGracePeriodSeconds: 10
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
 apiVersion: apps/v1
@@ -2659,6 +2676,7 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhai-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -2815,6 +2833,7 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
@@ -2905,6 +2924,7 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
 apiVersion: batch/v1
@@ -3064,3 +3084,4 @@ spec:
                     name: inference-gateway-config
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
+

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -4,21 +4,18 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml
 apiVersion: v1
@@ -28,7 +25,6 @@ metadata:
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -38,7 +34,6 @@ metadata:
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/crds/customresourcedefinition-awskubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -265,7 +260,6 @@ spec:
       storage: true
       subresources:
         status: {}
-
 ---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kserves.components.platform.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -573,7 +567,6 @@ spec:
       storage: true
       subresources:
         status: {}
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrole-rhai-aws-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -838,7 +831,6 @@ rules:
       - patch
       - update
       - watch
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -850,7 +842,6 @@ rules:
       - /metrics
     verbs:
       - get
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2249,7 +2240,6 @@ rules:
       - patch
       - update
       - watch
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrolebinding-rhai-aws-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2264,7 +2254,6 @@ subjects:
   - kind: ServiceAccount
     name: aws-cloud-manager-operator
     namespace: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2279,7 +2268,6 @@ subjects:
   - kind: ServiceAccount
     name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/role-aws-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2304,7 +2292,6 @@ rules:
     verbs:
       - create
       - patch
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/rolebinding-aws-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2320,7 +2307,6 @@ subjects:
   - kind: ServiceAccount
     name: aws-cloud-manager-operator
     namespace: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
 apiVersion: v1
@@ -2338,7 +2324,6 @@ spec:
       targetPort: http
   selector:
     name: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/service-rhai-operator-webhook-service.yaml
 apiVersion: v1
@@ -2360,7 +2345,6 @@ spec:
       targetPort: 9443
   selector:
     name: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/deployment-aws-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2472,7 +2456,6 @@ spec:
           type: RuntimeDefault
       serviceAccountName: aws-cloud-manager-operator
       terminationGracePeriodSeconds: 10
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
 apiVersion: apps/v1
@@ -2676,7 +2659,6 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
-
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhai-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -2833,7 +2815,6 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
-
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
@@ -2924,7 +2905,6 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
-
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
 apiVersion: batch/v1
@@ -3084,4 +3064,3 @@ spec:
                     name: inference-gateway-config
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
-

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -3196,9 +3196,15 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                   - name: https
                     port: 443
                     protocol: HTTPS
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -3196,9 +3196,9 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
-                    allowedRoutes:
-                      namespaces:
-                        from: All
+                  - name: https
+                    port: 443
+                    protocol: HTTPS
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -4,21 +4,18 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -46,7 +43,6 @@ metadata:
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 # TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
@@ -57,7 +53,6 @@ metadata:
   namespace: redhat-ods-applications
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -67,7 +62,6 @@ metadata:
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -385,7 +379,6 @@ spec:
       storage: true
       subresources:
         status: {}
-
 ---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kserves.components.platform.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -693,7 +686,6 @@ spec:
       storage: true
       subresources:
         status: {}
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrole-rhai-azure-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -958,7 +950,6 @@ rules:
       - patch
       - update
       - watch
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -970,7 +961,6 @@ rules:
       - /metrics
     verbs:
       - get
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2369,7 +2359,6 @@ rules:
       - patch
       - update
       - watch
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrolebinding-rhai-azure-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2384,7 +2373,6 @@ subjects:
   - kind: ServiceAccount
     name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2399,7 +2387,6 @@ subjects:
   - kind: ServiceAccount
     name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2424,7 +2411,6 @@ rules:
     verbs:
       - create
       - patch
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/rolebinding-azure-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2440,7 +2426,6 @@ subjects:
   - kind: ServiceAccount
     name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
 apiVersion: v1
@@ -2458,7 +2443,6 @@ spec:
       targetPort: http
   selector:
     name: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/service-rhai-operator-webhook-service.yaml
 apiVersion: v1
@@ -2480,7 +2464,6 @@ spec:
       targetPort: 9443
   selector:
     name: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2592,7 +2575,6 @@ spec:
           type: RuntimeDefault
       serviceAccountName: azure-cloud-manager-operator
       terminationGracePeriodSeconds: 10
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
 apiVersion: apps/v1
@@ -2796,7 +2778,6 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
-
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhai-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -2953,7 +2934,6 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
-
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
@@ -3044,7 +3024,6 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
-
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
 apiVersion: batch/v1
@@ -3208,4 +3187,3 @@ spec:
                     name: inference-gateway-config
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
-

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -4,18 +4,21 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -43,6 +46,7 @@ metadata:
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 # TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
@@ -53,6 +57,7 @@ metadata:
   namespace: redhat-ods-applications
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -62,6 +67,7 @@ metadata:
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -379,6 +385,7 @@ spec:
       storage: true
       subresources:
         status: {}
+
 ---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kserves.components.platform.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -686,6 +693,7 @@ spec:
       storage: true
       subresources:
         status: {}
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrole-rhai-azure-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -950,6 +958,7 @@ rules:
       - patch
       - update
       - watch
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -961,6 +970,7 @@ rules:
       - /metrics
     verbs:
       - get
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2359,6 +2369,7 @@ rules:
       - patch
       - update
       - watch
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrolebinding-rhai-azure-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2373,6 +2384,7 @@ subjects:
   - kind: ServiceAccount
     name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2387,6 +2399,7 @@ subjects:
   - kind: ServiceAccount
     name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2411,6 +2424,7 @@ rules:
     verbs:
       - create
       - patch
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/rolebinding-azure-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2426,6 +2440,7 @@ subjects:
   - kind: ServiceAccount
     name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
 apiVersion: v1
@@ -2443,6 +2458,7 @@ spec:
       targetPort: http
   selector:
     name: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/service-rhai-operator-webhook-service.yaml
 apiVersion: v1
@@ -2464,6 +2480,7 @@ spec:
       targetPort: 9443
   selector:
     name: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2575,6 +2592,7 @@ spec:
           type: RuntimeDefault
       serviceAccountName: azure-cloud-manager-operator
       terminationGracePeriodSeconds: 10
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
 apiVersion: apps/v1
@@ -2778,6 +2796,7 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhai-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -2934,6 +2953,7 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
@@ -3024,6 +3044,7 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
 apiVersion: batch/v1
@@ -3187,3 +3208,4 @@ spec:
                     name: inference-gateway-config
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
+

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -4,21 +4,18 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml
 apiVersion: v1
@@ -28,7 +25,6 @@ metadata:
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -38,7 +34,6 @@ metadata:
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/crds/customresourcedefinition-azurekubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -265,7 +260,6 @@ spec:
       storage: true
       subresources:
         status: {}
-
 ---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kserves.components.platform.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -573,7 +567,6 @@ spec:
       storage: true
       subresources:
         status: {}
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrole-rhai-azure-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -838,7 +831,6 @@ rules:
       - patch
       - update
       - watch
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -850,7 +842,6 @@ rules:
       - /metrics
     verbs:
       - get
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2249,7 +2240,6 @@ rules:
       - patch
       - update
       - watch
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrolebinding-rhai-azure-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2264,7 +2254,6 @@ subjects:
   - kind: ServiceAccount
     name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2279,7 +2268,6 @@ subjects:
   - kind: ServiceAccount
     name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2304,7 +2292,6 @@ rules:
     verbs:
       - create
       - patch
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/rolebinding-azure-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2320,7 +2307,6 @@ subjects:
   - kind: ServiceAccount
     name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
 apiVersion: v1
@@ -2338,7 +2324,6 @@ spec:
       targetPort: http
   selector:
     name: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/service-rhai-operator-webhook-service.yaml
 apiVersion: v1
@@ -2360,7 +2345,6 @@ spec:
       targetPort: 9443
   selector:
     name: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2472,7 +2456,6 @@ spec:
           type: RuntimeDefault
       serviceAccountName: azure-cloud-manager-operator
       terminationGracePeriodSeconds: 10
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
 apiVersion: apps/v1
@@ -2678,7 +2661,6 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
-
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhai-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -2835,7 +2817,6 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
-
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
@@ -2926,7 +2907,6 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
-
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
 apiVersion: batch/v1
@@ -3090,4 +3070,3 @@ spec:
                     name: inference-gateway-config
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
-

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -3078,9 +3078,9 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
-                    allowedRoutes:
-                      namespaces:
-                        from: All
+                  - name: https
+                    port: 443
+                    protocol: HTTPS
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -4,18 +4,21 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml
 apiVersion: v1
@@ -25,6 +28,7 @@ metadata:
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -34,6 +38,7 @@ metadata:
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/crds/customresourcedefinition-azurekubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -260,6 +265,7 @@ spec:
       storage: true
       subresources:
         status: {}
+
 ---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kserves.components.platform.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -567,6 +573,7 @@ spec:
       storage: true
       subresources:
         status: {}
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrole-rhai-azure-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -831,6 +838,7 @@ rules:
       - patch
       - update
       - watch
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -842,6 +850,7 @@ rules:
       - /metrics
     verbs:
       - get
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2240,6 +2249,7 @@ rules:
       - patch
       - update
       - watch
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrolebinding-rhai-azure-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2254,6 +2264,7 @@ subjects:
   - kind: ServiceAccount
     name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2268,6 +2279,7 @@ subjects:
   - kind: ServiceAccount
     name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2292,6 +2304,7 @@ rules:
     verbs:
       - create
       - patch
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/rolebinding-azure-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2307,6 +2320,7 @@ subjects:
   - kind: ServiceAccount
     name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
 apiVersion: v1
@@ -2324,6 +2338,7 @@ spec:
       targetPort: http
   selector:
     name: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/service-rhai-operator-webhook-service.yaml
 apiVersion: v1
@@ -2345,6 +2360,7 @@ spec:
       targetPort: 9443
   selector:
     name: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2456,6 +2472,7 @@ spec:
           type: RuntimeDefault
       serviceAccountName: azure-cloud-manager-operator
       terminationGracePeriodSeconds: 10
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
 apiVersion: apps/v1
@@ -2661,6 +2678,7 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhai-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -2817,6 +2835,7 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
@@ -2907,6 +2926,7 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
 apiVersion: batch/v1
@@ -3070,3 +3090,4 @@ spec:
                     name: inference-gateway-config
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
+

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -3078,9 +3078,15 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                   - name: https
                     port: 443
                     protocol: HTTPS
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/namespace-rhai-cloudmanager-system.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/manager/namespace-rhai-cloudmanager-system.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -20,11 +20,11 @@ metadata:
   name: redhat-ods-operator
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/serviceaccount-coreweave-cloud-manager-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: aws-cloud-manager-operator
+  name: coreweave-cloud-manager-operator
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
@@ -40,21 +40,21 @@ imagePullSecrets:
   - name: rhai-pull-secret
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/crds/customresourcedefinition-awskubernetesengines.infrastructure.opendatahub.io.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/crds/customresourcedefinition-coreweavekubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
     helm.sh/resource-policy: keep
-  name: awskubernetesengines.infrastructure.opendatahub.io
+  name: coreweavekubernetesengines.infrastructure.opendatahub.io
 spec:
   group: infrastructure.opendatahub.io
   names:
-    kind: AWSKubernetesEngine
-    listKind: AWSKubernetesEngineList
-    plural: awskubernetesengines
-    singular: awskubernetesengine
+    kind: CoreWeaveKubernetesEngine
+    listKind: CoreWeaveKubernetesEngineList
+    plural: coreweavekubernetesengines
+    singular: coreweavekubernetesengine
   scope: Cluster
   versions:
     - additionalPrinterColumns:
@@ -74,8 +74,8 @@ spec:
       schema:
         openAPIV3Schema:
           description: |-
-            AWSKubernetesEngine is the Schema for the awskubernetesengines API.
-            It represents the configuration for an AWS Kubernetes Service cluster.
+            CoreWeaveKubernetesEngine is the Schema for the CoreWeaveKubernetesEngines API.
+            It represents the configuration for a CoreWeave Kubernetes Engine cluster.
           properties:
             apiVersion:
               description: |-
@@ -95,10 +95,10 @@ spec:
             metadata:
               type: object
             spec:
-              description: AWSKubernetesEngineSpec defines the desired state of AWSKubernetesEngine.
+              description: CoreWeaveKubernetesEngineSpec defines the desired state of CoreWeaveKubernetesEngine.
               properties:
                 dependencies:
-                  description: Dependencies defines the dependency configurations for the AWS Kubernetes Engine.
+                  description: Dependencies defines the dependency configurations for the CoreWeave Kubernetes Engine.
                   properties:
                     certManager:
                       description: CertManager defines the cert-manager operator dependency.
@@ -193,7 +193,7 @@ spec:
                   type: object
               type: object
             status:
-              description: AWSKubernetesEngineStatus defines the observed state of AWSKubernetesEngine.
+              description: CoreWeaveKubernetesEngineStatus defines the observed state of CoreWeaveKubernetesEngine.
               properties:
                 conditions:
                   items:
@@ -259,8 +259,8 @@ spec:
               type: object
           type: object
           x-kubernetes-validations:
-            - message: AWSKubernetesEngine name must be default-awskubernetesengine
-              rule: self.metadata.name == 'default-awskubernetesengine'
+            - message: CoreWeaveKubernetesEngine name must be default-coreweavekubernetesengine
+              rule: self.metadata.name == 'default-coreweavekubernetesengine'
       served: true
       storage: true
       subresources:
@@ -575,11 +575,11 @@ spec:
         status: {}
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrole-rhai-aws-cloud-manager-role.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrole-rhai-coreweave-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhai-aws-cloud-manager-role
+  name: rhai-coreweave-cloud-manager-role
 rules:
   - apiGroups:
       - ""
@@ -668,7 +668,7 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines
+      - coreweavekubernetesengines
     verbs:
       - create
       - delete
@@ -680,13 +680,13 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines/finalizers
+      - coreweavekubernetesengines/finalizers
     verbs:
       - update
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines/status
+      - coreweavekubernetesengines/status
     verbs:
       - get
       - patch
@@ -2251,18 +2251,18 @@ rules:
       - watch
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrolebinding-rhai-aws-cloud-manager-rolebinding.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrolebinding-rhai-coreweave-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhai-aws-cloud-manager-rolebinding
+  name: rhai-coreweave-cloud-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhai-aws-cloud-manager-role
+  name: rhai-coreweave-cloud-manager-role
 subjects:
   - kind: ServiceAccount
-    name: aws-cloud-manager-operator
+    name: coreweave-cloud-manager-operator
     namespace: rhai-cloudmanager-system
 
 ---
@@ -2281,11 +2281,11 @@ subjects:
     namespace: redhat-ods-operator
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/role-aws-cloud-manager-leader-election-role.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/role-coreweave-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: aws-cloud-manager-leader-election-role
+  name: coreweave-cloud-manager-leader-election-role
   namespace: rhai-cloudmanager-system
 rules:
   - apiGroups:
@@ -2306,19 +2306,19 @@ rules:
       - patch
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/rolebinding-aws-cloud-manager-leader-election-rolebinding.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/rolebinding-coreweave-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: aws-cloud-manager-leader-election-rolebinding
+  name: coreweave-cloud-manager-leader-election-rolebinding
   namespace: rhai-cloudmanager-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: aws-cloud-manager-leader-election-role
+  name: coreweave-cloud-manager-leader-election-role
 subjects:
   - kind: ServiceAccount
-    name: aws-cloud-manager-operator
+    name: coreweave-cloud-manager-operator
     namespace: rhai-cloudmanager-system
 
 ---
@@ -2362,28 +2362,28 @@ spec:
     name: rhai-operator
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/deployment-aws-cloud-manager-operator.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
-    name: aws-cloud-manager-operator
-  name: aws-cloud-manager-operator
+    name: coreweave-cloud-manager-operator
+  name: coreweave-cloud-manager-operator
   namespace: rhai-cloudmanager-system
 spec:
   replicas: 1
   selector:
     matchLabels:
       control-plane: controller-manager
-      name: aws-cloud-manager-operator
+      name: coreweave-cloud-manager-operator
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
-        name: aws-cloud-manager-operator
+        name: coreweave-cloud-manager-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2402,12 +2402,12 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - aws-cloud-manager-operator
+                        - coreweave-cloud-manager-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
         - args:
-            - aws
+            - coreweave
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=0.0.0.0:8080
             - --leader-elect
@@ -2459,7 +2459,7 @@ spec:
               memory: 1Gi
             requests:
               cpu: 100m
-              memory: 512Mi
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2470,7 +2470,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: aws-cloud-manager-operator
+      serviceAccountName: coreweave-cloud-manager-operator
       terminationGracePeriodSeconds: 10
 
 ---
@@ -2897,12 +2897,12 @@ spec:
                   app.kubernetes.io/managed-by: Helm
               spec: {}
               EOF
-              echo "Creating AWSKubernetesEngine CR..."
+              echo "Creating CoreWeaveKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
-              kind: AWSKubernetesEngine
+              kind: CoreWeaveKubernetesEngine
               metadata:
-                name: default-awskubernetesengine
+                name: default-coreweavekubernetesengine
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm
@@ -2917,7 +2917,7 @@ spec:
                   lws:
                     configuration:
                       namespace: openshift-lws-operator
-                    managementPolicy: Managed
+                    managementPolicy: Unmanaged
                   sailOperator:
                     configuration:
                       namespace: istio-system
@@ -3072,9 +3072,21 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: Selector
+                        selector:
+                          matchLabels:
+                            inference-gateway-access: enabled
                   - name: https
                     port: 443
                     protocol: HTTPS
+                    allowedRoutes:
+                      namespaces:
+                        from: Selector
+                        selector:
+                          matchLabels:
+                            inference-gateway-access: enabled
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -3192,9 +3192,9 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
-                    allowedRoutes:
-                      namespaces:
-                        from: All
+                  - name: https
+                    port: 443
+                    protocol: HTTPS
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -3192,9 +3192,15 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                   - name: https
                     port: 443
                     protocol: HTTPS
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -4,18 +4,21 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -43,6 +46,7 @@ metadata:
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 # TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
@@ -53,6 +57,7 @@ metadata:
   namespace: redhat-ods-applications
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -62,6 +67,7 @@ metadata:
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -379,6 +385,7 @@ spec:
       storage: true
       subresources:
         status: {}
+
 ---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kserves.components.platform.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -686,6 +693,7 @@ spec:
       storage: true
       subresources:
         status: {}
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrole-rhai-coreweave-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -950,6 +958,7 @@ rules:
       - patch
       - update
       - watch
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -961,6 +970,7 @@ rules:
       - /metrics
     verbs:
       - get
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2359,6 +2369,7 @@ rules:
       - patch
       - update
       - watch
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrolebinding-rhai-coreweave-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2373,6 +2384,7 @@ subjects:
   - kind: ServiceAccount
     name: coreweave-cloud-manager-operator
     namespace: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2387,6 +2399,7 @@ subjects:
   - kind: ServiceAccount
     name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/role-coreweave-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2411,6 +2424,7 @@ rules:
     verbs:
       - create
       - patch
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/rolebinding-coreweave-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2426,6 +2440,7 @@ subjects:
   - kind: ServiceAccount
     name: coreweave-cloud-manager-operator
     namespace: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
 apiVersion: v1
@@ -2443,6 +2458,7 @@ spec:
       targetPort: http
   selector:
     name: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/service-rhai-operator-webhook-service.yaml
 apiVersion: v1
@@ -2464,6 +2480,7 @@ spec:
       targetPort: 9443
   selector:
     name: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2575,6 +2592,7 @@ spec:
           type: RuntimeDefault
       serviceAccountName: coreweave-cloud-manager-operator
       terminationGracePeriodSeconds: 10
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
 apiVersion: apps/v1
@@ -2778,6 +2796,7 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhai-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -2934,6 +2953,7 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
@@ -3024,6 +3044,7 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
 apiVersion: batch/v1
@@ -3183,3 +3204,4 @@ spec:
                     name: inference-gateway-config
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
+

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -4,21 +4,18 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -46,7 +43,6 @@ metadata:
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 # TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
@@ -57,7 +53,6 @@ metadata:
   namespace: redhat-ods-applications
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -67,7 +62,6 @@ metadata:
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -385,7 +379,6 @@ spec:
       storage: true
       subresources:
         status: {}
-
 ---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kserves.components.platform.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -693,7 +686,6 @@ spec:
       storage: true
       subresources:
         status: {}
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrole-rhai-coreweave-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -958,7 +950,6 @@ rules:
       - patch
       - update
       - watch
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -970,7 +961,6 @@ rules:
       - /metrics
     verbs:
       - get
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2369,7 +2359,6 @@ rules:
       - patch
       - update
       - watch
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrolebinding-rhai-coreweave-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2384,7 +2373,6 @@ subjects:
   - kind: ServiceAccount
     name: coreweave-cloud-manager-operator
     namespace: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2399,7 +2387,6 @@ subjects:
   - kind: ServiceAccount
     name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/role-coreweave-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2424,7 +2411,6 @@ rules:
     verbs:
       - create
       - patch
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/rolebinding-coreweave-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2440,7 +2426,6 @@ subjects:
   - kind: ServiceAccount
     name: coreweave-cloud-manager-operator
     namespace: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
 apiVersion: v1
@@ -2458,7 +2443,6 @@ spec:
       targetPort: http
   selector:
     name: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/service-rhai-operator-webhook-service.yaml
 apiVersion: v1
@@ -2480,7 +2464,6 @@ spec:
       targetPort: 9443
   selector:
     name: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2592,7 +2575,6 @@ spec:
           type: RuntimeDefault
       serviceAccountName: coreweave-cloud-manager-operator
       terminationGracePeriodSeconds: 10
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
 apiVersion: apps/v1
@@ -2796,7 +2778,6 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
-
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhai-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -2953,7 +2934,6 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
-
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
@@ -3044,7 +3024,6 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
-
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
 apiVersion: batch/v1
@@ -3204,4 +3183,3 @@ spec:
                     name: inference-gateway-config
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
-

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -3072,9 +3072,9 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
-                    allowedRoutes:
-                      namespaces:
-                        from: All
+                  - name: https
+                    port: 443
+                    protocol: HTTPS
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -4,18 +4,21 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/serviceaccount-coreweave-cloud-manager-operator.yaml
 apiVersion: v1
@@ -25,6 +28,7 @@ metadata:
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -34,6 +38,7 @@ metadata:
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/crds/customresourcedefinition-coreweavekubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -260,6 +265,7 @@ spec:
       storage: true
       subresources:
         status: {}
+
 ---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kserves.components.platform.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -567,6 +573,7 @@ spec:
       storage: true
       subresources:
         status: {}
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrole-rhai-coreweave-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -831,6 +838,7 @@ rules:
       - patch
       - update
       - watch
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -842,6 +850,7 @@ rules:
       - /metrics
     verbs:
       - get
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2240,6 +2249,7 @@ rules:
       - patch
       - update
       - watch
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrolebinding-rhai-coreweave-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2254,6 +2264,7 @@ subjects:
   - kind: ServiceAccount
     name: coreweave-cloud-manager-operator
     namespace: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2268,6 +2279,7 @@ subjects:
   - kind: ServiceAccount
     name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/role-coreweave-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2292,6 +2304,7 @@ rules:
     verbs:
       - create
       - patch
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/rolebinding-coreweave-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2307,6 +2320,7 @@ subjects:
   - kind: ServiceAccount
     name: coreweave-cloud-manager-operator
     namespace: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
 apiVersion: v1
@@ -2324,6 +2338,7 @@ spec:
       targetPort: http
   selector:
     name: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/service-rhai-operator-webhook-service.yaml
 apiVersion: v1
@@ -2345,6 +2360,7 @@ spec:
       targetPort: 9443
   selector:
     name: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2456,6 +2472,7 @@ spec:
           type: RuntimeDefault
       serviceAccountName: coreweave-cloud-manager-operator
       terminationGracePeriodSeconds: 10
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
 apiVersion: apps/v1
@@ -2659,6 +2676,7 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhai-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -2815,6 +2833,7 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
@@ -2905,6 +2924,7 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
 apiVersion: batch/v1
@@ -3064,3 +3084,4 @@ spec:
                     name: inference-gateway-config
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
+

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -4,21 +4,18 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/serviceaccount-coreweave-cloud-manager-operator.yaml
 apiVersion: v1
@@ -28,7 +25,6 @@ metadata:
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -38,7 +34,6 @@ metadata:
   namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/crds/customresourcedefinition-coreweavekubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -265,7 +260,6 @@ spec:
       storage: true
       subresources:
         status: {}
-
 ---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kserves.components.platform.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -573,7 +567,6 @@ spec:
       storage: true
       subresources:
         status: {}
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrole-rhai-coreweave-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -838,7 +831,6 @@ rules:
       - patch
       - update
       - watch
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -850,7 +842,6 @@ rules:
       - /metrics
     verbs:
       - get
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2249,7 +2240,6 @@ rules:
       - patch
       - update
       - watch
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrolebinding-rhai-coreweave-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2264,7 +2254,6 @@ subjects:
   - kind: ServiceAccount
     name: coreweave-cloud-manager-operator
     namespace: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2279,7 +2268,6 @@ subjects:
   - kind: ServiceAccount
     name: rhai-operator-controller-manager
     namespace: redhat-ods-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/role-coreweave-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2304,7 +2292,6 @@ rules:
     verbs:
       - create
       - patch
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/rolebinding-coreweave-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2320,7 +2307,6 @@ subjects:
   - kind: ServiceAccount
     name: coreweave-cloud-manager-operator
     namespace: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
 apiVersion: v1
@@ -2338,7 +2324,6 @@ spec:
       targetPort: http
   selector:
     name: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/service-rhai-operator-webhook-service.yaml
 apiVersion: v1
@@ -2360,7 +2345,6 @@ spec:
       targetPort: 9443
   selector:
     name: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2472,7 +2456,6 @@ spec:
           type: RuntimeDefault
       serviceAccountName: coreweave-cloud-manager-operator
       terminationGracePeriodSeconds: 10
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
 apiVersion: apps/v1
@@ -2676,7 +2659,6 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
-
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhai-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -2833,7 +2815,6 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
-
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
@@ -2924,7 +2905,6 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
-
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
 apiVersion: batch/v1
@@ -3084,4 +3064,3 @@ spec:
                     name: inference-gateway-config
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
-

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -3072,9 +3072,15 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                   - name: https
                     port: 443
                     protocol: HTTPS
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -4,18 +4,21 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-applications
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -43,6 +46,7 @@ metadata:
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 # TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
@@ -53,6 +57,7 @@ metadata:
   namespace: rhai-applications
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -62,6 +67,7 @@ metadata:
   namespace: rhai-operator
 imagePullSecrets:
   - name: rhai-pull-secret
+
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -379,6 +385,7 @@ spec:
       storage: true
       subresources:
         status: {}
+
 ---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kserves.components.platform.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -686,6 +693,7 @@ spec:
       storage: true
       subresources:
         status: {}
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrole-rhai-azure-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -950,6 +958,7 @@ rules:
       - patch
       - update
       - watch
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -961,6 +970,7 @@ rules:
       - /metrics
     verbs:
       - get
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2359,6 +2369,7 @@ rules:
       - patch
       - update
       - watch
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrolebinding-rhai-azure-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2373,6 +2384,7 @@ subjects:
   - kind: ServiceAccount
     name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2387,6 +2399,7 @@ subjects:
   - kind: ServiceAccount
     name: rhai-operator-controller-manager
     namespace: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2411,6 +2424,7 @@ rules:
     verbs:
       - create
       - patch
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/rolebinding-azure-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2426,6 +2440,7 @@ subjects:
   - kind: ServiceAccount
     name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
 apiVersion: v1
@@ -2443,6 +2458,7 @@ spec:
       targetPort: http
   selector:
     name: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/service-rhai-operator-webhook-service.yaml
 apiVersion: v1
@@ -2464,6 +2480,7 @@ spec:
       targetPort: 9443
   selector:
     name: rhai-operator
+
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2575,6 +2592,7 @@ spec:
           type: RuntimeDefault
       serviceAccountName: azure-cloud-manager-operator
       terminationGracePeriodSeconds: 10
+
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
 apiVersion: apps/v1
@@ -2778,6 +2796,7 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhai-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -2934,6 +2953,7 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
@@ -3024,6 +3044,7 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
 apiVersion: batch/v1
@@ -3187,3 +3208,4 @@ spec:
                     name: inference-gateway-config
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
+

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -3196,9 +3196,15 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                   - name: https
                     port: 443
                     protocol: HTTPS
+                    allowedRoutes:
+                      namespaces:
+                        from: All
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -3196,9 +3196,9 @@ spec:
                   - name: http
                     port: 80
                     protocol: HTTP
-                    allowedRoutes:
-                      namespaces:
-                        from: All
+                  - name: https
+                    port: 443
+                    protocol: HTTPS
                 infrastructure:
                   labels:
                     serving.kserve.io/gateway: kserve-ingress-gateway

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -4,21 +4,18 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-applications
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -46,7 +43,6 @@ metadata:
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 # TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
@@ -57,7 +53,6 @@ metadata:
   namespace: rhai-applications
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/serviceaccount-redhat-ods-operator-controller-manager.yaml
 apiVersion: v1
@@ -67,7 +62,6 @@ metadata:
   namespace: rhai-operator
 imagePullSecrets:
   - name: rhai-pull-secret
-
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
@@ -385,7 +379,6 @@ spec:
       storage: true
       subresources:
         status: {}
-
 ---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kserves.components.platform.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -693,7 +686,6 @@ spec:
       storage: true
       subresources:
         status: {}
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrole-rhai-azure-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -958,7 +950,6 @@ rules:
       - patch
       - update
       - watch
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-redhat-ods-operator-metrics-reader.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -970,7 +961,6 @@ rules:
       - /metrics
     verbs:
       - get
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2369,7 +2359,6 @@ rules:
       - patch
       - update
       - watch
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrolebinding-rhai-azure-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2384,7 +2373,6 @@ subjects:
   - kind: ServiceAccount
     name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/rbac/clusterrolebinding-rhods-operator-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2399,7 +2387,6 @@ subjects:
   - kind: ServiceAccount
     name: rhai-operator-controller-manager
     namespace: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2424,7 +2411,6 @@ rules:
     verbs:
       - create
       - patch
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/rolebinding-azure-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2440,7 +2426,6 @@ subjects:
   - kind: ServiceAccount
     name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/service-redhat-ods-operator-controller-manager-metrics-service.yaml
 apiVersion: v1
@@ -2458,7 +2443,6 @@ spec:
       targetPort: http
   selector:
     name: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/service-rhai-operator-webhook-service.yaml
 apiVersion: v1
@@ -2480,7 +2464,6 @@ spec:
       targetPort: 9443
   selector:
     name: rhai-operator
-
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
 apiVersion: apps/v1
@@ -2592,7 +2575,6 @@ spec:
           type: RuntimeDefault
       serviceAccountName: azure-cloud-manager-operator
       terminationGracePeriodSeconds: 10
-
 ---
 # Source: rhai-on-xks-chart/templates/manager/deployment-rhods-operator.yaml
 apiVersion: apps/v1
@@ -2796,7 +2778,6 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
-
 ---
 # Source: rhai-on-xks-chart/templates/webhooks/mutatingwebhookconfiguration-rhai-operator-mutating-webhook-configuration.yaml
 apiVersion: admissionregistration.k8s.io/v1
@@ -2953,7 +2934,6 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
-
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
 apiVersion: batch/v1
@@ -3044,7 +3024,6 @@ spec:
                     managementPolicy: Managed
               EOF
               echo "Done."
-
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-gateway-job.yaml
 apiVersion: batch/v1
@@ -3208,4 +3187,3 @@ spec:
                     name: inference-gateway-config
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
-

--- a/charts/rhai-on-xks-chart/values.schema.json
+++ b/charts/rhai-on-xks-chart/values.schema.json
@@ -194,9 +194,8 @@
                       "properties": {
                         "from": {
                           "type": "string",
-                          "description": "Which namespaces can attach routes to the Gateway (All, Same, or Selector)",
-                          "enum": ["All", "Same", "Selector"],
-                          "default": "All"
+                          "description": "Which namespaces can attach HTTPRoutes to the Gateway (All, Same, or Selector). If empty, defaults to Same — only from the Gateway's own namespace.",
+                          "enum": ["", "Selector", "Same", "All"]
                         },
                         "selector": {
                           "type": "object",

--- a/charts/rhai-on-xks-chart/values.schema.json
+++ b/charts/rhai-on-xks-chart/values.schema.json
@@ -183,9 +183,39 @@
                   "type": "boolean",
                   "description": "Create Gateway and ConfigMaps via post-install hook",
                   "default": true
+                },
+                "allowedRoutes": {
+                  "type": "object",
+                  "description": "Gateway allowedRoutes configuration for controlling which namespaces can attach HTTPRoutes",
+                  "properties": {
+                    "namespaces": {
+                      "type": "object",
+                      "description": "Namespace-based route attachment policy",
+                      "properties": {
+                        "from": {
+                          "type": "string",
+                          "description": "Which namespaces can attach routes to the Gateway (All, Same, or Selector)",
+                          "enum": ["All", "Same", "Selector"],
+                          "default": "All"
+                        },
+                        "selector": {
+                          "type": "object",
+                          "description": "Label selector for namespaces when from is Selector",
+                          "properties": {
+                            "matchLabels": {
+                              "type": "object",
+                              "description": "Label key-value pairs that namespaces must match",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
-              },
-              "additionalProperties": false
+              }
             }
           }
         }

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -69,7 +69,13 @@ components:
           # Which namespaces can attach HTTPRoutes to the Gateway (All, Same, or Selector).
           # If empty, defaults to Same — only from the Gateway's own namespace.
           from: ""
-          # Example for Selector:
+          # Example for All (any namespace can attach routes):
+          # from: All
+          #
+          # Example for Same (only the Gateway's namespace):
+          # from: Same
+          #
+          # Example for Selector (only namespaces matching labels):
           # from: Selector
           # selector:
           #   matchLabels:

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -64,6 +64,14 @@ components:
     gateway:
       # Create Gateway and ConfigMaps via post-install hook
       create: true
+      allowedRoutes:
+        namespaces:
+          from: All
+          # The following is an example of how to restrict the namespaces to the interested ones.
+          # from: Selector
+          # selector:
+          #   matchLabels:
+          #     inference-gateway-access: "true"
 
 # Azure cloud configuration
 azure:

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -66,8 +66,10 @@ components:
       create: true
       allowedRoutes:
         namespaces:
-          from: All
-          # The following is an example of how to restrict the namespaces to the interested ones.
+          # Which namespaces can attach HTTPRoutes to the Gateway (All, Same, or Selector).
+          # If empty, defaults to Same — only from the Gateway's own namespace.
+          from: ""
+          # Example for Selector:
           # from: Selector
           # selector:
           #   matchLabels:

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -67,13 +67,13 @@ components:
       allowedRoutes:
         namespaces:
           # Which namespaces can attach HTTPRoutes to the Gateway (All, Same, or Selector).
-          # If empty, defaults to Same — only from the Gateway's own namespace.
-          from: ""
-          # Example for All (any namespace can attach routes):
-          # from: All
-          #
+          # If empty, the allowedRoutes block is omitted and the Gateway API defaults to Same.
+          from: All
           # Example for Same (only the Gateway's namespace):
           # from: Same
+          #
+          # Example for All (any namespace can attach routes):
+          # from: All
           #
           # Example for Selector (only namespaces matching labels):
           # from: Selector

--- a/scripts/snapshot-config.yaml
+++ b/scripts/snapshot-config.yaml
@@ -118,3 +118,14 @@ charts:
         setFlags:
           - aws.enabled=true
           - imagePullSecret.dockerConfigJson=testauth
+
+      - name: aws-with-allowed-routes-all
+        setFlags:
+          - aws.enabled=true
+          - components.kserve.gateway.allowedRoutes.namespaces.from=All
+
+      - name: coreweave-with-allowed-routes-selector
+        setFlags:
+          - coreweave.enabled=true
+          - components.kserve.gateway.allowedRoutes.namespaces.from=Selector
+          - components.kserve.gateway.allowedRoutes.namespaces.selector.matchLabels.inference-gateway-access=enabled

--- a/scripts/snapshot-config.yaml
+++ b/scripts/snapshot-config.yaml
@@ -124,6 +124,11 @@ charts:
           - aws.enabled=true
           - components.kserve.gateway.allowedRoutes.namespaces.from=All
 
+      - name: aws-with-allowed-routes-same
+        setFlags:
+          - aws.enabled=true
+          - components.kserve.gateway.allowedRoutes.namespaces.from=Same
+
       - name: coreweave-with-allowed-routes-selector
         setFlags:
           - coreweave.enabled=true


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
cherrypick https://github.com/opendatahub-io/odh-gitops/pull/103
with more changes to
- add support for 443/https
- default if not set fall to SAME as can only create HTTPRoute to the same ns where GW is


Jira task: <!--- Link your JIRA and related links here for reference. -->
https://redhat.atlassian.net/browse/INFERENG-7126

## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->

- [ ] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable namespace access control for the KServe Gateway (choose which namespaces can attach routes).
  * Added HTTPS listener support for the Gateway.

* **Documentation**
  * Documented the new Gateway allowed-routes configuration in chart values and schema, including examples for All/Same/Selector.

* **Tests**
  * Added snapshot/test configurations covering allowed-routes scenarios (All/Same/Selector).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->