### PR TITLE
chore: upgrade to 3.5-ea.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ YQ ?= $(LOCALBIN)/yq
 
 ## Application Versions
 # RHOAI version to use for bundle updates - update this when new catalog folder appears in RHOAI-Build-Config
-RHOAI_VERSION ?= 3.5.0-ea.1
+RHOAI_VERSION ?= 3.5.0-ea.2
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.8.0

--- a/charts/rhai-on-xks-chart/Chart.yaml
+++ b/charts/rhai-on-xks-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rhai-on-xks-chart
 description: RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes services (Azure, CoreWeave).
 type: application
-version: 3.5.0-ea.1
-appVersion: 3.5.0-ea.1
+version: 3.5.0-ea.2
+appVersion: 3.5.0-ea.2

--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -1,6 +1,6 @@
 # rhai-on-xks-chart
 
-![Version: 3.5.0-ea.1](https://img.shields.io/badge/Version-3.5.0--ea.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.0-ea.1](https://img.shields.io/badge/AppVersion-3.5.0--ea.1-informational?style=flat-square)
+![Version: 3.5.0-ea.2](https://img.shields.io/badge/Version-3.5.0--ea.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.0-ea.2](https://img.shields.io/badge/AppVersion-3.5.0--ea.2-informational?style=flat-square)
 
 RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes services (Azure, CoreWeave).
 

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
@@ -2571,7 +2571,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.1"
+              value: "3.5.0-ea.2"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME
@@ -2917,7 +2917,7 @@ spec:
                   lws:
                     configuration:
                       namespace: openshift-lws-operator
-                    managementPolicy: Managed
+                    managementPolicy: Unmanaged
                   sailOperator:
                     configuration:
                       namespace: istio-system

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
@@ -2571,7 +2571,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.1"
+              value: "3.5.0-ea.2"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME
@@ -2917,7 +2917,7 @@ spec:
                   lws:
                     configuration:
                       namespace: openshift-lws-operator
-                    managementPolicy: Managed
+                    managementPolicy: Unmanaged
                   sailOperator:
                     configuration:
                       namespace: istio-system

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -2691,7 +2691,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.1"
+              value: "3.5.0-ea.2"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -2571,7 +2571,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.1"
+              value: "3.5.0-ea.2"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -2691,7 +2691,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.1"
+              value: "3.5.0-ea.2"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2571,7 +2571,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.1"
+              value: "3.5.0-ea.2"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
@@ -2571,7 +2571,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.1"
+              value: "3.5.0-ea.2"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -2691,7 +2691,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.1"
+              value: "3.5.0-ea.2"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -2571,7 +2571,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.1"
+              value: "3.5.0-ea.2"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -2691,7 +2691,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "rhai-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.1"
+              value: "3.5.0-ea.2"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/values-rhoai-3.5-ea.1.yaml
+++ b/charts/rhai-on-xks-chart/values-rhoai-3.5-ea.1.yaml
@@ -1,0 +1,218 @@
+# Enable/disable all resource creation
+enabled: true
+# Install CRDs or not using the chart
+installCRDs: true
+# Common labels applied to all resources
+labels: {}
+# RHAI Operator configuration
+rhaiOperator:
+  # Operator namespace
+  namespace: redhat-ods-operator
+  applicationsNamespace: redhat-ods-applications
+  # Manager container image
+  image: "quay.io/rhoai/odh-rhel9-operator@sha256:516f84a71474c34978ef065bda84b9ae899698b034a0975d8310d7e4ebe75c77" # image is updated during Helm chart build by konflux
+  # Image pull policy
+  imagePullPolicy: Always
+  # Number of operator replicas
+  replicas: 1
+  # Resources for the main manager container
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 300m
+      memory: 256Mi
+  # Resources for the copy-manifests init container
+  initResources:
+    limits:
+      cpu: 100m
+      memory: 512Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  # Related images env vars (RELATED_IMAGE_*)
+  relatedImages:
+    - name: RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE
+      value: "quay.io/rhoai/odh-kserve-agent-rhel9@sha256:cdfbde088f31f86ce1ac4a9a31c322b9ad0ee2d85af5f323cc754ce61cc845c0"
+    - name: RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE
+      value: "quay.io/rhoai/odh-kserve-controller-rhel9@sha256:fd81a28562926ea731022087d125610c273c29b7d329463d0addcccecf99b71f"
+    - name: RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE
+      value: "quay.io/rhoai/odh-kserve-llmisvc-controller-rhel9@sha256:d1dca56b13f6e48d98148add62000b9bc98785cb6f0e1bae5d60921ba6f549e8"
+    - name: RELATED_IMAGE_ODH_KSERVE_ROUTER_IMAGE
+      value: "quay.io/rhoai/odh-kserve-router-rhel9@sha256:bcc2ecb1c5645d5cfab400cd5519e8fda4e67d35084ec6bd6f16856120cd541a"
+    - name: RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE
+      value: "quay.io/rhoai/odh-kserve-storage-initializer-rhel9@sha256:4ecbf7804e7e61c87ae0056b0749abf6a4bf9e66e9c6eadbdf5d6acbfd0e4667"
+    - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
+      value: "registry.redhat.io/rhaii-early-access/vllm-cuda-rhel9@sha256:d4677a76a30aa006f5dba9f1bf095b734f5f4561a5b43e11338e6800fab97aa6"
+    - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
+      value: "registry.redhat.io/rhaii-early-access/vllm-rocm-rhel9@sha256:479bbcfd88fd3b2e1e5cc40d21beccc2c6deeaf08d3e2f53665155d007ebc149"
+    - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
+      value: "registry.redhat.io/rhaii-early-access/vllm-spyre-rhel9@sha256:6031caf2f3b6901f6a155f105b7fef6bdcf48a659371645b5551b2ba412c5705"
+    - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
+      value: "registry.redhat.io/rhaii-early-access/vllm-cpu-rhel9@sha256:c64ed56ee8622f55fc1b22a3f1bc114755672f655d56b8b76572c3e81f03fd79"
+    - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
+      value: "registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9@sha256:ebe23cd1bfa50116cab50944fb0b8d146de218f742841aedf2a99ae25480cf7e"
+    - name: RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE
+      value: "quay.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:0323abbb1fee434123c0f3b47f32206d3101436907ef695b472d9cda725c2332"
+    - name: RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE
+      value: "quay.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:42e0e01595b755da5788ba4518b4c9530b1c688b6308fa777385594c1dc6c2fa"
+    - name: RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
+      value: "quay.io/rhoai/odh-kube-rbac-proxy-rhel9@sha256:a685bb77e1ba90e6555f56e26e49d640080c34ebfc7c0995569e52a3e02e94bd"
+    - name: RELATED_IMAGE_ODH_LLM_D_KV_CACHE_IMAGE
+      value: "quay.io/rhoai/odh-llm-d-kv-cache-rhel9@sha256:82f0bcd33208744d52c46a29e498a0d537b7e358ab7952ec5da1dac0337bbb36"
+    - name: RELATED_IMAGE_ODH_KSERVE_LOCALMODEL_CONTROLLER_IMAGE
+      value: "quay.io/rhoai/odh-kserve-localmodel-controller-rhel9@sha256:8ec86117f58fba040786aa0cf9114be8cab52afbfeadca692a6da7f434959f29"
+    - name: RELATED_IMAGE_ODH_KSERVE_LOCALMODELNODE_AGENT_IMAGE
+      value: "quay.io/rhoai/odh-kserve-localmodelnode-agent-rhel9@sha256:732042c138d738c36ad751d6e30e1e23e9f1bf7172fc525086d680a3c694afb2"
+hooks:
+  cliImage: "registry.redhat.io/openshift4/ose-cli-rhel9@sha256:7feb4aac0703a07483fb3b0d49bd8db240b7d18604657a2b89ba537c8dbbd64b"
+  # Default resources for all hook job containers
+  resources:
+    limits:
+      cpu: 200m
+      memory: 512Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+  postInstallCrs:
+    enabled: true
+# Components configuration
+components:
+  kserve:
+    # Create Kserve CR via post-install hook
+    enabled: true
+    spec: {}
+    # Gateway configuration for KServe inference
+    gateway:
+      # Create Gateway and ConfigMaps via post-install hook
+      create: true
+# Azure cloud configuration
+azure:
+  enabled: false
+  cloudManager:
+    # Cloud Manager operator namespace
+    namespace: rhai-cloudmanager-system
+    # Cloud Manager container image
+    image: "quay.io/rhoai/odh-rhel9-operator@sha256:516f84a71474c34978ef065bda84b9ae899698b034a0975d8310d7e4ebe75c77"
+    # Image pull policy
+    imagePullPolicy: Always
+    # Number of cloud manager replicas
+    replicas: 1
+    # Resources for the cloud manager container
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+  kubernetesEngine:
+    # Create AzureKubernetesEngine CR via post-install hook
+    enabled: true
+    spec:
+      dependencies:
+        certManager:
+          managementPolicy: Managed
+          configuration: {}
+        gatewayAPI:
+          managementPolicy: Managed
+          configuration: {}
+        lws:
+          managementPolicy: Unmanaged # Required only when need run WideEP, set to Managed then
+          configuration:
+            namespace: openshift-lws-operator
+        sailOperator:
+          managementPolicy: Managed
+          configuration:
+            namespace: istio-system
+# CoreWeave cloud configuration
+coreweave:
+  enabled: false
+  cloudManager:
+    # Cloud Manager operator namespace
+    namespace: rhai-cloudmanager-system
+    # Cloud Manager container image
+    image: "quay.io/rhoai/odh-rhel9-operator@sha256:516f84a71474c34978ef065bda84b9ae899698b034a0975d8310d7e4ebe75c77"
+    # Image pull policy
+    imagePullPolicy: Always
+    # Number of cloud manager replicas
+    replicas: 1
+    # Resources for the cloud manager container
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+  kubernetesEngine:
+    # Create CoreWeaveKubernetesEngine CR via post-install hook
+    enabled: true
+    spec:
+      dependencies:
+        certManager:
+          managementPolicy: Managed
+          configuration: {}
+        gatewayAPI:
+          managementPolicy: Managed
+          configuration: {}
+        lws:
+          managementPolicy: Unmanaged # Required only when need run WideEP, set to Managed then
+          configuration:
+            namespace: openshift-lws-operator
+        sailOperator:
+          managementPolicy: Managed
+          configuration:
+            namespace: istio-system
+# AWS cloud configuration
+aws:
+  enabled: false
+  cloudManager:
+    # Cloud Manager operator namespace
+    namespace: rhai-cloudmanager-system
+    # Cloud Manager container image
+    image: "quay.io/rhoai/odh-rhel9-operator@sha256:516f84a71474c34978ef065bda84b9ae899698b034a0975d8310d7e4ebe75c77"
+    # Image pull policy
+    imagePullPolicy: Always
+    # Number of cloud manager replicas
+    replicas: 1
+    # Resources for the cloud manager container
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 512Mi
+  kubernetesEngine:
+    # Create AWSKubernetesEngine CR via post-install hook
+    enabled: true
+    spec:
+      dependencies:
+        certManager:
+          managementPolicy: Managed
+          configuration: {}
+        gatewayAPI:
+          managementPolicy: Managed
+          configuration: {}
+        lws:
+          managementPolicy: Managed
+          configuration:
+            namespace: openshift-lws-operator
+        sailOperator:
+          managementPolicy: Managed
+          configuration:
+            namespace: istio-system
+# Pull secret for private registries
+# Use --set-file imagePullSecret.dockerConfigJson=path/to/auth.json
+imagePullSecret:
+  # Name of the pull secret to create in target namespaces. This name MUST not be changed
+  # as it is referred also in other installed dependencies and not yet configurable.
+  name: rhai-pull-secret
+  # Docker config JSON content (populated via --set-file)
+  dockerConfigJson: ""
+  # Namespaces created by dependency operators where pull secrets should be injected
+  dependencyNamespaces:
+    - cert-manager-operator
+    - cert-manager

--- a/charts/rhai-on-xks-chart/values-rhoai-3.5-ea.2.yaml
+++ b/charts/rhai-on-xks-chart/values-rhoai-3.5-ea.2.yaml
@@ -1,0 +1,234 @@
+# Enable/disable all resource creation
+enabled: true
+# Install CRDs or not using the chart
+installCRDs: true
+# Common labels applied to all resources
+labels: {}
+# RHAI Operator configuration
+rhaiOperator:
+  # Operator namespace
+  namespace: redhat-ods-operator
+  applicationsNamespace: redhat-ods-applications
+  # Manager container image
+  image: "quay.io/rhoai/odh-rhel9-operator@sha256:6558135226a074bcfd1a53a32fb342250ea6099965e7e3874f5e8c509323609d" # image is updated during Helm chart build by konflux
+  # Image pull policy
+  imagePullPolicy: Always
+  # Number of operator replicas
+  replicas: 1
+  # Resources for the main manager container
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 300m
+      memory: 256Mi
+  # Resources for the copy-manifests init container
+  initResources:
+    limits:
+      cpu: 100m
+      memory: 512Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  # Related images env vars (RELATED_IMAGE_*)
+  relatedImages:
+    - name: RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE
+      value: "quay.io/rhoai/odh-kserve-agent-rhel9@sha256:43d9203f10c4579cf6140f4b9a540bc616d5e49ca8252d33e7b6bdbe71d3478e"
+    - name: RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE
+      value: "quay.io/rhoai/odh-kserve-controller-rhel9@sha256:7f6f393635a7431d530256ef8ad48ebd35531166dbb361c6c0ff9fc37bd5dc2b"
+    - name: RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE
+      value: "quay.io/rhoai/odh-kserve-llmisvc-controller-rhel9@sha256:d3225eb3f0bfcb20a6d1dccd63403e58a810921680425ecae1b22d86a451417d"
+    - name: RELATED_IMAGE_ODH_KSERVE_ROUTER_IMAGE
+      value: "quay.io/rhoai/odh-kserve-router-rhel9@sha256:e864671939db9cd211c6ae607d894260088d14246c418ecd2479ce1a59f9be3d"
+    - name: RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE
+      value: "quay.io/rhoai/odh-kserve-storage-initializer-rhel9@sha256:0cf99daf3963a5b1ef859b6b54b0516e8cb2117874390989889db169ac387a86"
+    - name: RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-cuda-rhel9@sha256:d3e57d4ca13a17f4d5d1228df4fe47cfe1a9f630250a8b3d26f86d871fdb9e69"
+    - name: RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-rocm-rhel9@sha256:cfeac10c571206514c2876f220ce845058511185ebe8944afc32581dc45b34f3"
+    - name: RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-spyre-rhel9@sha256:5c0ed9be230a307d512fa99236b060ac2ecd86973d17c467badc7b5c2d2b5da4"
+    - name: RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-cpu-rhel9@sha256:562aeaf7dabfccccf9ecc2d8c0e7d84d813778f146dd9d5c8e3a1d595d07a82c"
+    - name: RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE
+      value: "registry.redhat.io/rhaii/vllm-gaudi-rhel9@sha256:1adc51d99455d90f758d840cb3bb5747ed29585c1b0830c051f7fe5cca3471e6"
+    - name: RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE
+      value: "quay.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:f9d11f39a52cb80f5a62c27470c1170efd1861c47251e6a6c3a4a055fcb75865"
+    - name: RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE
+      value: "quay.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:ce44d551c58db4c9768e91283a84b36eee8a1189ae07536aaa3bbf49968d04b2"
+    - name: RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
+      value: "quay.io/rhoai/odh-kube-rbac-proxy-rhel9@sha256:84459a75f19a225c932cdff52fd81f21e8cacc1fc48b236b0b82e2f1412da37e"
+    - name: RELATED_IMAGE_ODH_LLM_D_KV_CACHE_IMAGE
+      value: "quay.io/rhoai/odh-llm-d-kv-cache-rhel9@sha256:0187e28be320073295b1e241eb84dd50cb5f5b6827a0cb68a0d425fb185b58f1"
+    - name: RELATED_IMAGE_ODH_KSERVE_LOCALMODEL_CONTROLLER_IMAGE
+      value: "quay.io/rhoai/odh-kserve-localmodel-controller-rhel9@sha256:41c02ca30a21902ba2907d48cb647a17c7dcaf3dcf3b97ea61159a619bb618c8"
+    - name: RELATED_IMAGE_ODH_KSERVE_LOCALMODELNODE_AGENT_IMAGE
+      value: "quay.io/rhoai/odh-kserve-localmodelnode-agent-rhel9@sha256:31b29024570534fbc6580269f050d396c361546fea15fb14d79b847870a08ae8"
+hooks:
+  cliImage: "registry.redhat.io/openshift4/ose-cli-rhel9@sha256:7434fde9f36d6e638a77977ff1bc2c77d61508227744319497c007649f12fd00"
+  # Default resources for all hook job containers
+  resources:
+    limits:
+      cpu: 200m
+      memory: 512Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+  postInstallCrs:
+    enabled: true
+# Components configuration
+components:
+  kserve:
+    # Create Kserve CR via post-install hook
+    enabled: true
+    spec: {}
+    # Gateway configuration for KServe inference
+    gateway:
+      # Create Gateway and ConfigMaps via post-install hook
+      create: true
+      allowedRoutes:
+        namespaces:
+          # Which namespaces can attach HTTPRoutes to the Gateway (All, Same, or Selector).
+          # If empty, the allowedRoutes block is omitted and the Gateway API defaults to Same.
+          from: All
+          # Example for Same (only the Gateway's namespace):
+          # from: Same
+          #
+          # Example for All (any namespace can attach routes):
+          # from: All
+          #
+          # Example for Selector (only namespaces matching labels):
+          # from: Selector
+          # selector:
+          #   matchLabels:
+          #     inference-gateway-access: "true"
+# Azure cloud configuration
+azure:
+  enabled: false
+  cloudManager:
+    # Cloud Manager operator namespace
+    namespace: rhai-cloudmanager-system
+    # Cloud Manager container image
+    image: "quay.io/rhoai/odh-rhel9-operator@sha256:6558135226a074bcfd1a53a32fb342250ea6099965e7e3874f5e8c509323609d"
+    # Image pull policy
+    imagePullPolicy: Always
+    # Number of cloud manager replicas
+    replicas: 1
+    # Resources for the cloud manager container
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+  kubernetesEngine:
+    # Create AzureKubernetesEngine CR via post-install hook
+    enabled: true
+    spec:
+      dependencies:
+        certManager:
+          managementPolicy: Managed
+          configuration: {}
+        gatewayAPI:
+          managementPolicy: Managed
+          configuration: {}
+        lws:
+          managementPolicy: Unmanaged # Required only when need run WideEP, set to Managed then
+          configuration:
+            namespace: openshift-lws-operator
+        sailOperator:
+          managementPolicy: Managed
+          configuration:
+            namespace: istio-system
+# CoreWeave cloud configuration
+coreweave:
+  enabled: false
+  cloudManager:
+    # Cloud Manager operator namespace
+    namespace: rhai-cloudmanager-system
+    # Cloud Manager container image
+    image: "quay.io/rhoai/odh-rhel9-operator@sha256:6558135226a074bcfd1a53a32fb342250ea6099965e7e3874f5e8c509323609d"
+    # Image pull policy
+    imagePullPolicy: Always
+    # Number of cloud manager replicas
+    replicas: 1
+    # Resources for the cloud manager container
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+  kubernetesEngine:
+    # Create CoreWeaveKubernetesEngine CR via post-install hook
+    enabled: true
+    spec:
+      dependencies:
+        certManager:
+          managementPolicy: Managed
+          configuration: {}
+        gatewayAPI:
+          managementPolicy: Managed
+          configuration: {}
+        lws:
+          managementPolicy: Unmanaged # Required only when need run WideEP, set to Managed then
+          configuration:
+            namespace: openshift-lws-operator
+        sailOperator:
+          managementPolicy: Managed
+          configuration:
+            namespace: istio-system
+# AWS cloud configuration
+aws:
+  enabled: false
+  cloudManager:
+    # Cloud Manager operator namespace
+    namespace: rhai-cloudmanager-system
+    # Cloud Manager container image
+    image: "quay.io/rhoai/odh-rhel9-operator@sha256:6558135226a074bcfd1a53a32fb342250ea6099965e7e3874f5e8c509323609d"
+    # Image pull policy
+    imagePullPolicy: Always
+    # Number of cloud manager replicas
+    replicas: 1
+    # Resources for the cloud manager container
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 512Mi
+  kubernetesEngine:
+    # Create AWSKubernetesEngine CR via post-install hook
+    enabled: true
+    spec:
+      dependencies:
+        certManager:
+          managementPolicy: Managed
+          configuration: {}
+        gatewayAPI:
+          managementPolicy: Managed
+          configuration: {}
+        lws:
+          managementPolicy: Managed
+          configuration:
+            namespace: openshift-lws-operator
+        sailOperator:
+          managementPolicy: Managed
+          configuration:
+            namespace: istio-system
+# Pull secret for private registries
+# Use --set-file imagePullSecret.dockerConfigJson=path/to/auth.json
+imagePullSecret:
+  # Name of the pull secret to create in target namespaces. This name MUST not be changed
+  # as it is referred also in other installed dependencies and not yet configurable.
+  name: rhai-pull-secret
+  # Docker config JSON content (populated via --set-file)
+  dockerConfigJson: ""
+  # Namespaces created by dependency operators where pull secrets should be injected
+  dependencyNamespaces:
+    - cert-manager-operator
+    - cert-manager


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped application/version references from 3.5.0-ea.1 to 3.5.0-ea.2 across chart metadata, configuration and deployment snapshots.
  * Adjusted a post-install dependency management policy from Managed to Unmanaged (affects post-install behavior).

* **New Files**
  * Added a new values configuration for the 3.5.0-ea.2 release with updated operator, component, and image settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->