### PR TITLE
fix: lws default is now unmanaged also in aws

### DIFF
--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -23,7 +23,7 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | aws.kubernetesEngine.spec.dependencies.gatewayAPI.configuration | object | `{}` |  |
 | aws.kubernetesEngine.spec.dependencies.gatewayAPI.managementPolicy | string | `"Managed"` |  |
 | aws.kubernetesEngine.spec.dependencies.lws.configuration.namespace | string | `"openshift-lws-operator"` |  |
-| aws.kubernetesEngine.spec.dependencies.lws.managementPolicy | string | `"Managed"` |  |
+| aws.kubernetesEngine.spec.dependencies.lws.managementPolicy | string | `"Unmanaged"` |  |
 | aws.kubernetesEngine.spec.dependencies.sailOperator.configuration.namespace | string | `"istio-system"` |  |
 | aws.kubernetesEngine.spec.dependencies.sailOperator.managementPolicy | string | `"Managed"` |  |
 | azure.cloudManager.image | string | `"quay.io/opendatahub/opendatahub-operator:latest"` |  |

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -36,12 +36,6 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-lws-operator
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
   name: istio-system
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml
@@ -146,19 +140,6 @@ kind: Secret
 metadata:
   name: rhai-pull-secret
   namespace: cert-manager
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: dGVzdGF1dGg=
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rhai-pull-secret
-  namespace: openshift-lws-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -3056,7 +3037,7 @@ spec:
                   lws:
                     configuration:
                       namespace: openshift-lws-operator
-                    managementPolicy: Managed
+                    managementPolicy: Unmanaged
                   sailOperator:
                     configuration:
                       namespace: istio-system

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -2917,7 +2917,7 @@ spec:
                   lws:
                     configuration:
                       namespace: openshift-lws-operator
-                    managementPolicy: Managed
+                    managementPolicy: Unmanaged
                   sailOperator:
                     configuration:
                       namespace: istio-system

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -177,7 +177,7 @@ aws:
           managementPolicy: Managed
           configuration: {}
         lws:
-          managementPolicy: Managed
+          managementPolicy: Unmanaged
           configuration:
             namespace: openshift-lws-operator
         sailOperator:


### PR DESCRIPTION
## Description

- Change LWS (LeaderWorkerSet) default `managementPolicy` from `Managed` to `Unmanaged` in the AWS cloud configuration of `rhai-on-xks-chart`, aligning it with Azure and CoreWeave defaults
- LWS is only required when running WideEP — keeping it `Unmanaged` by default avoids installing unnecessary dependencies
- Updated snapshots and api-docs to reflect the change

## Has it been tested?

- [ ] Installed on a real cluster to verify the changes
- [x] Snapshot tests updated and passing (`make chart-snapshots`)

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated Lightweight Services (LWS) dependency management policy configuration across Helm values, deployment manifests, and documentation
  * Reconfigured pull-secret deployment to target the istio-system namespace

<!-- end of auto-generated comment: release notes by coderabbit.ai -->