### PR TITLE
fix: remove crds filter

### DIFF
--- a/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
+++ b/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
@@ -1,12 +1,5 @@
 # helmtemplate-generator configuration for RHAI operator chart
 
-filter:
-  include:
-    - kinds:
-        - CustomResourceDefinition
-      names:
-        - "kserves.components.platform.opendatahub.io"
-
 rules:
   # Replace namespace references with Helm template
   - match:


### PR DESCRIPTION
The bundle is already taken from opendatahub-operator config for rhaii, so it already contains only the needed CRDs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed processing filter restrictions to enable support for a broader range of resource types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->