### PR TITLE
feat(ci): accept reactive sync trigger from rhods-operator and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Operator team is auto-requested for review on chart template changes
+/charts/rhai-on-xks-chart/templates/ @opendatahub-io/odh-operator-maintainers

--- a/.github/workflows/update-rhai-xks-bundle.yaml
+++ b/.github/workflows/update-rhai-xks-bundle.yaml
@@ -1,9 +1,13 @@
 name: Update RHAI XKS Bundle
 
 on:
-  # Run daily at 6:00 AM UTC
+  # Run daily at 6:00 AM UTC (safety-net fallback)
   schedule:
     - cron: '0 6 * * *'
+
+  # Triggered by rhods-operator when manifest-relevant changes merge
+  repository_dispatch:
+    types: [operator-manifest-update]
 
   workflow_dispatch:
     inputs:
@@ -44,11 +48,13 @@ jobs:
         env:
           VERSION_INPUT: ${{ github.event.inputs.version }}
           BRANCH_INPUT: ${{ github.event.inputs.branch }}
+          DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
         run: |
           echo "=== RHAI XKS Bundle Configuration ==="
 
           # Set defaults and override with inputs if provided
-          BRANCH="${BRANCH_INPUT:-main}"
+          # repository_dispatch payload takes precedence, then workflow_dispatch input, then default
+          BRANCH="${DISPATCH_BRANCH:-${BRANCH_INPUT:-main}}"
           if [[ -z "$VERSION_INPUT" ]]; then
             VERSION=$(make -s print-rhoai-version)
             echo "Using RHOAI_VERSION from Makefile: $VERSION"
@@ -122,7 +128,7 @@ jobs:
 
             **Source Branch**: ${{ env.BRANCH }}
             **Version**: ${{ env.VERSION }}
-            **Triggered by**: ${{ github.event_name == 'schedule' && 'Scheduled run' || 'Manual trigger' }}
+            **Triggered by**: ${{ github.event_name == 'repository_dispatch' && format('Operator change (commit {0})', github.event.client_payload.sha) || github.event_name == 'schedule' && 'Scheduled run' || 'Manual trigger' }}
 
             This PR updates the RHAI XKS chart templates and snapshots to stay current with the rhods-operator repository.
 


### PR DESCRIPTION

## Description

Add repository_dispatch trigger (operator-manifest-update) to the existing update-rhai-xks-bundle workflow so syncs happen immediately when operator manifests change, rather than waiting for the daily cron. Add CODEOWNERS to auto-request the operator team for review on chart template changes.

Ref: [RHOAIENG-63322](https://redhat.atlassian.net/browse/RHOAIENG-63322)


## Has it been tested?
Not testable - change in workflow

- [ ] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for automatic bundle updates when triggered by external repository events, alongside the daily schedule and manual runs.
  * Improved branch selection logic for bundle updates with a clear priority order for choosing the source branch.
  * Updated the PR description to clearly indicate whether the update was scheduled, manually triggered, or event-triggered (including dispatched commit details).

* **Chores**
  * Expanded code ownership coverage so chart template changes route review to the appropriate maintainers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-63322]: https://redhat.atlassian.net/browse/RHOAIENG-63322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ