### PR TITLE
feat(RHOAIENG-65198): uninstall CRs on helm uninstall with centralized provider definitions

### DIFF
--- a/.github/workflows/rhai-on-xks-chart-test.yaml
+++ b/.github/workflows/rhai-on-xks-chart-test.yaml
@@ -48,7 +48,7 @@ jobs:
           printf '%s' "${RHAI_PULL_SECRET}" > "${PULL_SECRET_FILE}"
           make helm-install-verify-xks \
             XKS_CLOUD_PROVIDER=${{ matrix.cloud_provider }} \
-            HELM_EXTRA_ARGS="--set-file imagePullSecret.dockerConfigJson=${PULL_SECRET_FILE}"
+            XKS_PULL_SECRET="${PULL_SECRET_FILE}"
 
       - name: Dump custom resources on failure
         if: failure()

--- a/.rules/helm-xks-chart.md
+++ b/.rules/helm-xks-chart.md
@@ -43,7 +43,8 @@ Component CRs (e.g. Kserve from `components.platform.opendatahub.io`) are create
 
 - `providerRegistry` / `componentCRRegistry`: static YAML maps — CR kind, resource name (plural + singular), default CR name, API group.
 - `activeProvider`: returns YAML dict for the one enabled provider. Parse with `| fromYaml`. Fields: `name`, `keKind`, `keResource`, `keResourceSingular`, `keName`, `keEnabled` (bool), `keSpec`, `cloudManagerNamespace`. Returns empty map if no provider enabled.
-- `enabledProviderKECR` / `enabledComponentCRs`: JSON lists used for guard conditions only (`if or $componentCRs $providerKECR`). Do not inspect contents.
+- `enabledProviderKECR`: returns `"true"` (truthy) or empty string when provider + KE are both enabled. Used as a boolean guard only — do not parse or inspect contents.
+- `enabledComponentCRs`: returns a JSON list of enabled component names. Parse with `fromJson` before use in guards (`if or $componentCRs $providerKECR`). Do not range over or access fields — use `crApplyCommands` / `crDeleteCommands` instead.
 - `crApplyCommands` / `crDeleteCommands`: emit kubectl apply/delete bash commands for all enabled CRs. Include with `| trimPrefix "\n" | nindent 14`.
 
 ### Image updates

--- a/.rules/helm-xks-chart.md
+++ b/.rules/helm-xks-chart.md
@@ -11,6 +11,7 @@ Template prefix: `rhai-on-xks-chart.` for all helpers.
 - `templates/rbac/` — ServiceAccount, ClusterRole, ClusterRoleBinding.
 - `templates/crds/` — CRDs bundled in chart.
 - `templates/hooks/` — post-install Jobs (CRs creation, gateway setup).
+  - `_crs-definitions.tpl` — **single source of truth** for provider and component CR metadata; add new providers/CRs here only. All templates update automatically.
 - `templates/webhooks/` — MutatingWebhookConfiguration.
 - `templates/cloudmanager/{azure,coreweave}/` — cloud-specific resources (RBAC, CRDs, deployment).
 - `templates/pull-secret.yaml` — optional image pull secret.
@@ -18,15 +19,32 @@ Template prefix: `rhai-on-xks-chart.` for all helpers.
 
 ### Cloud provider pattern
 
-Exactly one of `azure.enabled` or `coreweave.enabled` must be true. Validated by `validateCloudProvider` helper.
-Cloud-specific templates gated with `{{- if .Values.<provider>.enabled }}`.
+Exactly one of `aws.enabled`, `azure.enabled`, or `coreweave.enabled` must be true. Validated by `validateCloudProvider` helper.
+Use `activeProvider | fromYaml` to access the active provider — avoid ranging over all providers or checking `.Values.<provider>.enabled` directly.
 
-### Key helpers (`_helpers.tpl`)
+**To add a new provider:** add one entry to `providerRegistry` in `templates/hooks/_crs-definitions.tpl`. No other templates need changing.
+
+### Component CR pattern
+
+Component CRs (e.g. Kserve from `components.platform.opendatahub.io`) are created/deleted via post-install and pre-delete hook jobs.
+
+**To add a new component CR:** add one entry to `componentCRRegistry` in `templates/hooks/_crs-definitions.tpl`. No other templates need changing.
+
+### Key helpers
+
+**`templates/_helpers.tpl`:**
 
 - `validateCloudProvider`: fails if zero or multiple providers enabled.
-- `imagePullSecretEnabled`: checks `imagePullSecret.dockerConfigJson`.
-- `imagePullSecretName`: defaults to `rhai-pull-secret`.
-- `imagePullSecrets`: renders pod spec block.
+- `keResourceName`: returns plural KE resource name for the active provider.
+- `kubernetesEngineDependencyNamespaces`: collects namespaces from enabled provider KE dependencies.
+- `imagePullSecretEnabled` / `imagePullSecretName` / `imagePullSecrets`: image pull secret helpers.
+
+**`templates/hooks/_crs-definitions.tpl`:**
+
+- `providerRegistry` / `componentCRRegistry`: static YAML maps — CR kind, resource name (plural + singular), default CR name, API group.
+- `activeProvider`: returns YAML dict for the one enabled provider. Parse with `| fromYaml`. Fields: `name`, `keKind`, `keResource`, `keResourceSingular`, `keName`, `keEnabled` (bool), `keSpec`, `cloudManagerNamespace`. Returns empty map if no provider enabled.
+- `enabledProviderKECR` / `enabledComponentCRs`: JSON lists used for guard conditions only (`if or $componentCRs $providerKECR`). Do not inspect contents.
+- `crApplyCommands` / `crDeleteCommands`: emit kubectl apply/delete bash commands for all enabled CRs. Include with `| trimPrefix "\n" | nindent 14`.
 
 ### Image updates
 

--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ XKS_PULL_SECRET ?=
 
 .PHONY: helm-verify-xks
 helm-verify-xks: ## Verify rhai-on-xks-chart installation and lifecycle. Use XKS_TEST=<num> for specific test
-	RELEASE_NAME=$(XKS_RELEASE_NAME) NAMESPACE=$(XKS_NAMESPACE) CLOUD_PROVIDER=$(XKS_CLOUD_PROVIDER) PULL_SECRET=$(XKS_PULL_SECRET) bash ./charts/rhai-on-xks-chart/scripts/verify.sh $(XKS_TEST)
+	RELEASE_NAME="$(XKS_RELEASE_NAME)" NAMESPACE="$(XKS_NAMESPACE)" CLOUD_PROVIDER="$(XKS_CLOUD_PROVIDER)" PULL_SECRET="$(XKS_PULL_SECRET)" bash ./charts/rhai-on-xks-chart/scripts/verify.sh $(XKS_TEST)
 
 .PHONY: helm-install-verify-xks
 helm-install-verify-xks: ## Install and verify rhai-on-xks-chart

--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ XKS_PULL_SECRET ?=
 
 .PHONY: helm-verify-xks
 helm-verify-xks: ## Verify rhai-on-xks-chart installation and lifecycle. Use XKS_TEST=<num> for specific test
-	RELEASE_NAME="$(XKS_RELEASE_NAME)" NAMESPACE="$(XKS_NAMESPACE)" CLOUD_PROVIDER="$(XKS_CLOUD_PROVIDER)" PULL_SECRET="$(XKS_PULL_SECRET)" bash ./charts/rhai-on-xks-chart/scripts/verify.sh $(XKS_TEST)
+	RELEASE_NAME="$(XKS_RELEASE_NAME)" NAMESPACE="$(XKS_NAMESPACE)" CLOUD_PROVIDER="$(XKS_CLOUD_PROVIDER)" PULL_SECRET="$(XKS_PULL_SECRET)" HELM_EXTRA_ARGS="$(HELM_EXTRA_ARGS)" bash ./charts/rhai-on-xks-chart/scripts/verify.sh $(XKS_TEST)
 
 .PHONY: helm-install-verify-xks
 helm-install-verify-xks: ## Install and verify rhai-on-xks-chart

--- a/Makefile
+++ b/Makefile
@@ -296,19 +296,16 @@ XKS_CHART_PATH ?= $(CHARTS_DIR)/rhai-on-xks-chart
 XKS_RELEASE_NAME ?= rhai-on-xks
 XKS_NAMESPACE ?= rhai-on-xks
 XKS_CLOUD_PROVIDER ?= azure
+XKS_PULL_SECRET ?=
 
 .PHONY: helm-verify-xks
-helm-verify-xks: ## Verify rhai-on-xks-chart installation
-	RELEASE_NAME=$(XKS_RELEASE_NAME) NAMESPACE=$(XKS_NAMESPACE) CLOUD_PROVIDER=$(XKS_CLOUD_PROVIDER) ./charts/rhai-on-xks-chart/scripts/verify.sh
+helm-verify-xks: ## Verify rhai-on-xks-chart installation and lifecycle. Use XKS_TEST=<num> for specific test
+	RELEASE_NAME=$(XKS_RELEASE_NAME) NAMESPACE=$(XKS_NAMESPACE) CLOUD_PROVIDER=$(XKS_CLOUD_PROVIDER) PULL_SECRET=$(XKS_PULL_SECRET) bash ./charts/rhai-on-xks-chart/scripts/verify.sh $(XKS_TEST)
 
 .PHONY: helm-install-verify-xks
 helm-install-verify-xks: ## Install and verify rhai-on-xks-chart
-	@echo "=== Step 1: Install rhai-on-xks-chart ==="
 	# TODO(RHOAIENG-63729): remove -f values-e2e.yaml once a runner with sufficient resources is available
-	helm upgrade --install $(XKS_RELEASE_NAME) ./$(XKS_CHART_PATH) -n $(XKS_NAMESPACE) --create-namespace --set $(XKS_CLOUD_PROVIDER).enabled=true -f $(XKS_CHART_PATH)/test/values-e2e.yaml $(HELM_EXTRA_ARGS)
-	@echo ""
-	@echo "=== Step 2: Verify installation ==="
-	$(MAKE) helm-verify-xks
+	VALUES_FILE=$(XKS_CHART_PATH)/test/values-e2e.yaml $(MAKE) helm-verify-xks
 
 .PHONY: helm-uninstall
 helm-uninstall: ## Uninstall helm chart and all dependencies

--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -98,4 +98,5 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | rhaiOperator.resources.limits.memory | string | `"1Gi"` |  |
 | rhaiOperator.resources.requests.cpu | string | `"300m"` |  |
 | rhaiOperator.resources.requests.memory | string | `"256Mi"` |  |
+| uninstall.cleanupNamespaces | bool | `false` |  |
 

--- a/charts/rhai-on-xks-chart/scripts/verify.sh
+++ b/charts/rhai-on-xks-chart/scripts/verify.sh
@@ -17,7 +17,7 @@
 #   DELETE_TIMEOUT   - Helm uninstall timeout (default: 360s)
 #   CLEANUP_WAIT     - Seconds to wait for reconciliation (default: 90)
 
-set -uo pipefail
+set -euo pipefail
 
 # ─── Configuration ──────────────────────────────────────────────────────────
 
@@ -121,7 +121,7 @@ wait_for() {
   shift
   local elapsed=0
   local interval=$INTERVAL_INIT
-  while [ $elapsed -lt "$TIMEOUT" ]; do
+  while [ "$elapsed" -lt "$TIMEOUT" ]; do
     if "$@" >/dev/null 2>&1; then
       return 0
     fi
@@ -129,7 +129,7 @@ wait_for() {
     sleep "$interval"
     elapsed=$((elapsed + interval))
     interval=$((interval * 2))
-    if [ $interval -gt $INTERVAL_MAX ]; then
+    if [ "$interval" -gt "$INTERVAL_MAX" ]; then
       interval=$INTERVAL_MAX
     fi
   done
@@ -344,7 +344,7 @@ ensure_deployed() {
     | jq -r '.info.status' 2>/dev/null || echo "not-installed")
   if [[ "$status" != "deployed" && "$status" != "not-installed" ]]; then
     log "Release in broken state '$status' — cleaning up..."
-    helm uninstall "$RELEASE_NAME" -n "$NAMESPACE" --no-hooks 2>/dev/null || true
+    helm uninstall "$RELEASE_NAME" -n "$NAMESPACE" --timeout 120s 2>/dev/null || true
     kubectl patch "$KE_KIND/$KE_NAME" --type=merge \
       -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
     kubectl wait --for=delete "$KE_KIND/$KE_NAME" --timeout=60s 2>/dev/null || true
@@ -376,8 +376,10 @@ run_test() {
   header "Test $test_num: $test_name"
   ASSERT_FAILED=0
 
-  if $test_fn; then
-    :
+  local test_exit=0
+  $test_fn || test_exit=$?
+  if [[ "$test_exit" -ne 0 ]]; then
+    ASSERT_FAILED=1
   fi
 
   if [[ "$ASSERT_FAILED" -eq 0 ]]; then

--- a/charts/rhai-on-xks-chart/scripts/verify.sh
+++ b/charts/rhai-on-xks-chart/scripts/verify.sh
@@ -14,6 +14,7 @@
 #   CHART            - Path to chart directory (default: ./charts/rhai-on-xks-chart)
 #   VALUES_FILE      - Extra values file for helm deploy (default: empty)
 #   PULL_SECRET      - Path to dockerconfigjson for image pull secret (default: empty)
+#   HELM_EXTRA_ARGS  - Extra args passed to every helm deploy (default: empty, TODO: remove)
 #   DELETE_TIMEOUT   - Helm uninstall timeout (default: 360s)
 #   CLEANUP_WAIT     - Seconds to wait for reconciliation (default: 90)
 
@@ -28,6 +29,8 @@ TIMEOUT="${TIMEOUT:-300}"
 CHART="${CHART:-./charts/rhai-on-xks-chart}"
 VALUES_FILE="${VALUES_FILE:-}"
 PULL_SECRET="${PULL_SECRET:-}"
+# TODO: remove HELM_EXTRA_ARGS once workflows pass PULL_SECRET directly
+HELM_EXTRA_ARGS="${HELM_EXTRA_ARGS:-}"
 DELETE_TIMEOUT="${DELETE_TIMEOUT:-360s}"
 CLEANUP_WAIT="${CLEANUP_WAIT:-90}"
 
@@ -322,12 +325,17 @@ helm_deploy() {
   if [[ -n "$PULL_SECRET" ]]; then
     secret_args+=(--set-file "imagePullSecret.dockerConfigJson=${PULL_SECRET}")
   fi
+  local helm_extra=()
+  if [[ -n "$HELM_EXTRA_ARGS" ]]; then
+    read -ra helm_extra <<< "$HELM_EXTRA_ARGS"
+  fi
   log "helm upgrade --install $RELEASE_NAME"
   helm upgrade --install "$RELEASE_NAME" "$CHART" \
     -n "$NAMESPACE" --create-namespace \
     --set "${CLOUD_PROVIDER}.enabled=true" \
     ${values_args[@]+"${values_args[@]}"} \
     ${secret_args[@]+"${secret_args[@]}"} \
+    ${helm_extra[@]+"${helm_extra[@]}"} \
     ${extra_args[@]+"${extra_args[@]}"} \
     --timeout 10m
 }

--- a/charts/rhai-on-xks-chart/scripts/verify.sh
+++ b/charts/rhai-on-xks-chart/scripts/verify.sh
@@ -636,7 +636,7 @@ for i in "${!TEST_NAMES[@]}"; do
     color="$RED"
     all_passed=false
   fi
-  printf "  %-55s %s%s%s\n" "${TEST_NAMES[$i]}" "$color" "$result" "$NC"
+  printf "  %-55s %b%s%b\n" "${TEST_NAMES[$i]}" "$color" "$result" "$NC"
 done
 
 echo ""

--- a/charts/rhai-on-xks-chart/scripts/verify.sh
+++ b/charts/rhai-on-xks-chart/scripts/verify.sh
@@ -1,23 +1,42 @@
 #!/bin/bash
-# Verify rhai-on-xks-chart installation in a Kubernetes cluster.
+# Verify rhai-on-xks-chart installation and lifecycle in a Kubernetes cluster.
+#
+# Usage:
+#   ./verify.sh              # run all tests (1-4)
+#   ./verify.sh 1            # run only test 1 (install check)
+#   ./verify.sh 2 4          # run tests 2 and 4
 #
 # Environment variables:
 #   RELEASE_NAME     - Helm release name (default: rhai-on-xks)
 #   NAMESPACE        - Helm release namespace (default: rhai-on-xks)
 #   CLOUD_PROVIDER   - Cloud provider: azure, coreweave, or aws (default: azure)
 #   TIMEOUT          - Max wait time in seconds per check (default: 300)
+#   CHART            - Path to chart directory (default: ./charts/rhai-on-xks-chart)
+#   VALUES_FILE      - Extra values file for helm deploy (default: empty)
+#   PULL_SECRET      - Path to dockerconfigjson for image pull secret (default: empty)
+#   DELETE_TIMEOUT   - Helm uninstall timeout (default: 360s)
+#   CLEANUP_WAIT     - Seconds to wait for reconciliation (default: 90)
 
-set -euo pipefail
+set -uo pipefail
+
+# ─── Configuration ──────────────────────────────────────────────────────────
 
 RELEASE_NAME="${RELEASE_NAME:-rhai-on-xks}"
 NAMESPACE="${NAMESPACE:-rhai-on-xks}"
 CLOUD_PROVIDER="${CLOUD_PROVIDER:-azure}"
 TIMEOUT="${TIMEOUT:-300}"
+CHART="${CHART:-./charts/rhai-on-xks-chart}"
+VALUES_FILE="${VALUES_FILE:-}"
+PULL_SECRET="${PULL_SECRET:-}"
+DELETE_TIMEOUT="${DELETE_TIMEOUT:-360s}"
+CLEANUP_WAIT="${CLEANUP_WAIT:-90}"
+
 if ! [[ "$TIMEOUT" =~ ^[0-9]+$ ]]; then
   echo "ERROR: TIMEOUT must be a positive integer" >&2
   exit 1
 fi
-INTERVAL=10
+INTERVAL_INIT=2
+INTERVAL_MAX=10
 
 declare -A PROVIDER_CRDS=(
   [azure]="azurekubernetesengines.infrastructure.opendatahub.io"
@@ -31,16 +50,49 @@ declare -A PROVIDER_CR_DISPLAY=(
   [aws]="AWSKubernetesEngine"
 )
 
+declare -A PROVIDER_KE_KIND=(
+  [azure]="azurekubernetesengine"
+  [coreweave]="coreweavekubernetesengine"
+  [aws]="awskubernetesengine"
+)
+
 if [[ -z "${PROVIDER_CRDS[$CLOUD_PROVIDER]+_}" ]]; then
   echo "ERROR: unsupported CLOUD_PROVIDER '${CLOUD_PROVIDER}'. Valid values: ${!PROVIDER_CRDS[*]}" >&2
   exit 1
 fi
 
-ERRORS=0
-ERROR_MESSAGES=()
+KE_KIND="${PROVIDER_KE_KIND[$CLOUD_PROVIDER]}"
+KE_NAME="default-${CLOUD_PROVIDER}kubernetesengine"
+KE_CRD="${PROVIDER_CRDS[$CLOUD_PROVIDER]}"
+CM_NS="rhai-cloudmanager-system"
+PROV_PREFIX="${CLOUD_PROVIDER}.kubernetesEngine.spec.dependencies"
 
-log_ok()   { echo "  OK: $1"; }
-log_fail() { echo "  FAIL: $1"; ERRORS=$((ERRORS + 1)); ERROR_MESSAGES+=("$1"); }
+# ─── Colors ─────────────────────────────────────────────────────────────────
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ─── Result tracking ───────────────────────────────────────────────────────
+
+declare -a TEST_NAMES=()
+declare -a TEST_RESULTS=()
+
+record_result() {
+  TEST_NAMES+=("$1")
+  TEST_RESULTS+=("$2")
+}
+
+# ─── Helpers ────────────────────────────────────────────────────────────────
+
+log()    { echo -e "${CYAN}[$(date +%H:%M:%S)]${NC} $*"; }
+pass()   { echo -e "${GREEN}  ✓ $*${NC}"; }
+fail()   { echo -e "${RED}  ✗ $*${NC}"; ASSERT_FAILED=1; }
+warn()   { echo -e "${YELLOW}  ⚠ $*${NC}"; }
+header() { echo -e "\n${BOLD}═══════════════════════════════════════════════════${NC}"; echo -e "${BOLD}  $*${NC}"; echo -e "${BOLD}═══════════════════════════════════════════════════${NC}"; }
 
 debug_namespace() {
   local ns="$1"
@@ -50,8 +102,8 @@ debug_namespace() {
     filter_args=(-l "${filter}")
   fi
   echo "  DEBUG: pods in '${ns}'${filter:+ (filter: ${filter})}:"
-  kubectl get pods -n "${ns}" "${filter_args[@]}" -o wide 2>/dev/null || true
-  for pod in $(kubectl get pods -n "${ns}" "${filter_args[@]}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+  kubectl get pods -n "${ns}" ${filter_args[@]+"${filter_args[@]}"} -o wide 2>/dev/null || true
+  for pod in $(kubectl get pods -n "${ns}" ${filter_args[@]+"${filter_args[@]}"} -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
     local phase
     phase=$(kubectl get pod "${pod}" -n "${ns}" -o jsonpath='{.status.phase}' 2>/dev/null)
     echo "  --- pod: ${pod} (${phase}) ---"
@@ -68,13 +120,18 @@ wait_for() {
   local description="$1"
   shift
   local elapsed=0
+  local interval=$INTERVAL_INIT
   while [ $elapsed -lt "$TIMEOUT" ]; do
     if "$@" >/dev/null 2>&1; then
       return 0
     fi
     echo "  Waiting for ${description}... (${elapsed}s/${TIMEOUT}s)"
-    sleep "$INTERVAL"
-    elapsed=$((elapsed + INTERVAL))
+    sleep "$interval"
+    elapsed=$((elapsed + interval))
+    interval=$((interval * 2))
+    if [ $interval -gt $INTERVAL_MAX ]; then
+      interval=$INTERVAL_MAX
+    fi
   done
   return 1
 }
@@ -85,12 +142,12 @@ wait_for_deployment() {
   local expected_replicas="${3:-}"
 
   if ! wait_for "deployment ${name} in ${ns}" kubectl get deployment "${name}" -n "${ns}"; then
-    log_fail "Deployment '${name}' not found in '${ns}'"
+    fail "Deployment '${name}' not found in '${ns}'"
     return 1
   fi
 
   if ! wait_for "deployment ${name} rollout" kubectl rollout status deployment "${name}" -n "${ns}" --timeout=0s; then
-    log_fail "Deployment '${name}' in '${ns}' did not become ready within ${TIMEOUT}s"
+    fail "Deployment '${name}' in '${ns}' did not become ready within ${TIMEOUT}s"
     kubectl get deployment "${name}" -n "${ns}" -o wide 2>/dev/null || true
     kubectl get pods -n "${ns}" 2>/dev/null || true
     return 1
@@ -99,12 +156,12 @@ wait_for_deployment() {
   if [ -n "${expected_replicas}" ]; then
     actual=$(kubectl get deployment "${name}" -n "${ns}" -o jsonpath='{.status.availableReplicas}' 2>/dev/null || echo "0")
     if [ "${actual:-0}" -ne "${expected_replicas}" ]; then
-      log_fail "Deployment '${name}' in '${ns}': expected ${expected_replicas} replicas, got ${actual:-0}"
+      fail "Deployment '${name}' in '${ns}': expected ${expected_replicas} replicas, got ${actual:-0}"
       return 1
     fi
   fi
 
-  log_ok "Deployment '${name}' in '${ns}' is ready"
+  pass "Deployment '${name}' in '${ns}' is ready"
   return 0
 }
 
@@ -112,13 +169,13 @@ wait_for_all_deployments_in_namespace() {
   local ns="$1"
   local deployments
   if ! wait_for "deployments in ${ns}" kubectl get deployments -n "${ns}" -o name; then
-    log_fail "No deployments found in namespace '${ns}'"
+    fail "No deployments found in namespace '${ns}'"
     return 1
   fi
 
   deployments=$(kubectl get deployments -n "${ns}" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null)
   if [ -z "${deployments}" ]; then
-    log_fail "No deployments found in namespace '${ns}'"
+    fail "No deployments found in namespace '${ns}'"
     return 1
   fi
 
@@ -134,7 +191,7 @@ wait_for_cr_ready() {
   local description="${3:-${api_resource}/${name}}"
 
   if ! wait_for "${description} to exist" kubectl get "${api_resource}" "${name}"; then
-    log_fail "${description} not found"
+    fail "${description} not found"
     return 1
   fi
 
@@ -145,116 +202,438 @@ wait_for_cr_ready() {
   }
 
   if ! wait_for "${description} to be Ready" check_cr_conditions; then
-    log_fail "${description} did not become Ready within ${TIMEOUT}s"
+    fail "${description} did not become Ready within ${TIMEOUT}s"
     kubectl get "${api_resource}" "${name}" -o yaml 2>/dev/null || true
     return 1
   fi
 
-  log_ok "${description} is Ready"
+  pass "${description} is Ready"
   return 0
 }
 
-echo "=== Verifying rhai-on-xks-chart Installation ==="
-echo "Release: ${RELEASE_NAME} | Namespace: ${NAMESPACE} | Cloud: ${CLOUD_PROVIDER}"
+assert_cr_not_degraded() {
+  local api_resource="$1"
+  local name="$2"
+  local description="${3:-${api_resource}/${name}}"
+
+  if ! wait_for "${description} to exist" kubectl get "${api_resource}" "${name}"; then
+    fail "${description} not found"
+    return 1
+  fi
+
+  local errors
+  errors=$(kubectl get "${api_resource}" "${name}" \
+    -o jsonpath='{range .status.conditions[?(@.type=="Degraded")]}{.status}{end}' 2>/dev/null)
+  if [[ "$errors" == "True" ]]; then
+    local msg
+    msg=$(kubectl get "${api_resource}" "${name}" \
+      -o jsonpath='{range .status.conditions[?(@.type=="Degraded")]}{.reason}: {.message}{end}' 2>/dev/null)
+    fail "${description} is Degraded: ${msg}"
+    return 1
+  fi
+
+  pass "${description} exists (not degraded)"
+  return 0
+}
+
+# ─── Assertion helpers ──────────────────────────────────────────────────────
+
+assert_exists() {
+  local label="$1"
+  shift
+  if wait_for "${label} to exist" kubectl get "$@"; then
+    pass "$label exists"
+  else
+    fail "$label should exist but not found"
+  fi
+}
+
+assert_not_exists() {
+  local label="$1"
+  shift
+  local kubectl_args=("$@")
+  check_gone() { ! kubectl get "${kubectl_args[@]}" &>/dev/null; }
+  if wait_for "${label} to be gone" check_gone; then
+    pass "$label gone"
+  else
+    fail "$label should be gone but still exists"
+  fi
+}
+
+assert_has_finalizer() {
+  local resource="$1"
+  local finalizer="$2"
+  check_finalizer() {
+    kubectl get "$resource" -o jsonpath='{.metadata.finalizers}' 2>/dev/null | grep -q "$finalizer"
+  }
+  if wait_for "$resource to have finalizer $finalizer" check_finalizer; then
+    pass "$resource has finalizer $finalizer"
+  else
+    local actual
+    actual=$(kubectl get "$resource" -o jsonpath='{.metadata.finalizers}' 2>/dev/null)
+    fail "$resource missing finalizer $finalizer (got: $actual)"
+  fi
+}
+
+assert_deployment_gone() {
+  local ns="$1"
+  shift
+  local selector_args=("$@")
+  local label_desc=""
+  if [[ ${#selector_args[@]} -gt 0 ]]; then label_desc=" (${selector_args[*]})"; fi
+  check_gone() {
+    local count
+    count=$(kubectl get deployment -n "$ns" ${selector_args[@]+"${selector_args[@]}"} --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    [[ "$count" == "0" ]]
+  }
+  if wait_for "deployments gone in $ns${label_desc}" check_gone; then
+    pass "no deployments in $ns${label_desc}"
+  else
+    fail "deployments still exist in $ns${label_desc}"
+    kubectl get deployment -n "$ns" ${selector_args[@]+"${selector_args[@]}"} --no-headers 2>/dev/null | sed 's/^/    /'
+  fi
+}
+
+assert_no_stuck_istiorevision() {
+  local revisions
+  revisions=$(kubectl get istiorevision --no-headers 2>/dev/null | wc -l | tr -d ' ')
+  if [[ "$revisions" == "0" ]]; then
+    pass "no IstioRevision resources (clean)"
+  else
+    local stuck
+    stuck=$(kubectl get istiorevision -o jsonpath='{range .items[*]}{.metadata.name}: {.metadata.finalizers}{"\n"}{end}' 2>/dev/null)
+    if echo "$stuck" | grep -q "sailoperator.io"; then
+      fail "IstioRevision stuck with finalizer:\n    $stuck"
+    else
+      pass "IstioRevision exists but no stuck finalizers"
+    fi
+  fi
+}
+
+# ─── Helm helpers ───────────────────────────────────────────────────────────
+
+helm_deploy() {
+  local extra_args=("$@")
+  local values_args=()
+  if [[ -n "$VALUES_FILE" ]]; then
+    values_args+=(-f "$VALUES_FILE")
+  fi
+  local secret_args=()
+  if [[ -n "$PULL_SECRET" ]]; then
+    secret_args+=(--set-file "imagePullSecret.dockerConfigJson=${PULL_SECRET}")
+  fi
+  log "helm upgrade --install $RELEASE_NAME"
+  helm upgrade --install "$RELEASE_NAME" "$CHART" \
+    -n "$NAMESPACE" --create-namespace \
+    --set "${CLOUD_PROVIDER}.enabled=true" \
+    ${values_args[@]+"${values_args[@]}"} \
+    ${secret_args[@]+"${secret_args[@]}"} \
+    ${extra_args[@]+"${extra_args[@]}"} \
+    --timeout 10m
+}
+
+wait_ke_ready() {
+  log "Waiting for $KE_KIND/$KE_NAME to be Ready (timeout: ${TIMEOUT}s)..."
+  wait_for_cr_ready "$KE_CRD" "$KE_NAME" "${PROVIDER_CR_DISPLAY[$CLOUD_PROVIDER]} '$KE_NAME'"
+}
+
+ensure_deployed() {
+  local extra_args=("$@")
+  local status
+  status=$(helm status "$RELEASE_NAME" -n "$NAMESPACE" -o json 2>/dev/null \
+    | jq -r '.info.status' 2>/dev/null || echo "not-installed")
+  if [[ "$status" != "deployed" && "$status" != "not-installed" ]]; then
+    log "Release in broken state '$status' — cleaning up..."
+    helm uninstall "$RELEASE_NAME" -n "$NAMESPACE" --no-hooks 2>/dev/null || true
+    kubectl patch "$KE_KIND/$KE_NAME" --type=merge \
+      -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+    kubectl wait --for=delete "$KE_KIND/$KE_NAME" --timeout=60s 2>/dev/null || true
+  fi
+  if [[ "$status" == "deployed" && ${#extra_args[@]} -eq 0 ]]; then
+    log "Release already deployed, verifying KE ready..."
+    wait_ke_ready
+    return 0
+  fi
+  helm_deploy ${extra_args[@]+"${extra_args[@]}"}
+  wait_ke_ready
+}
+
+wait_reconciliation() {
+  local seconds="${1:-$CLEANUP_WAIT}"
+  log "Waiting ${seconds}s for reconciliation..."
+  sleep "$seconds"
+}
+
+# ─── Test runner ────────────────────────────────────────────────────────────
+
+ASSERT_FAILED=0
+
+run_test() {
+  local test_num="$1"
+  local test_name="$2"
+  local test_fn="$3"
+
+  header "Test $test_num: $test_name"
+  ASSERT_FAILED=0
+
+  if $test_fn; then
+    :
+  fi
+
+  if [[ "$ASSERT_FAILED" -eq 0 ]]; then
+    log "Result: ${GREEN}PASS${NC}"
+    record_result "$test_num: $test_name" "PASS"
+  else
+    log "Result: ${RED}FAIL${NC}"
+    record_result "$test_num: $test_name" "FAIL"
+  fi
+}
+
+# ─── Test 1: Install check ─────────────────────────────────────────────────
+
+test_1_install_check() {
+  ensure_deployed
+
+  log "Verifying install..."
+
+  # Helm release
+  if helm list -n "${NAMESPACE}" 2>/dev/null | grep -qF "${RELEASE_NAME}"; then
+    pass "Helm release '${RELEASE_NAME}' found"
+  else
+    fail "Helm release '${RELEASE_NAME}' not found in namespace '${NAMESPACE}'"
+  fi
+
+  # Namespaces
+  for ns in "redhat-ods-operator" "redhat-ods-applications" "${NAMESPACE}" "${CM_NS}"; do
+    assert_exists "Namespace '${ns}'" "namespace/${ns}"
+  done
+
+  # CRDs
+  assert_exists "CRD kserves" crd/kserves.components.platform.opendatahub.io
+  assert_exists "CRD ${KE_CRD}" "crd/${KE_CRD}"
+
+  # Cloud manager deployment
+  wait_for_deployment "${CLOUD_PROVIDER}-cloud-manager-operator" "${CM_NS}" 1
+
+  # KE CR
+  assert_has_finalizer "$KE_KIND/$KE_NAME" "platform.opendatahub.io/finalizer"
+
+  # cert-manager
+  wait_for_all_deployments_in_namespace "cert-manager"
+
+  # RHAI operator
+  wait_for_deployment "rhai-operator" "redhat-ods-operator"
+
+  # KServe component CR
+  if ! assert_cr_not_degraded "kserves.components.platform.opendatahub.io" "default-kserve" "Kserve 'default-kserve'"; then
+    debug_namespace "redhat-ods-operator"
+    debug_namespace "redhat-ods-applications" "app.kubernetes.io/part-of=kserve"
+  fi
+
+  # Inference Gateway Istio
+  wait_for_deployment "inference-gateway-istio" "redhat-ods-applications"
+}
+
+# ─── Test 2: sail + lws Managed→Unmanaged→Managed ──────────────────────────
+
+test_2_sail_lws_managed_unmanaged() {
+  ensure_deployed \
+    --set "${PROV_PREFIX}.lws.managementPolicy=Managed"
+
+  log "Step 1: sailOperator + lws → Unmanaged"
+  helm_deploy \
+    --set "${PROV_PREFIX}.sailOperator.managementPolicy=Unmanaged" \
+    --set "${PROV_PREFIX}.lws.managementPolicy=Unmanaged"
+
+  log "Waiting for Istio CR deletion..."
+  kubectl wait --for=delete istio/default --timeout="${TIMEOUT}s" 2>/dev/null \
+    || { fail "Istio CR not deleted within timeout"; return; }
+
+  log "Waiting for IstioRevision deletion..."
+  kubectl wait --for=delete istiorevision --all --timeout="${TIMEOUT}s" 2>/dev/null \
+    || { fail "IstioRevision not deleted within timeout"; return; }
+
+  log "Waiting for istiod deletion..."
+  kubectl wait --for=delete deployment/istiod -n istio-system --timeout="${TIMEOUT}s" 2>/dev/null \
+    || { fail "istiod not deleted within timeout"; return; }
+
+  log "Waiting for LWS cleanup..."
+  kubectl wait --for=delete leaderworkersetoperator/cluster --timeout="${TIMEOUT}s" 2>/dev/null \
+    || { fail "LeaderWorkerSetOperator CR not deleted within timeout"; return; }
+  assert_deployment_gone "openshift-lws-operator"
+
+  assert_exists "istio-system namespace (persists)" namespace/istio-system
+  assert_exists "openshift-lws-operator namespace (persists)" namespace/openshift-lws-operator
+  assert_no_stuck_istiorevision
+
+  log "Step 2: sailOperator + lws → Managed (revert)"
+  helm_deploy \
+    --set "${PROV_PREFIX}.lws.managementPolicy=Managed"
+  wait_ke_ready
+
+  assert_cr_not_degraded "istio" "default" "Istio CR restored"
+  wait_for_deployment "istiod" "istio-system"
+  assert_cr_not_degraded "leaderworkersetoperator" "cluster" "LeaderWorkerSetOperator CR restored"
+}
+
+# ─── Test 3: certManager Managed→Unmanaged→Managed ─────────────────────────
+
+test_3_certmanager_managed_unmanaged() {
+  ensure_deployed
+
+  log "Step 1: certManager → Unmanaged"
+  helm_deploy \
+    --set "${PROV_PREFIX}.certManager.managementPolicy=Unmanaged"
+
+  log "Verifying certManager cleanup..."
+
+  # NOTE: CertManager CR can still exists (CM-1019: cert-manager-operator may recreate it)
+
+  assert_deployment_gone "cert-manager-operator"
+  assert_exists "cert-manager-operator namespace (persists)" namespace/cert-manager-operator
+
+  # Other deps unaffected
+  assert_cr_not_degraded "istio" "default" "Istio CR (unaffected)"
+  wait_for_deployment "istiod" "istio-system"
+
+  log "Step 2: certManager → Managed (revert)"
+  helm_deploy
+  wait_ke_ready
+
+  assert_cr_not_degraded "certmanager" "cluster" "CertManager CR restored"
+}
+
+# ─── Test 4: Uninstall lifecycle ────────────────────────────────────────────
+
+test_4_uninstall_lifecycle() {
+  ensure_deployed
+
+  # Phase A: uninstall without namespace cleanup (default)
+  log "Phase A: helm uninstall (cleanupNamespaces=false)"
+  helm uninstall "$RELEASE_NAME" -n "$NAMESPACE" --timeout "$DELETE_TIMEOUT"
+
+  wait_reconciliation 15
+
+  log "Verifying clean uninstall..."
+
+  if helm status "$RELEASE_NAME" -n "$NAMESPACE" &>/dev/null; then
+    fail "Helm release $RELEASE_NAME still exists"
+  else
+    pass "Helm release $RELEASE_NAME removed"
+  fi
+
+  assert_not_exists "KubernetesEngine CR" "$KE_KIND/$KE_NAME"
+  assert_not_exists "Kserve CR" kserves.components.platform.opendatahub.io/default-kserve
+  assert_not_exists "Istio CR" istio/default
+  assert_not_exists "istiod deployment" deployment/istiod -n istio-system
+  assert_no_stuck_istiorevision
+
+  # Dependency namespaces persist (cleanupNamespaces=false)
+  assert_exists "istio-system namespace (persists)" namespace/istio-system
+
+  # Wait for helm-managed namespaces to finish terminating before re-install
+  log "Waiting for terminating namespaces to be fully gone..."
+  for ns in redhat-ods-operator redhat-ods-applications "${CM_NS}"; do
+    if kubectl get namespace "$ns" &>/dev/null; then
+      log "  waiting for namespace/$ns to terminate..."
+      kubectl wait --for=delete "namespace/$ns" --timeout=120s 2>/dev/null \
+        || warn "namespace/$ns still terminating after 120s"
+    fi
+  done
+
+  # Phase B: reinstall with cleanupNamespaces=true, then uninstall
+  log "Phase B: reinstall with cleanupNamespaces=true"
+  helm_deploy --set "uninstall.cleanupNamespaces=true"
+  wait_ke_ready
+
+  log "Phase B: helm uninstall (cleanupNamespaces=true)"
+  helm uninstall "$RELEASE_NAME" -n "$NAMESPACE" --wait --timeout "$DELETE_TIMEOUT"
+
+  log "Verifying full cleanup including namespaces..."
+  assert_not_exists "KubernetesEngine CR" "$KE_KIND/$KE_NAME"
+  assert_not_exists "${CM_NS} namespace" "namespace/${CM_NS}"
+  assert_not_exists "istio-system namespace" namespace/istio-system
+  assert_not_exists "cert-manager-operator namespace" namespace/cert-manager-operator
+}
+
+# ─── Main ───────────────────────────────────────────────────────────────────
+
+ALL_TESTS=(
+  "1:Install check:test_1_install_check"
+  "2:sail+lws Managed→Unmanaged→Managed:test_2_sail_lws_managed_unmanaged"
+  "3:certManager Managed→Unmanaged→Managed:test_3_certmanager_managed_unmanaged"
+  "4:Uninstall lifecycle (cleanup + cleanupNamespaces):test_4_uninstall_lifecycle"
+)
+
+# Validate prerequisites
+if ! command -v helm &>/dev/null; then echo "ERROR: helm not found" >&2; exit 1; fi
+if ! command -v kubectl &>/dev/null; then echo "ERROR: kubectl not found" >&2; exit 1; fi
+if ! command -v jq &>/dev/null; then echo "ERROR: jq not found" >&2; exit 1; fi
+if [[ -n "$CHART" && ! -d "$CHART" ]]; then echo "ERROR: Chart not found at: $CHART" >&2; exit 1; fi
+if [[ -n "$VALUES_FILE" && ! -f "$VALUES_FILE" ]]; then echo "ERROR: Values file not found at: $VALUES_FILE" >&2; exit 1; fi
+if [[ -n "$PULL_SECRET" && ! -f "$PULL_SECRET" ]]; then echo "ERROR: Pull secret not found at: $PULL_SECRET" >&2; exit 1; fi
+
+# Determine which tests to run
+TESTS_TO_RUN=()
+if [[ $# -gt 0 ]]; then
+  for arg in "$@"; do
+    matched=false
+    for entry in "${ALL_TESTS[@]}"; do
+      IFS=: read -r num name fn <<< "$entry"
+      if [[ "$num" == "$arg" ]]; then
+        TESTS_TO_RUN+=("$entry")
+        matched=true
+      fi
+    done
+    if [[ "$matched" == "false" ]]; then
+      echo "WARNING: unknown test number '$arg' (available: 1-${#ALL_TESTS[@]})" >&2
+    fi
+  done
+else
+  TESTS_TO_RUN=("${ALL_TESTS[@]}")
+fi
+
+if [[ ${#TESTS_TO_RUN[@]} -eq 0 ]]; then
+  echo "No matching tests found for: $*"
+  echo "Available tests: 1-${#ALL_TESTS[@]}"
+  exit 1
+fi
+
+header "rhai-on-xks-chart Verification"
+echo "  Release:   $RELEASE_NAME"
+echo "  Namespace: $NAMESPACE"
+echo "  Provider:  $CLOUD_PROVIDER"
+echo "  Chart:     $CHART"
+echo "  Tests:     ${#TESTS_TO_RUN[@]}"
 echo ""
 
-# --- Helm release ---
-echo "--- Helm Release ---"
-if helm list -n "${NAMESPACE}" 2>/dev/null | grep -qF "${RELEASE_NAME}"; then
-  log_ok "Helm release '${RELEASE_NAME}' found"
-else
-  log_fail "Helm release '${RELEASE_NAME}' not found in namespace '${NAMESPACE}'"
-fi
-
-# --- Namespaces ---
-echo "--- Namespaces ---"
-EXPECTED_NAMESPACES=("redhat-ods-operator" "redhat-ods-applications" "${NAMESPACE}" "rhai-cloudmanager-system")
-
-for ns in "${EXPECTED_NAMESPACES[@]}"; do
-  if kubectl get namespace "${ns}" >/dev/null 2>&1; then
-    log_ok "Namespace '${ns}' exists"
-  else
-    log_fail "Namespace '${ns}' not found"
-  fi
+for entry in "${TESTS_TO_RUN[@]}"; do
+  IFS=: read -r num name fn <<< "$entry"
+  run_test "$num" "$name" "$fn"
 done
 
-# --- CRDs ---
-echo "--- CRDs ---"
-if kubectl get crd kserves.components.platform.opendatahub.io >/dev/null 2>&1; then
-  log_ok "CRD 'kserves.components.platform.opendatahub.io' exists"
-else
-  log_fail "CRD 'kserves.components.platform.opendatahub.io' not found"
-fi
+# ─── Summary ────────────────────────────────────────────────────────────────
 
-for provider in "${!PROVIDER_CRDS[@]}"; do
-  crd="${PROVIDER_CRDS[$provider]}"
-  if [ "${CLOUD_PROVIDER}" = "${provider}" ]; then
-    if kubectl get crd "${crd}" >/dev/null 2>&1; then
-      log_ok "CRD '${crd}' exists"
-    else
-      log_fail "CRD '${crd}' not found"
-    fi
+header "Results Summary"
+printf "  %-55s %s\n" "TEST" "RESULT"
+printf "  %-55s %s\n" "───────────────────────────────────────────────────────" "──────"
+all_passed=true
+for i in "${!TEST_NAMES[@]}"; do
+  result="${TEST_RESULTS[$i]}"
+  if [[ "$result" == "PASS" ]]; then
+    color="$GREEN"
   else
-    if kubectl get crd "${crd}" >/dev/null 2>&1; then
-      log_fail "CRD '${crd}' should NOT exist for ${CLOUD_PROVIDER} provider"
-    else
-      log_ok "CRD '${crd}' correctly absent"
-    fi
+    color="$RED"
+    all_passed=false
   fi
+  printf "  %-55s %s%s%s\n" "${TEST_NAMES[$i]}" "$color" "$result" "$NC"
 done
 
-# --- Step 1: Cloud manager deployment ---
-echo "--- Cloud Manager ---"
-CM_NS="rhai-cloudmanager-system"
-for provider in "${!PROVIDER_CRDS[@]}"; do
-  deploy="${provider}-cloud-manager-operator"
-  if [ "${CLOUD_PROVIDER}" = "${provider}" ]; then
-    wait_for_deployment "${deploy}" "${CM_NS}" 1
-  else
-    if kubectl get deployment "${deploy}" -n "${CM_NS}" >/dev/null 2>&1; then
-      log_fail "Deployment '${deploy}' should NOT exist for ${CLOUD_PROVIDER} provider"
-    else
-      log_ok "Deployment '${deploy}' correctly absent"
-    fi
-  fi
-done
-
-# --- Step 2: Cloud provider CR status ---
-echo "--- Cloud Provider CR ---"
-cr_name="default-${CLOUD_PROVIDER}kubernetesengine"
-if ! wait_for_cr_ready "${PROVIDER_CRDS[$CLOUD_PROVIDER]}" "${cr_name}" "${PROVIDER_CR_DISPLAY[$CLOUD_PROVIDER]} '${cr_name}'"; then
-  debug_namespace "${CM_NS}"
-fi
-
-# --- Step 3: cert-manager deployments ---
-echo "--- cert-manager ---"
-wait_for_all_deployments_in_namespace "cert-manager"
-
-# --- Step 4: rhai-operator ---
-echo "--- RHAI Operator ---"
-wait_for_deployment "rhai-operator" "redhat-ods-operator" 3
-
-# --- Step 5: KServe component CR status ---
-echo "--- KServe Component ---"
-if ! wait_for_cr_ready "kserves.components.platform.opendatahub.io" "default-kserve" "Kserve 'default-kserve'"; then
-  debug_namespace "redhat-ods-operator"
-  debug_namespace "redhat-ods-applications" "app.kubernetes.io/part-of=kserve"
-fi
-
-# --- Step 6: Inference Gateway Istio ---
-echo "--- Inference Gateway Istio ---"
-wait_for_deployment "inference-gateway-istio" "redhat-ods-applications"
-
-# --- Summary ---
 echo ""
-echo "==============================="
-if [ $ERRORS -eq 0 ]; then
-  echo "All checks passed"
+if [[ "$all_passed" == "true" ]]; then
+  echo -e "${GREEN}All tests passed.${NC}"
   exit 0
 else
-  echo "${ERRORS} check(s) failed:"
-  for msg in "${ERROR_MESSAGES[@]}"; do
-    echo "  - ${msg}"
-  done
+  echo -e "${RED}Some tests failed.${NC}"
   exit 1
 fi

--- a/charts/rhai-on-xks-chart/templates/_helpers.tpl
+++ b/charts/rhai-on-xks-chart/templates/_helpers.tpl
@@ -99,7 +99,7 @@ Usage:
 {{- $namespaces := list }}
 {{- $managedOnly := .managedOnly | default false }}
 {{- $provider := include "rhai-on-xks-chart.activeProvider" .root | fromYaml }}
-{{- if $provider }}
+{{- if and $provider (index $provider "keEnabled") }}
   {{- $provVals := index $.root.Values (index $provider "name") | default dict }}
   {{- range $depName, $dep := (dig "kubernetesEngine" "spec" "dependencies" (dict) $provVals) }}
     {{- if or (not $managedOnly) (eq (dig "managementPolicy" "" $dep) "Managed") }}

--- a/charts/rhai-on-xks-chart/templates/_helpers.tpl
+++ b/charts/rhai-on-xks-chart/templates/_helpers.tpl
@@ -40,6 +40,27 @@ Return the imagePullSecret name.
 {{- end -}}
 
 {{/*
+Render a dockerconfigjson Secret for a given namespace.
+Pass a dict with "root" (top-level context), "namespace", and optional "annotations" (dict).
+*/}}
+{{- define "rhai-on-xks-chart.imagePullSecretResource" -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "rhai-on-xks-chart.imagePullSecretName" .root }}
+  namespace: {{ .namespace }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" .root | nindent 4 }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ .root.Values.imagePullSecret.dockerConfigJson | b64enc }}
+{{- end -}}
+
+{{/*
 Render imagePullSecrets block for pod specs.
 Always outputs the block so that pre-created secrets are picked up.
 */}}
@@ -64,6 +85,41 @@ allowedRoutes:
     selector:
       {{- toYaml $ns.selector | nindent 6 }}
 {{- end }}
+{{- end -}}
+
+{{/*
+Collect dependency namespaces from enabled providers.
+Pass a dict with "root" (top-level context) and optional "managedOnly" (bool).
+When managedOnly is true, only dependencies with managementPolicy: Managed are included.
+Returns a JSON object with key "items" containing unique namespace strings.
+Usage:
+  (include "rhai-on-xks-chart.kubernetesEngineDependencyNamespaces" (dict "root" . "managedOnly" true) | fromJson).items
+*/}}
+{{- define "rhai-on-xks-chart.kubernetesEngineDependencyNamespaces" -}}
+{{- $namespaces := list }}
+{{- $managedOnly := .managedOnly | default false }}
+{{- range $provider := list .root.Values.azure .root.Values.coreweave .root.Values.aws }}
+  {{- if $provider.enabled }}
+    {{- range $depName, $dep := (dig "kubernetesEngine" "spec" "dependencies" (dict) $provider) }}
+      {{- if or (not $managedOnly) (eq (dig "managementPolicy" "" $dep) "Managed") }}
+        {{- with (dig "configuration" "namespace" "" $dep) }}
+          {{- $namespaces = append $namespaces . }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- dict "items" ($namespaces | uniq) | toJson }}
+{{- end -}}
+
+{{/*
+Return the KubernetesEngine CRD plural resource name for the active cloud provider.
+*/}}
+{{- define "rhai-on-xks-chart.keResourceName" -}}
+{{- if and .Values.azure.enabled .Values.azure.kubernetesEngine.enabled -}}azurekubernetesengines
+{{- else if and .Values.coreweave.enabled .Values.coreweave.kubernetesEngine.enabled -}}coreweavekubernetesengines
+{{- else if and .Values.aws.enabled .Values.aws.kubernetesEngine.enabled -}}awskubernetesengines
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/rhai-on-xks-chart/templates/_helpers.tpl
+++ b/charts/rhai-on-xks-chart/templates/_helpers.tpl
@@ -98,13 +98,13 @@ Usage:
 {{- define "rhai-on-xks-chart.kubernetesEngineDependencyNamespaces" -}}
 {{- $namespaces := list }}
 {{- $managedOnly := .managedOnly | default false }}
-{{- range $provider := list .root.Values.azure .root.Values.coreweave .root.Values.aws }}
-  {{- if $provider.enabled }}
-    {{- range $depName, $dep := (dig "kubernetesEngine" "spec" "dependencies" (dict) $provider) }}
-      {{- if or (not $managedOnly) (eq (dig "managementPolicy" "" $dep) "Managed") }}
-        {{- with (dig "configuration" "namespace" "" $dep) }}
-          {{- $namespaces = append $namespaces . }}
-        {{- end }}
+{{- $provider := include "rhai-on-xks-chart.activeProvider" .root | fromYaml }}
+{{- if $provider }}
+  {{- $provVals := index $.root.Values (index $provider "name") | default dict }}
+  {{- range $depName, $dep := (dig "kubernetesEngine" "spec" "dependencies" (dict) $provVals) }}
+    {{- if or (not $managedOnly) (eq (dig "managementPolicy" "" $dep) "Managed") }}
+      {{- with (dig "configuration" "namespace" "" $dep) }}
+        {{- $namespaces = append $namespaces . }}
       {{- end }}
     {{- end }}
   {{- end }}
@@ -116,24 +116,30 @@ Usage:
 Return the KubernetesEngine CRD plural resource name for the active cloud provider.
 */}}
 {{- define "rhai-on-xks-chart.keResourceName" -}}
-{{- if and .Values.azure.enabled .Values.azure.kubernetesEngine.enabled -}}azurekubernetesengines
-{{- else if and .Values.coreweave.enabled .Values.coreweave.kubernetesEngine.enabled -}}coreweavekubernetesengines
-{{- else if and .Values.aws.enabled .Values.aws.kubernetesEngine.enabled -}}awskubernetesengines
-{{- end -}}
+{{- $provider := include "rhai-on-xks-chart.activeProvider" . | fromYaml }}
+{{- if and $provider (index $provider "keEnabled") -}}
+  {{- index $provider "keResource" -}}
+{{- end }}
 {{- end -}}
 
 {{/*
 Validate that exactly one cloud provider is enabled.
 */}}
 {{- define "rhai-on-xks-chart.validateCloudProvider" -}}
-{{- if and .Values.enabled (not (or .Values.azure.enabled .Values.coreweave.enabled .Values.aws.enabled)) -}}
-{{- fail "Exactly one cloud provider must be enabled: set azure.enabled=true, coreweave.enabled=true, or aws.enabled=true" -}}
-{{- end -}}
+{{- $registry := include "rhai-on-xks-chart.providerRegistry" . | fromYaml }}
 {{- $enabledCount := 0 -}}
-{{- if .Values.azure.enabled }}{{- $enabledCount = add $enabledCount 1 -}}{{- end -}}
-{{- if .Values.coreweave.enabled }}{{- $enabledCount = add $enabledCount 1 -}}{{- end -}}
-{{- if .Values.aws.enabled }}{{- $enabledCount = add $enabledCount 1 -}}{{- end -}}
+{{- $enabledNames := list -}}
+{{- range $name := keys $registry | sortAlpha }}
+  {{- $providerVals := index $.Values $name | default dict }}
+  {{- if $providerVals.enabled }}
+    {{- $enabledCount = add $enabledCount 1 }}
+    {{- $enabledNames = append $enabledNames $name }}
+  {{- end }}
+{{- end }}
+{{- if and .Values.enabled (eq (int $enabledCount) 0) -}}
+{{- fail (printf "Exactly one cloud provider must be enabled: set %s" (join ".enabled=true, " (keys $registry | sortAlpha) | printf "%s.enabled=true")) -}}
+{{- end -}}
 {{- if and .Values.enabled (gt (int $enabledCount) 1) -}}
-{{- fail "Only one cloud provider can be enabled at a time: set either azure.enabled=true, coreweave.enabled=true, or aws.enabled=true, not multiple" -}}
+{{- fail (printf "Only one cloud provider can be enabled at a time: set either %s, not multiple" (join ".enabled=true, " $enabledNames | printf "%s.enabled=true")) -}}
 {{- end -}}
 {{- end -}}

--- a/charts/rhai-on-xks-chart/templates/hooks/_crs-definitions.tpl
+++ b/charts/rhai-on-xks-chart/templates/hooks/_crs-definitions.tpl
@@ -1,0 +1,159 @@
+{{/*
+Registry of cloud providers and their KubernetesEngine CR metadata.
+Returns a YAML map keyed by provider name.
+To add a new provider: add an entry here. All templates update automatically.
+*/}}
+{{- define "rhai-on-xks-chart.providerRegistry" -}}
+aws:
+  keKind: AWSKubernetesEngine
+  keResource: awskubernetesengines
+  keResourceSingular: awskubernetesengine
+  keName: default-awskubernetesengine
+azure:
+  keKind: AzureKubernetesEngine
+  keResource: azurekubernetesengines
+  keResourceSingular: azurekubernetesengine
+  keName: default-azurekubernetesengine
+coreweave:
+  keKind: CoreWeaveKubernetesEngine
+  keResource: coreweavekubernetesengines
+  keResourceSingular: coreweavekubernetesengine
+  keName: default-coreweavekubernetesengine
+{{- end -}}
+
+{{/*
+Registry of component CRs (components.platform.opendatahub.io API group).
+Returns a YAML map keyed by component name.
+To add a new component CR: add an entry here. All templates update automatically.
+*/}}
+{{- define "rhai-on-xks-chart.componentCRRegistry" -}}
+kserve:
+  kind: Kserve
+  resource: kserves
+  resourceSingular: kserve
+  crName: default-kserve
+  apiGroup: components.platform.opendatahub.io
+{{- end -}}
+
+{{/*
+Return a YAML dict for the active cloud provider (the one with .enabled=true).
+Returns empty string (→ empty map after fromYaml) if none enabled.
+Exactly one expected (enforced by rhai-on-xks-chart.validateCloudProvider).
+
+Fields: name, keKind, keResource, keResourceSingular, keName,
+        keEnabled (bool), keSpec (kubernetesEngine.spec), cloudManagerNamespace.
+*/}}
+{{- define "rhai-on-xks-chart.activeProvider" -}}
+{{- $registry := include "rhai-on-xks-chart.providerRegistry" . | fromYaml }}
+{{- range $name := keys $registry | sortAlpha }}
+  {{- $meta := index $registry $name }}
+  {{- $vals := index $.Values $name | default dict }}
+  {{- if $vals.enabled -}}
+    {{- dict
+      "name" $name
+      "keKind" (index $meta "keKind")
+      "keResource" (index $meta "keResource")
+      "keResourceSingular" (index $meta "keResourceSingular")
+      "keName" (index $meta "keName")
+      "keEnabled" (dig "kubernetesEngine" "enabled" false $vals)
+      "keSpec" (dig "kubernetesEngine" "spec" nil $vals)
+      "cloudManagerNamespace" (dig "cloudManager" "namespace" "" $vals)
+    | toYaml }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Returns "true" if provider + KE are both enabled, empty string otherwise. Used for guard conditions only.
+*/}}
+{{- define "rhai-on-xks-chart.enabledProviderKECR" -}}
+{{- $provider := include "rhai-on-xks-chart.activeProvider" . | fromYaml }}
+{{- if and $provider (index $provider "keEnabled") -}}true{{- end }}
+{{- end -}}
+
+{{/*
+Returns a JSON list of enabled component names for guard conditions (non-empty = at least one enabled).
+Do NOT range over this and access fields with .field syntax — use crApplyCommands / crDeleteCommands instead.
+*/}}
+{{- define "rhai-on-xks-chart.enabledComponentCRs" -}}
+{{- $registry := include "rhai-on-xks-chart.componentCRRegistry" . | fromYaml }}
+{{- $result := list }}
+{{- range $name := keys $registry | sortAlpha }}
+  {{- $compVals := index $.Values.components $name | default dict }}
+  {{- if $compVals.enabled }}
+    {{- $result = append $result $name }}
+  {{- end }}
+{{- end }}
+{{- $result | toJson }}
+{{- end -}}
+
+{{/*
+Emit kubectl apply commands for all enabled component CRs and provider KE CRs.
+Include with: {{- include "rhai-on-xks-chart.crApplyCommands" . | nindent 14 }}
+Component CRs are applied before provider KE CRs.
+*/}}
+{{- define "rhai-on-xks-chart.crApplyCommands" -}}
+{{- $root := . }}
+{{- $compRegistry := include "rhai-on-xks-chart.componentCRRegistry" . | fromYaml }}
+{{- range $name := keys $compRegistry | sortAlpha }}
+  {{- $meta := index $compRegistry $name }}
+  {{- $compVals := index $.Values.components $name | default dict }}
+  {{- if $compVals.enabled }}
+echo "Creating {{ index $meta "kind" }} CR..."
+kubectl apply -f - <<'EOF'
+apiVersion: {{ index $meta "apiGroup" }}/v1alpha1
+kind: {{ index $meta "kind" }}
+metadata:
+  name: {{ index $meta "crName" }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" $root | nindent 4 }}
+{{- if $compVals.spec }}
+spec:
+  {{- $compVals.spec | toYaml | nindent 2 }}
+{{- else }}
+spec: {}
+{{- end }}
+EOF
+  {{- end }}
+{{- end }}
+{{- $provider := include "rhai-on-xks-chart.activeProvider" . | fromYaml }}
+{{- if and $provider (index $provider "keEnabled") }}
+echo "Creating {{ index $provider "keKind" }} CR..."
+kubectl apply -f - <<'EOF'
+apiVersion: infrastructure.opendatahub.io/v1alpha1
+kind: {{ index $provider "keKind" }}
+metadata:
+  name: {{ index $provider "keName" }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" $root | nindent 4 }}
+{{- $spec := index $provider "keSpec" }}
+{{- if $spec }}
+spec:
+  {{- $spec | toYaml | nindent 2 }}
+{{- else }}
+spec: {}
+{{- end }}
+EOF
+{{- end }}
+{{- end -}}
+
+{{/*
+Emit kubectl delete commands for all enabled component CRs and provider KE CRs.
+Include with: {{- include "rhai-on-xks-chart.crDeleteCommands" . | nindent 14 }}
+*/}}
+{{- define "rhai-on-xks-chart.crDeleteCommands" -}}
+{{- $compRegistry := include "rhai-on-xks-chart.componentCRRegistry" . | fromYaml }}
+{{- range $name := keys $compRegistry | sortAlpha }}
+  {{- $meta := index $compRegistry $name }}
+  {{- $compVals := index $.Values.components $name | default dict }}
+  {{- if $compVals.enabled }}
+echo "Deleting {{ index $meta "kind" }} CR '{{ index $meta "crName" }}'..."
+kubectl delete {{ index $meta "resourceSingular" }} {{ index $meta "crName" }} --ignore-not-found --timeout=300s
+  {{- end }}
+{{- end }}
+{{- $provider := include "rhai-on-xks-chart.activeProvider" . | fromYaml }}
+{{- if and $provider (index $provider "keEnabled") }}
+echo "Deleting {{ index $provider "keKind" }} CR '{{ index $provider "keName" }}'..."
+kubectl delete {{ index $provider "keResourceSingular" }} {{ index $provider "keName" }} --ignore-not-found --timeout=300s
+{{- end }}
+{{- end -}}

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
@@ -1,10 +1,8 @@
 {{- if .Values.enabled }}
 {{- if .Values.hooks.postInstallCrs.enabled }}
-{{- $createKserve := .Values.components.kserve.enabled }}
-{{- $createAzureKE := and .Values.azure.enabled .Values.azure.kubernetesEngine.enabled }}
-{{- $createCoreweaveKE := and .Values.coreweave.enabled .Values.coreweave.kubernetesEngine.enabled }}
-{{- $createAwsKE := and .Values.aws.enabled .Values.aws.kubernetesEngine.enabled }}
-{{- if or $createKserve $createAzureKE $createCoreweaveKE $createAwsKE }}
+{{- $componentCRs := include "rhai-on-xks-chart.enabledComponentCRs" . | fromJson }}
+{{- $providerKECR := include "rhai-on-xks-chart.enabledProviderKECR" . }}
+{{- if or $componentCRs $providerKECR }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -47,74 +45,7 @@ spec:
             - -c
             - |
               set -euo pipefail
-              {{- if $createKserve }}
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  {{- include "rhai-on-xks-chart.labels" . | nindent 18 }}
-              {{- if .Values.components.kserve.spec }}
-              spec:
-                {{- .Values.components.kserve.spec | toYaml | nindent 16 }}
-              {{- else }}
-              spec: {}
-              {{- end }}
-              EOF
-              {{- end }}
-              {{- if $createAzureKE }}
-              echo "Creating AzureKubernetesEngine CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: infrastructure.opendatahub.io/v1alpha1
-              kind: AzureKubernetesEngine
-              metadata:
-                name: default-azurekubernetesengine
-                labels:
-                  {{- include "rhai-on-xks-chart.labels" . | nindent 18 }}
-              {{- if .Values.azure.kubernetesEngine.spec }}
-              spec:
-                {{- .Values.azure.kubernetesEngine.spec | toYaml | nindent 16 }}
-              {{- else }}
-              spec: {}
-              {{- end }}
-              EOF
-              {{- end }}
-              {{- if $createCoreweaveKE }}
-              echo "Creating CoreWeaveKubernetesEngine CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: infrastructure.opendatahub.io/v1alpha1
-              kind: CoreWeaveKubernetesEngine
-              metadata:
-                name: default-coreweavekubernetesengine
-                labels:
-                  {{- include "rhai-on-xks-chart.labels" . | nindent 18 }}
-              {{- if .Values.coreweave.kubernetesEngine.spec }}
-              spec:
-                {{- .Values.coreweave.kubernetesEngine.spec | toYaml | nindent 16 }}
-              {{- else }}
-              spec: {}
-              {{- end }}
-              EOF
-              {{- end }}
-              {{- if $createAwsKE }}
-              echo "Creating AWSKubernetesEngine CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: infrastructure.opendatahub.io/v1alpha1
-              kind: AWSKubernetesEngine
-              metadata:
-                name: default-awskubernetesengine
-                labels:
-                  {{- include "rhai-on-xks-chart.labels" . | nindent 18 }}
-              {{- if .Values.aws.kubernetesEngine.spec }}
-              spec:
-                {{- .Values.aws.kubernetesEngine.spec | toYaml | nindent 16 }}
-              {{- else }}
-              spec: {}
-              {{- end }}
-              EOF
-              {{- end }}
+              {{- include "rhai-on-xks-chart.crApplyCommands" . | trimPrefix "\n" | nindent 14 }}
               echo "Done."
 {{- end }}
 {{- end }}

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -4,6 +4,7 @@
 {{- $createAzureKE := and .Values.azure.enabled .Values.azure.kubernetesEngine.enabled }}
 {{- $createCoreweaveKE := and .Values.coreweave.enabled .Values.coreweave.kubernetesEngine.enabled }}
 {{- $createAwsKE := and .Values.aws.enabled .Values.aws.kubernetesEngine.enabled }}
+{{- $keResource := include "rhai-on-xks-chart.keResourceName" . }}
 {{- $createGateway := and .Values.components.kserve.enabled .Values.components.kserve.gateway.create }}
 {{- $gatewayTls := and $createGateway .Values.gateway.tls.enabled }}
 {{- $appNs := .Values.rhaiOperator.applicationsNamespace }}
@@ -19,7 +20,6 @@ metadata:
     {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,9 +30,9 @@ metadata:
     {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
+  {{- if $createKserve }}
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -42,17 +42,18 @@ rules:
       - create
       - patch
       - update
+  {{- end }}
+  {{- if $keResource }}
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines
-      - coreweavekubernetesengines
-      - awskubernetesengines
+      - {{ $keResource }}
     verbs:
       - get
       - create
       - patch
       - update
+  {{- end }}
   {{- if $createGateway }}
   - apiGroups:
       - gateway.networking.k8s.io
@@ -112,7 +113,6 @@ metadata:
     {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -134,7 +134,6 @@ metadata:
     {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -166,7 +165,6 @@ metadata:
     {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -1,16 +1,14 @@
 {{- if .Values.enabled }}
 {{- if .Values.hooks.postInstallCrs.enabled }}
-{{- $createKserve := .Values.components.kserve.enabled }}
-{{- $createAzureKE := and .Values.azure.enabled .Values.azure.kubernetesEngine.enabled }}
-{{- $createCoreweaveKE := and .Values.coreweave.enabled .Values.coreweave.kubernetesEngine.enabled }}
-{{- $createAwsKE := and .Values.aws.enabled .Values.aws.kubernetesEngine.enabled }}
+{{- $componentCRs := include "rhai-on-xks-chart.enabledComponentCRs" . | fromJson }}
+{{- $providerKECR := include "rhai-on-xks-chart.enabledProviderKECR" . }}
 {{- $keResource := include "rhai-on-xks-chart.keResourceName" . }}
 {{- $createGateway := and .Values.components.kserve.enabled .Values.components.kserve.gateway.create }}
 {{- $gatewayTls := and $createGateway .Values.gateway.tls.enabled }}
 {{- $appNs := .Values.rhaiOperator.applicationsNamespace }}
 {{- $issuerName := .Values.gateway.tls.issuerRef.name }}
 {{- $issuerKind := .Values.gateway.tls.issuerRef.kind }}
-{{- if or $createKserve $createAzureKE $createCoreweaveKE $createAwsKE $createGateway }}
+{{- if or $componentCRs $providerKECR $createGateway }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -32,16 +30,21 @@ metadata:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
-  {{- if $createKserve }}
+  {{- $compRegistry := include "rhai-on-xks-chart.componentCRRegistry" . | fromYaml }}
+  {{- range $name := keys $compRegistry | sortAlpha }}
+    {{- $meta := index $compRegistry $name }}
+    {{- $compVals := index $.Values.components $name | default dict }}
+    {{- if $compVals.enabled }}
   - apiGroups:
-      - components.platform.opendatahub.io
+      - {{ index $meta "apiGroup" }}
     resources:
-      - kserves
+      - {{ index $meta "resource" }}
     verbs:
       - get
       - create
       - patch
       - update
+    {{- end }}
   {{- end }}
   {{- if $keResource }}
   - apiGroups:

--- a/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.enabled }}
+{{- if .Values.hooks.postInstallCrs.enabled }}
+{{- $createKserve := .Values.components.kserve.enabled }}
+{{- $createAzureKE := and .Values.azure.enabled .Values.azure.kubernetesEngine.enabled }}
+{{- $createCoreweaveKE := and .Values.coreweave.enabled .Values.coreweave.kubernetesEngine.enabled }}
+{{- $createAwsKE := and .Values.aws.enabled .Values.aws.kubernetesEngine.enabled }}
+{{- $depNamespaces := (include "rhai-on-xks-chart.kubernetesEngineDependencyNamespaces" (dict "root" .) | fromJson).items }}
+{{- if or $createKserve $createAzureKE $createCoreweaveKE $createAwsKE }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-delete-crs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "rhai-on-xks-chart.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-delete-hook
+      {{- include "rhai-on-xks-chart.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: delete-crs
+          image: {{ required "hooks.cliImage is required" .Values.hooks.cliImage | quote }}
+          resources:
+            {{- toYaml .Values.hooks.resources | nindent 12 }}
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              {{- if $createKserve }}
+              echo "Deleting Kserve CR 'default-kserve'..."
+              kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
+              {{- end }}
+
+              {{- if $createAzureKE }}
+              echo "Deleting AzureKubernetesEngine CR 'default-azurekubernetesengine'..."
+              kubectl delete azurekubernetesengine default-azurekubernetesengine --ignore-not-found --timeout=300s
+              {{- end }}
+              {{- if $createCoreweaveKE }}
+              echo "Deleting CoreWeaveKubernetesEngine CR 'default-coreweavekubernetesengine'..."
+              kubectl delete coreweavekubernetesengine default-coreweavekubernetesengine --ignore-not-found --timeout=300s
+              {{- end }}
+              {{- if $createAwsKE }}
+              echo "Deleting AWSKubernetesEngine CR 'default-awskubernetesengine'..."
+              kubectl delete awskubernetesengine default-awskubernetesengine --ignore-not-found --timeout=300s
+              {{- end }}
+
+              {{- if $.Values.uninstall.cleanupNamespaces }}
+              {{- range $ns := $depNamespaces }}
+              echo "Deleting namespace {{ $ns }}..."
+              kubectl delete namespace {{ $ns }} --ignore-not-found --timeout=60s
+              {{- end }}
+              {{- end }}
+              echo "Done."
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
@@ -2,7 +2,7 @@
 {{- if .Values.hooks.postInstallCrs.enabled }}
 {{- $componentCRs := include "rhai-on-xks-chart.enabledComponentCRs" . | fromJson }}
 {{- $providerKECR := include "rhai-on-xks-chart.enabledProviderKECR" . }}
-{{- $depNamespaces := (include "rhai-on-xks-chart.kubernetesEngineDependencyNamespaces" (dict "root" .) | fromJson).items }}
+{{- $depNamespaces := (include "rhai-on-xks-chart.kubernetesEngineDependencyNamespaces" (dict "root" . "managedOnly" true) | fromJson).items }}
 {{- if or $componentCRs $providerKECR }}
 apiVersion: batch/v1
 kind: Job
@@ -50,8 +50,8 @@ spec:
 
               {{- if $.Values.uninstall.cleanupNamespaces }}
               {{- range $ns := $depNamespaces }}
-              echo "Deleting namespace {{ $ns }}..."
-              kubectl delete namespace {{ $ns }} --ignore-not-found --timeout=60s
+              echo "Deleting namespace '{{ $ns }}'..."
+              kubectl delete namespace '{{ $ns }}' --ignore-not-found --timeout=60s
               {{- end }}
               {{- end }}
               echo "Done."

--- a/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
@@ -1,11 +1,9 @@
 {{- if .Values.enabled }}
 {{- if .Values.hooks.postInstallCrs.enabled }}
-{{- $createKserve := .Values.components.kserve.enabled }}
-{{- $createAzureKE := and .Values.azure.enabled .Values.azure.kubernetesEngine.enabled }}
-{{- $createCoreweaveKE := and .Values.coreweave.enabled .Values.coreweave.kubernetesEngine.enabled }}
-{{- $createAwsKE := and .Values.aws.enabled .Values.aws.kubernetesEngine.enabled }}
+{{- $componentCRs := include "rhai-on-xks-chart.enabledComponentCRs" . | fromJson }}
+{{- $providerKECR := include "rhai-on-xks-chart.enabledProviderKECR" . }}
 {{- $depNamespaces := (include "rhai-on-xks-chart.kubernetesEngineDependencyNamespaces" (dict "root" .) | fromJson).items }}
-{{- if or $createKserve $createAzureKE $createCoreweaveKE $createAwsKE }}
+{{- if or $componentCRs $providerKECR }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -48,23 +46,7 @@ spec:
             - -c
             - |
               set -euo pipefail
-              {{- if $createKserve }}
-              echo "Deleting Kserve CR 'default-kserve'..."
-              kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
-              {{- end }}
-
-              {{- if $createAzureKE }}
-              echo "Deleting AzureKubernetesEngine CR 'default-azurekubernetesengine'..."
-              kubectl delete azurekubernetesengine default-azurekubernetesengine --ignore-not-found --timeout=300s
-              {{- end }}
-              {{- if $createCoreweaveKE }}
-              echo "Deleting CoreWeaveKubernetesEngine CR 'default-coreweavekubernetesengine'..."
-              kubectl delete coreweavekubernetesengine default-coreweavekubernetesengine --ignore-not-found --timeout=300s
-              {{- end }}
-              {{- if $createAwsKE }}
-              echo "Deleting AWSKubernetesEngine CR 'default-awskubernetesengine'..."
-              kubectl delete awskubernetesengine default-awskubernetesengine --ignore-not-found --timeout=300s
-              {{- end }}
+              {{- include "rhai-on-xks-chart.crDeleteCommands" . | trimPrefix "\n" | nindent 14 }}
 
               {{- if $.Values.uninstall.cleanupNamespaces }}
               {{- range $ns := $depNamespaces }}

--- a/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
@@ -38,6 +38,7 @@ rules:
       {{- end }}
     verbs:
       - get
+      - list
       - watch
       - delete
   {{- end }}
@@ -52,6 +53,7 @@ rules:
       - {{ index $meta "resource" }}
     verbs:
       - get
+      - list
       - watch
       - delete
     {{- end }}

--- a/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
@@ -4,6 +4,8 @@
 {{- $providerKECR := include "rhai-on-xks-chart.enabledProviderKECR" . }}
 {{- $keResource := include "rhai-on-xks-chart.keResourceName" . }}
 {{- if or $componentCRs $providerKECR }}
+{{- $provider := include "rhai-on-xks-chart.activeProvider" . | fromYaml }}
+{{- $depNamespaces := (include "rhai-on-xks-chart.kubernetesEngineDependencyNamespaces" (dict "root" . "managedOnly" true) | fromJson).items }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -25,14 +27,17 @@ metadata:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
-  {{- if .Values.uninstall.cleanupNamespaces }}
+  {{- if and .Values.uninstall.cleanupNamespaces $depNamespaces }}
   - apiGroups:
       - ""
     resources:
       - namespaces
+    resourceNames:
+      {{- range $ns := $depNamespaces }}
+      - {{ $ns }}
+      {{- end }}
     verbs:
       - get
-      - list
       - watch
       - delete
   {{- end }}
@@ -47,19 +52,17 @@ rules:
       - {{ index $meta "resource" }}
     verbs:
       - get
-      - list
       - watch
       - delete
     {{- end }}
   {{- end }}
-  {{- if $keResource }}
+  {{- if and $keResource $provider }}
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
       - {{ $keResource }}
     verbs:
       - get
-      - list
       - watch
       - delete
   {{- end }}

--- a/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.enabled }}
+{{- if .Values.hooks.postInstallCrs.enabled }}
+{{- $createKserve := .Values.components.kserve.enabled }}
+{{- $createAzureKE := and .Values.azure.enabled .Values.azure.kubernetesEngine.enabled }}
+{{- $createCoreweaveKE := and .Values.coreweave.enabled .Values.coreweave.kubernetesEngine.enabled }}
+{{- $createAwsKE := and .Values.aws.enabled .Values.aws.kubernetesEngine.enabled }}
+{{- $keResource := include "rhai-on-xks-chart.keResourceName" . }}
+{{- if or $createKserve $createAzureKE $createCoreweaveKE $createAwsKE }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-delete-hook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  {{- if .Values.uninstall.cleanupNamespaces }}
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  {{- end }}
+  {{- if $createKserve }}
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - kserves
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  {{- end }}
+  {{- if $keResource }}
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - {{ $keResource }}
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-delete-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-delete-hook
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
@@ -1,11 +1,9 @@
 {{- if .Values.enabled }}
 {{- if .Values.hooks.postInstallCrs.enabled }}
-{{- $createKserve := .Values.components.kserve.enabled }}
-{{- $createAzureKE := and .Values.azure.enabled .Values.azure.kubernetesEngine.enabled }}
-{{- $createCoreweaveKE := and .Values.coreweave.enabled .Values.coreweave.kubernetesEngine.enabled }}
-{{- $createAwsKE := and .Values.aws.enabled .Values.aws.kubernetesEngine.enabled }}
+{{- $componentCRs := include "rhai-on-xks-chart.enabledComponentCRs" . | fromJson }}
+{{- $providerKECR := include "rhai-on-xks-chart.enabledProviderKECR" . }}
 {{- $keResource := include "rhai-on-xks-chart.keResourceName" . }}
-{{- if or $createKserve $createAzureKE $createCoreweaveKE $createAwsKE }}
+{{- if or $componentCRs $providerKECR }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -38,16 +36,21 @@ rules:
       - watch
       - delete
   {{- end }}
-  {{- if $createKserve }}
+  {{- $compRegistry := include "rhai-on-xks-chart.componentCRRegistry" . | fromYaml }}
+  {{- range $name := keys $compRegistry | sortAlpha }}
+    {{- $meta := index $compRegistry $name }}
+    {{- $compVals := index $.Values.components $name | default dict }}
+    {{- if $compVals.enabled }}
   - apiGroups:
-      - components.platform.opendatahub.io
+      - {{ index $meta "apiGroup" }}
     resources:
-      - kserves
+      - {{ index $meta "resource" }}
     verbs:
       - get
       - list
       - watch
       - delete
+    {{- end }}
   {{- end }}
   {{- if $keResource }}
   - apiGroups:

--- a/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
@@ -5,6 +5,11 @@
 {{- $keResource := include "rhai-on-xks-chart.keResourceName" . }}
 {{- if or $componentCRs $providerKECR }}
 {{- $provider := include "rhai-on-xks-chart.activeProvider" . | fromYaml }}
+{{- if include "rhai-on-xks-chart.imagePullSecretEnabled" . }}
+{{- $hookAnnotations := dict "helm.sh/hook" "pre-delete" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" }}
+{{ include "rhai-on-xks-chart.imagePullSecretResource" (dict "root" . "namespace" .Release.Namespace "annotations" $hookAnnotations) }}
+---
+{{- end }}
 {{- $depNamespaces := (include "rhai-on-xks-chart.kubernetesEngineDependencyNamespaces" (dict "root" . "managedOnly" true) | fromJson).items }}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/rhai-on-xks-chart/templates/hooks/pre-install-namespaces-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/pre-install-namespaces-job.yaml
@@ -45,8 +45,8 @@ spec:
             - |
               set -euo pipefail
               {{- range $ns := $namespaces }}
-              echo "Ensuring namespace {{ $ns }} exists..."
-              kubectl create namespace {{ $ns }} --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace '{{ $ns }}' exists..."
+              kubectl create namespace '{{ $ns }}' --dry-run=client -o yaml | kubectl apply -f -
               {{- end }}
               echo "Done."
 {{- end }}

--- a/charts/rhai-on-xks-chart/templates/hooks/pre-install-namespaces-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/pre-install-namespaces-job.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.enabled }}
+{{- if include "rhai-on-xks-chart.imagePullSecretEnabled" . }}
+{{- $namespaces := (include "rhai-on-xks-chart.kubernetesEngineDependencyNamespaces" (dict "root" . "managedOnly" true) | fromJson).items }}
+{{- if $namespaces }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-install-namespaces
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "rhai-on-xks-chart.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-install-namespaces-hook
+      {{- include "rhai-on-xks-chart.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: create-namespaces
+          image: {{ required "hooks.cliImage is required" .Values.hooks.cliImage | quote }}
+          resources:
+            {{- toYaml .Values.hooks.resources | nindent 12 }}
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              {{- range $ns := $namespaces }}
+              echo "Ensuring namespace {{ $ns }} exists..."
+              kubectl create namespace {{ $ns }} --dry-run=client -o yaml | kubectl apply -f -
+              {{- end }}
+              echo "Done."
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.enabled }}
+{{- if include "rhai-on-xks-chart.imagePullSecretEnabled" . }}
+{{- $namespaces := (include "rhai-on-xks-chart.kubernetesEngineDependencyNamespaces" (dict "root" . "managedOnly" true) | fromJson).items }}
+{{- if $namespaces }}
+{{- $hookAnnotations := dict "helm.sh/hook" "pre-install,pre-upgrade" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" }}
+{{ include "rhai-on-xks-chart.imagePullSecretResource" (dict "root" . "namespace" .Release.Namespace "annotations" $hookAnnotations) }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-install-namespaces-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-install-namespaces-hook
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/pull-secret.yaml
+++ b/charts/rhai-on-xks-chart/templates/pull-secret.yaml
@@ -2,7 +2,9 @@
 {{- $namespaces := list .Values.rhaiOperator.namespace .Values.rhaiOperator.applicationsNamespace .Release.Namespace }}
 {{- $provider := include "rhai-on-xks-chart.activeProvider" . | fromYaml }}
 {{- if $provider }}
-  {{- $namespaces = append $namespaces (index $provider "cloudManagerNamespace") }}
+  {{- with (index $provider "cloudManagerNamespace") }}
+    {{- $namespaces = append $namespaces . }}
+  {{- end }}
 {{- end }}
 {{- $dependencyNamespaces := .Values.imagePullSecret.dependencyNamespaces | default list | uniq }}
 {{- $managedDepNamespaces := (include "rhai-on-xks-chart.kubernetesEngineDependencyNamespaces" (dict "root" . "managedOnly" true) | fromJson).items }}

--- a/charts/rhai-on-xks-chart/templates/pull-secret.yaml
+++ b/charts/rhai-on-xks-chart/templates/pull-secret.yaml
@@ -9,20 +9,9 @@
 {{- if .Values.aws.enabled }}
 {{- $namespaces = append $namespaces .Values.aws.cloudManager.namespace }}
 {{- end }}
-{{- $dependencyNamespaces := .Values.imagePullSecret.dependencyNamespaces | default list }}
-{{- range $provider := list $.Values.azure $.Values.coreweave $.Values.aws }}
-  {{- if $provider.enabled }}
-    {{- range $depName, $dep := (dig "kubernetesEngine" "spec" "dependencies" (dict) $provider) }}
-      {{- if eq (dig "managementPolicy" "" $dep) "Managed" }}
-        {{- with (dig "configuration" "namespace" "" $dep) }}
-          {{- $dependencyNamespaces = append $dependencyNamespaces . }}
-        {{- end }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-{{- end }}
-{{- $dependencyNamespaces = $dependencyNamespaces | uniq }}
-{{- $allNamespaces := concat $namespaces $dependencyNamespaces | uniq }}
+{{- $dependencyNamespaces := .Values.imagePullSecret.dependencyNamespaces | default list | uniq }}
+{{- $managedDepNamespaces := (include "rhai-on-xks-chart.kubernetesEngineDependencyNamespaces" (dict "root" . "managedOnly" true) | fromJson).items }}
+{{- $allNamespaces := concat $namespaces $dependencyNamespaces $managedDepNamespaces | uniq }}
 {{- range $i, $ns := $dependencyNamespaces }}
 {{- if $i }}
 ---
@@ -34,16 +23,7 @@ metadata:
 {{- end }}
 {{- range $ns := $allNamespaces }}
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "rhai-on-xks-chart.imagePullSecretName" $ }}
-  namespace: {{ $ns }}
-  labels:
-    {{- include "rhai-on-xks-chart.labels" $ | nindent 4 }}
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: {{ $.Values.imagePullSecret.dockerConfigJson | b64enc }}
+{{ include "rhai-on-xks-chart.imagePullSecretResource" (dict "root" $ "namespace" $ns) }}
 {{- end }}
 {{- end }}
 {{- if and .Values.enabled (include "rhai-on-xks-chart.imagePullSecretEnabled" .) }}

--- a/charts/rhai-on-xks-chart/templates/pull-secret.yaml
+++ b/charts/rhai-on-xks-chart/templates/pull-secret.yaml
@@ -1,13 +1,8 @@
 {{- if and .Values.enabled (include "rhai-on-xks-chart.imagePullSecretEnabled" .) }}
 {{- $namespaces := list .Values.rhaiOperator.namespace .Values.rhaiOperator.applicationsNamespace .Release.Namespace }}
-{{- if .Values.azure.enabled }}
-{{- $namespaces = append $namespaces .Values.azure.cloudManager.namespace }}
-{{- end }}
-{{- if .Values.coreweave.enabled }}
-{{- $namespaces = append $namespaces .Values.coreweave.cloudManager.namespace }}
-{{- end }}
-{{- if .Values.aws.enabled }}
-{{- $namespaces = append $namespaces .Values.aws.cloudManager.namespace }}
+{{- $provider := include "rhai-on-xks-chart.activeProvider" . | fromYaml }}
+{{- if $provider }}
+  {{- $namespaces = append $namespaces (index $provider "cloudManagerNamespace") }}
 {{- end }}
 {{- $dependencyNamespaces := .Values.imagePullSecret.dependencyNamespaces | default list | uniq }}
 {{- $managedDepNamespaces := (include "rhai-on-xks-chart.kubernetesEngineDependencyNamespaces" (dict "root" . "managedOnly" true) | fromJson).items }}

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
@@ -3188,6 +3188,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
@@ -3188,7 +3188,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3197,7 +3196,6 @@ rules:
       - awskubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---
@@ -3723,9 +3721,9 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Ensuring namespace openshift-lws-operator exists..."
-              kubectl create namespace openshift-lws-operator --dry-run=client -o yaml | kubectl apply -f -
-              echo "Ensuring namespace istio-system exists..."
-              kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace 'openshift-lws-operator' exists..."
+              kubectl create namespace 'openshift-lws-operator' --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace 'istio-system' exists..."
+              kubectl create namespace 'istio-system' --dry-run=client -o yaml | kubectl apply -f -
               echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
@@ -20,12 +20,35 @@ metadata:
   name: redhat-ods-operator
 
 ---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aws-cloud-manager-operator
   namespace: rhai-cloudmanager-system
+imagePullSecrets:
+  - name: rhai-pull-secret
+
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+# TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: llmisvc-controller-manager
+  namespace: redhat-ods-applications
 imagePullSecrets:
   - name: rhai-pull-secret
 
@@ -39,6 +62,110 @@ metadata:
 imagePullSecrets:
   - name: rhai-pull-secret
 
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: cert-manager-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: cert-manager
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: openshift-lws-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: istio-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/crds/customresourcedefinition-awskubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -2937,6 +3064,35 @@ metadata:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -3045,6 +3201,27 @@ rules:
       - watch
       - delete
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - create
+      - patch
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3083,6 +3260,27 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rhai-pre-delete-hook
+    namespace: default
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-install-namespaces-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-install-namespaces-hook
     namespace: default
 
 ---
@@ -3214,7 +3412,7 @@ spec:
                   lws:
                     configuration:
                       namespace: openshift-lws-operator
-                    managementPolicy: Unmanaged
+                    managementPolicy: Managed
                   sailOperator:
                     configuration:
                       namespace: istio-system
@@ -3391,13 +3589,13 @@ spec:
                     protocol: HTTP
                     allowedRoutes:
                       namespaces:
-                        from: All
+                        from: Same
                   - name: https
                     port: 443
                     protocol: HTTPS
                     allowedRoutes:
                       namespaces:
-                        from: All
+                        from: Same
                     tls:
                       certificateRefs:
                         - group: ''
@@ -3471,5 +3669,63 @@ spec:
               kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
               echo "Deleting AWSKubernetesEngine CR 'default-awskubernetesengine'..."
               kubectl delete awskubernetesengine default-awskubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-install-namespaces
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-install-namespaces-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: create-namespaces
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Ensuring namespace openshift-lws-operator exists..."
+              kubectl create namespace openshift-lws-operator --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace istio-system exists..."
+              kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
               echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
@@ -3077,6 +3077,22 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
 # Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
 apiVersion: v1
 kind: Secret

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
@@ -3032,7 +3032,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3041,7 +3040,6 @@ rules:
       - awskubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
@@ -3032,6 +3032,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
@@ -3032,7 +3032,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3041,7 +3040,6 @@ rules:
       - awskubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
@@ -2922,7 +2922,19 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-delete-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -2935,7 +2947,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -2950,8 +2961,6 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines
-      - coreweavekubernetesengines
       - awskubernetesengines
     verbs:
       - get
@@ -3005,6 +3014,37 @@ rules:
     verbs:
       - get
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - kserves
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - awskubernetesengines
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3015,7 +3055,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3025,6 +3064,27 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-delete-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-delete-hook
+    namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 # Certificate is namespaced to the applications namespace.
@@ -3038,7 +3098,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3062,7 +3121,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3356,4 +3414,62 @@ spec:
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
               
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-delete-crs
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-delete-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: delete-crs
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Deleting Kserve CR 'default-kserve'..."
+              kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
+              echo "Deleting AWSKubernetesEngine CR 'default-awskubernetesengine'..."
+              kubectl delete awskubernetesengine default-awskubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
@@ -3032,6 +3032,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -32,12 +32,6 @@ kind: Namespace
 metadata:
   name: cert-manager
 ---
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system
----
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -3042,8 +3036,49 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-delete-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3055,7 +3090,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3070,8 +3104,6 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines
-      - coreweavekubernetesengines
       - awskubernetesengines
     verbs:
       - get
@@ -3125,6 +3157,58 @@ rules:
     verbs:
       - get
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - kserves
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - awskubernetesengines
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - create
+      - patch
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3135,7 +3219,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3145,6 +3228,48 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-delete-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-delete-hook
+    namespace: default
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-install-namespaces-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-install-namespaces-hook
+    namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 # Certificate is namespaced to the applications namespace.
@@ -3158,7 +3283,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3182,7 +3306,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3476,4 +3599,118 @@ spec:
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
               
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-delete-crs
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-delete-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: delete-crs
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Deleting Kserve CR 'default-kserve'..."
+              kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
+              echo "Deleting AWSKubernetesEngine CR 'default-awskubernetesengine'..."
+              kubectl delete awskubernetesengine default-awskubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-install-namespaces
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-install-namespaces-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: create-namespaces
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Ensuring namespace istio-system exists..."
+              kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
+              echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -3175,6 +3175,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -3175,7 +3175,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3184,7 +3183,6 @@ rules:
       - awskubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---
@@ -3710,7 +3708,7 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Ensuring namespace istio-system exists..."
-              kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace 'istio-system' exists..."
+              kubectl create namespace 'istio-system' --dry-run=client -o yaml | kubectl apply -f -
               echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -3064,6 +3064,22 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
 # Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
 apiVersion: v1
 kind: Secret

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -3032,7 +3032,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3041,7 +3040,6 @@ rules:
       - awskubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -2922,7 +2922,19 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-delete-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -2935,7 +2947,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -2950,8 +2961,6 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines
-      - coreweavekubernetesengines
       - awskubernetesengines
     verbs:
       - get
@@ -3005,6 +3014,37 @@ rules:
     verbs:
       - get
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - kserves
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - awskubernetesengines
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3015,7 +3055,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3025,6 +3064,27 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-delete-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-delete-hook
+    namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 # Certificate is namespaced to the applications namespace.
@@ -3038,7 +3098,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3062,7 +3121,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3356,4 +3414,62 @@ spec:
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
               
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-delete-crs
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-delete-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: delete-crs
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Deleting Kserve CR 'default-kserve'..."
+              kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
+              echo "Deleting AWSKubernetesEngine CR 'default-awskubernetesengine'..."
+              kubectl delete awskubernetesengine default-awskubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -3032,6 +3032,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
@@ -3188,6 +3188,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/namespace-rhai-cloudmanager-system.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/manager/namespace-rhai-cloudmanager-system.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -20,12 +20,35 @@ metadata:
   name: redhat-ods-operator
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+---
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: aws-cloud-manager-operator
+  name: azure-cloud-manager-operator
   namespace: rhai-cloudmanager-system
+imagePullSecrets:
+  - name: rhai-pull-secret
+
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+# TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: llmisvc-controller-manager
+  namespace: redhat-ods-applications
 imagePullSecrets:
   - name: rhai-pull-secret
 
@@ -40,21 +63,125 @@ imagePullSecrets:
   - name: rhai-pull-secret
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/crds/customresourcedefinition-awskubernetesengines.infrastructure.opendatahub.io.yaml
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: cert-manager-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: cert-manager
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: openshift-lws-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: istio-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/crds/customresourcedefinition-azurekubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
     helm.sh/resource-policy: keep
-  name: awskubernetesengines.infrastructure.opendatahub.io
+  name: azurekubernetesengines.infrastructure.opendatahub.io
 spec:
   group: infrastructure.opendatahub.io
   names:
-    kind: AWSKubernetesEngine
-    listKind: AWSKubernetesEngineList
-    plural: awskubernetesengines
-    singular: awskubernetesengine
+    kind: AzureKubernetesEngine
+    listKind: AzureKubernetesEngineList
+    plural: azurekubernetesengines
+    singular: azurekubernetesengine
   scope: Cluster
   versions:
     - additionalPrinterColumns:
@@ -74,8 +201,8 @@ spec:
       schema:
         openAPIV3Schema:
           description: |-
-            AWSKubernetesEngine is the Schema for the awskubernetesengines API.
-            It represents the configuration for an AWS Kubernetes Service cluster.
+            AzureKubernetesEngine is the Schema for the azurekubernetesengines API.
+            It represents the configuration for an Azure Kubernetes Service (AKS) cluster.
           properties:
             apiVersion:
               description: |-
@@ -95,10 +222,10 @@ spec:
             metadata:
               type: object
             spec:
-              description: AWSKubernetesEngineSpec defines the desired state of AWSKubernetesEngine.
+              description: AzureKubernetesEngineSpec defines the desired state of AzureKubernetesEngine.
               properties:
                 dependencies:
-                  description: Dependencies defines the dependency configurations for the AWS Kubernetes Engine.
+                  description: Dependencies defines the dependency configurations for the Azure Kubernetes Engine.
                   properties:
                     certManager:
                       description: CertManager defines the cert-manager operator dependency.
@@ -193,7 +320,7 @@ spec:
                   type: object
               type: object
             status:
-              description: AWSKubernetesEngineStatus defines the observed state of AWSKubernetesEngine.
+              description: AzureKubernetesEngineStatus defines the observed state of AzureKubernetesEngine.
               properties:
                 conditions:
                   items:
@@ -259,8 +386,8 @@ spec:
               type: object
           type: object
           x-kubernetes-validations:
-            - message: AWSKubernetesEngine name must be default-awskubernetesengine
-              rule: self.metadata.name == 'default-awskubernetesengine'
+            - message: AzureKubernetesEngine name must be default-azurekubernetesengine
+              rule: self.metadata.name == 'default-azurekubernetesengine'
       served: true
       storage: true
       subresources:
@@ -734,11 +861,11 @@ spec:
         status: {}
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrole-rhai-aws-cloud-manager-role.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrole-rhai-azure-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhai-aws-cloud-manager-role
+  name: rhai-azure-cloud-manager-role
 rules:
   - apiGroups:
       - ""
@@ -827,7 +954,7 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines
+      - azurekubernetesengines
     verbs:
       - create
       - delete
@@ -839,13 +966,13 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines/finalizers
+      - azurekubernetesengines/finalizers
     verbs:
       - update
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines/status
+      - azurekubernetesengines/status
     verbs:
       - get
       - patch
@@ -2431,18 +2558,18 @@ rules:
       - watch
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrolebinding-rhai-aws-cloud-manager-rolebinding.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrolebinding-rhai-azure-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhai-aws-cloud-manager-rolebinding
+  name: rhai-azure-cloud-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhai-aws-cloud-manager-role
+  name: rhai-azure-cloud-manager-role
 subjects:
   - kind: ServiceAccount
-    name: aws-cloud-manager-operator
+    name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
 
 ---
@@ -2461,11 +2588,11 @@ subjects:
     namespace: redhat-ods-operator
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/role-aws-cloud-manager-leader-election-role.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: aws-cloud-manager-leader-election-role
+  name: azure-cloud-manager-leader-election-role
   namespace: rhai-cloudmanager-system
 rules:
   - apiGroups:
@@ -2486,19 +2613,19 @@ rules:
       - patch
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/rolebinding-aws-cloud-manager-leader-election-rolebinding.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/rolebinding-azure-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: aws-cloud-manager-leader-election-rolebinding
+  name: azure-cloud-manager-leader-election-rolebinding
   namespace: rhai-cloudmanager-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: aws-cloud-manager-leader-election-role
+  name: azure-cloud-manager-leader-election-role
 subjects:
   - kind: ServiceAccount
-    name: aws-cloud-manager-operator
+    name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
 
 ---
@@ -2542,28 +2669,28 @@ spec:
     name: rhai-operator
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/deployment-aws-cloud-manager-operator.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
-    name: aws-cloud-manager-operator
-  name: aws-cloud-manager-operator
+    name: azure-cloud-manager-operator
+  name: azure-cloud-manager-operator
   namespace: rhai-cloudmanager-system
 spec:
   replicas: 1
   selector:
     matchLabels:
       control-plane: controller-manager
-      name: aws-cloud-manager-operator
+      name: azure-cloud-manager-operator
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
-        name: aws-cloud-manager-operator
+        name: azure-cloud-manager-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2582,12 +2709,12 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - aws-cloud-manager-operator
+                        - azure-cloud-manager-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
         - args:
-            - aws
+            - azure
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=0.0.0.0:8080
             - --leader-elect
@@ -2639,7 +2766,7 @@ spec:
               memory: 1Gi
             requests:
               cpu: 100m
-              memory: 512Mi
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2650,7 +2777,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: aws-cloud-manager-operator
+      serviceAccountName: azure-cloud-manager-operator
       terminationGracePeriodSeconds: 10
 
 ---
@@ -2937,6 +3064,35 @@ metadata:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2961,7 +3117,7 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines
+      - azurekubernetesengines
     verbs:
       - get
       - create
@@ -3038,12 +3194,33 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines
+      - azurekubernetesengines
     verbs:
       - get
       - list
       - watch
       - delete
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - create
+      - patch
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3083,6 +3260,27 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rhai-pre-delete-hook
+    namespace: default
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-install-namespaces-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-install-namespaces-hook
     namespace: default
 
 ---
@@ -3194,12 +3392,12 @@ spec:
                   app.kubernetes.io/managed-by: Helm
               spec: {}
               EOF
-              echo "Creating AWSKubernetesEngine CR..."
+              echo "Creating AzureKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
-              kind: AWSKubernetesEngine
+              kind: AzureKubernetesEngine
               metadata:
-                name: default-awskubernetesengine
+                name: default-azurekubernetesengine
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm
@@ -3214,7 +3412,7 @@ spec:
                   lws:
                     configuration:
                       namespace: openshift-lws-operator
-                    managementPolicy: Unmanaged
+                    managementPolicy: Managed
                   sailOperator:
                     configuration:
                       namespace: istio-system
@@ -3346,6 +3544,10 @@ spec:
                           - name: rhai-ca-bundle
                             mountPath: /var/run/secrets/rhai
                             readOnly: true
+                service: |
+                  metadata:
+                    annotations:
+                      service.beta.kubernetes.io/port_80_health-probe_protocol: tcp
               EOF
               echo "ConfigMap used by Gateway CR 'inference-gateway' created."
               ISSUER_NAME="rhai-ca-issuer"
@@ -3391,13 +3593,13 @@ spec:
                     protocol: HTTP
                     allowedRoutes:
                       namespaces:
-                        from: All
+                        from: Same
                   - name: https
                     port: 443
                     protocol: HTTPS
                     allowedRoutes:
                       namespaces:
-                        from: All
+                        from: Same
                     tls:
                       certificateRefs:
                         - group: ''
@@ -3469,7 +3671,65 @@ spec:
               set -euo pipefail
               echo "Deleting Kserve CR 'default-kserve'..."
               kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
-              echo "Deleting AWSKubernetesEngine CR 'default-awskubernetesengine'..."
-              kubectl delete awskubernetesengine default-awskubernetesengine --ignore-not-found --timeout=300s
+              echo "Deleting AzureKubernetesEngine CR 'default-azurekubernetesengine'..."
+              kubectl delete azurekubernetesengine default-azurekubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-install-namespaces
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-install-namespaces-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: create-namespaces
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Ensuring namespace openshift-lws-operator exists..."
+              kubectl create namespace openshift-lws-operator --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace istio-system exists..."
+              kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
               echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
@@ -3188,7 +3188,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3197,7 +3196,6 @@ rules:
       - azurekubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---
@@ -3727,9 +3725,9 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Ensuring namespace openshift-lws-operator exists..."
-              kubectl create namespace openshift-lws-operator --dry-run=client -o yaml | kubectl apply -f -
-              echo "Ensuring namespace istio-system exists..."
-              kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace 'openshift-lws-operator' exists..."
+              kubectl create namespace 'openshift-lws-operator' --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace 'istio-system' exists..."
+              kubectl create namespace 'istio-system' --dry-run=client -o yaml | kubectl apply -f -
               echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
@@ -3077,6 +3077,22 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
 # Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
 apiVersion: v1
 kind: Secret

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
@@ -3032,7 +3032,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3041,7 +3040,6 @@ rules:
       - azurekubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
@@ -2922,7 +2922,19 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-delete-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -2935,7 +2947,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -2951,8 +2962,6 @@ rules:
       - infrastructure.opendatahub.io
     resources:
       - azurekubernetesengines
-      - coreweavekubernetesengines
-      - awskubernetesengines
     verbs:
       - get
       - create
@@ -3005,6 +3014,37 @@ rules:
     verbs:
       - get
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - kserves
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - azurekubernetesengines
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3015,7 +3055,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3025,6 +3064,27 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-delete-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-delete-hook
+    namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 # Certificate is namespaced to the applications namespace.
@@ -3038,7 +3098,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3062,7 +3121,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3363,4 +3421,62 @@ spec:
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
               
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-delete-crs
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-delete-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: delete-crs
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Deleting Kserve CR 'default-kserve'..."
+              kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
+              echo "Deleting AzureKubernetesEngine CR 'default-azurekubernetesengine'..."
+              kubectl delete azurekubernetesengine default-azurekubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
@@ -3032,6 +3032,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
@@ -3030,9 +3030,10 @@ rules:
       - ""
     resources:
       - namespaces
+    resourceNames:
+      - istio-system
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3041,7 +3042,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3050,7 +3050,6 @@ rules:
       - azurekubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---
@@ -3484,9 +3483,7 @@ spec:
               kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
               echo "Deleting AzureKubernetesEngine CR 'default-azurekubernetesengine'..."
               kubectl delete azurekubernetesengine default-azurekubernetesengine --ignore-not-found --timeout=300s
-              echo "Deleting namespace openshift-lws-operator..."
-              kubectl delete namespace openshift-lws-operator --ignore-not-found --timeout=60s
-              echo "Deleting namespace istio-system..."
-              kubectl delete namespace istio-system --ignore-not-found --timeout=60s
+              echo "Deleting namespace 'istio-system'..."
+              kubectl delete namespace 'istio-system' --ignore-not-found --timeout=60s
               echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
@@ -3034,6 +3034,7 @@ rules:
       - istio-system
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:
@@ -3042,6 +3043,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/namespace-rhai-cloudmanager-system.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/manager/namespace-rhai-cloudmanager-system.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -20,11 +20,11 @@ metadata:
   name: redhat-ods-operator
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: aws-cloud-manager-operator
+  name: azure-cloud-manager-operator
   namespace: rhai-cloudmanager-system
 imagePullSecrets:
   - name: rhai-pull-secret
@@ -40,21 +40,21 @@ imagePullSecrets:
   - name: rhai-pull-secret
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/crds/customresourcedefinition-awskubernetesengines.infrastructure.opendatahub.io.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/crds/customresourcedefinition-azurekubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
     helm.sh/resource-policy: keep
-  name: awskubernetesengines.infrastructure.opendatahub.io
+  name: azurekubernetesengines.infrastructure.opendatahub.io
 spec:
   group: infrastructure.opendatahub.io
   names:
-    kind: AWSKubernetesEngine
-    listKind: AWSKubernetesEngineList
-    plural: awskubernetesengines
-    singular: awskubernetesengine
+    kind: AzureKubernetesEngine
+    listKind: AzureKubernetesEngineList
+    plural: azurekubernetesengines
+    singular: azurekubernetesengine
   scope: Cluster
   versions:
     - additionalPrinterColumns:
@@ -74,8 +74,8 @@ spec:
       schema:
         openAPIV3Schema:
           description: |-
-            AWSKubernetesEngine is the Schema for the awskubernetesengines API.
-            It represents the configuration for an AWS Kubernetes Service cluster.
+            AzureKubernetesEngine is the Schema for the azurekubernetesengines API.
+            It represents the configuration for an Azure Kubernetes Service (AKS) cluster.
           properties:
             apiVersion:
               description: |-
@@ -95,10 +95,10 @@ spec:
             metadata:
               type: object
             spec:
-              description: AWSKubernetesEngineSpec defines the desired state of AWSKubernetesEngine.
+              description: AzureKubernetesEngineSpec defines the desired state of AzureKubernetesEngine.
               properties:
                 dependencies:
-                  description: Dependencies defines the dependency configurations for the AWS Kubernetes Engine.
+                  description: Dependencies defines the dependency configurations for the Azure Kubernetes Engine.
                   properties:
                     certManager:
                       description: CertManager defines the cert-manager operator dependency.
@@ -193,7 +193,7 @@ spec:
                   type: object
               type: object
             status:
-              description: AWSKubernetesEngineStatus defines the observed state of AWSKubernetesEngine.
+              description: AzureKubernetesEngineStatus defines the observed state of AzureKubernetesEngine.
               properties:
                 conditions:
                   items:
@@ -259,8 +259,8 @@ spec:
               type: object
           type: object
           x-kubernetes-validations:
-            - message: AWSKubernetesEngine name must be default-awskubernetesengine
-              rule: self.metadata.name == 'default-awskubernetesengine'
+            - message: AzureKubernetesEngine name must be default-azurekubernetesengine
+              rule: self.metadata.name == 'default-azurekubernetesengine'
       served: true
       storage: true
       subresources:
@@ -734,11 +734,11 @@ spec:
         status: {}
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrole-rhai-aws-cloud-manager-role.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrole-rhai-azure-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhai-aws-cloud-manager-role
+  name: rhai-azure-cloud-manager-role
 rules:
   - apiGroups:
       - ""
@@ -827,7 +827,7 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines
+      - azurekubernetesengines
     verbs:
       - create
       - delete
@@ -839,13 +839,13 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines/finalizers
+      - azurekubernetesengines/finalizers
     verbs:
       - update
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines/status
+      - azurekubernetesengines/status
     verbs:
       - get
       - patch
@@ -2431,18 +2431,18 @@ rules:
       - watch
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrolebinding-rhai-aws-cloud-manager-rolebinding.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrolebinding-rhai-azure-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhai-aws-cloud-manager-rolebinding
+  name: rhai-azure-cloud-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhai-aws-cloud-manager-role
+  name: rhai-azure-cloud-manager-role
 subjects:
   - kind: ServiceAccount
-    name: aws-cloud-manager-operator
+    name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
 
 ---
@@ -2461,11 +2461,11 @@ subjects:
     namespace: redhat-ods-operator
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/role-aws-cloud-manager-leader-election-role.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: aws-cloud-manager-leader-election-role
+  name: azure-cloud-manager-leader-election-role
   namespace: rhai-cloudmanager-system
 rules:
   - apiGroups:
@@ -2486,19 +2486,19 @@ rules:
       - patch
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/rolebinding-aws-cloud-manager-leader-election-rolebinding.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/rolebinding-azure-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: aws-cloud-manager-leader-election-rolebinding
+  name: azure-cloud-manager-leader-election-rolebinding
   namespace: rhai-cloudmanager-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: aws-cloud-manager-leader-election-role
+  name: azure-cloud-manager-leader-election-role
 subjects:
   - kind: ServiceAccount
-    name: aws-cloud-manager-operator
+    name: azure-cloud-manager-operator
     namespace: rhai-cloudmanager-system
 
 ---
@@ -2542,28 +2542,28 @@ spec:
     name: rhai-operator
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/deployment-aws-cloud-manager-operator.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/azure/manager/deployment-azure-cloud-manager-operator.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
-    name: aws-cloud-manager-operator
-  name: aws-cloud-manager-operator
+    name: azure-cloud-manager-operator
+  name: azure-cloud-manager-operator
   namespace: rhai-cloudmanager-system
 spec:
   replicas: 1
   selector:
     matchLabels:
       control-plane: controller-manager
-      name: aws-cloud-manager-operator
+      name: azure-cloud-manager-operator
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
-        name: aws-cloud-manager-operator
+        name: azure-cloud-manager-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2582,12 +2582,12 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - aws-cloud-manager-operator
+                        - azure-cloud-manager-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
         - args:
-            - aws
+            - azure
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=0.0.0.0:8080
             - --leader-elect
@@ -2639,7 +2639,7 @@ spec:
               memory: 1Gi
             requests:
               cpu: 100m
-              memory: 512Mi
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2650,7 +2650,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: aws-cloud-manager-operator
+      serviceAccountName: azure-cloud-manager-operator
       terminationGracePeriodSeconds: 10
 
 ---
@@ -2961,7 +2961,7 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines
+      - azurekubernetesengines
     verbs:
       - get
       - create
@@ -3027,6 +3027,15 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
       - components.platform.opendatahub.io
     resources:
       - kserves
@@ -3038,7 +3047,7 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines
+      - azurekubernetesengines
     verbs:
       - get
       - list
@@ -3194,12 +3203,12 @@ spec:
                   app.kubernetes.io/managed-by: Helm
               spec: {}
               EOF
-              echo "Creating AWSKubernetesEngine CR..."
+              echo "Creating AzureKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
-              kind: AWSKubernetesEngine
+              kind: AzureKubernetesEngine
               metadata:
-                name: default-awskubernetesengine
+                name: default-azurekubernetesengine
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm
@@ -3346,6 +3355,10 @@ spec:
                           - name: rhai-ca-bundle
                             mountPath: /var/run/secrets/rhai
                             readOnly: true
+                service: |
+                  metadata:
+                    annotations:
+                      service.beta.kubernetes.io/port_80_health-probe_protocol: tcp
               EOF
               echo "ConfigMap used by Gateway CR 'inference-gateway' created."
               ISSUER_NAME="rhai-ca-issuer"
@@ -3391,13 +3404,13 @@ spec:
                     protocol: HTTP
                     allowedRoutes:
                       namespaces:
-                        from: All
+                        from: Same
                   - name: https
                     port: 443
                     protocol: HTTPS
                     allowedRoutes:
                       namespaces:
-                        from: All
+                        from: Same
                     tls:
                       certificateRefs:
                         - group: ''
@@ -3469,7 +3482,11 @@ spec:
               set -euo pipefail
               echo "Deleting Kserve CR 'default-kserve'..."
               kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
-              echo "Deleting AWSKubernetesEngine CR 'default-awskubernetesengine'..."
-              kubectl delete awskubernetesengine default-awskubernetesengine --ignore-not-found --timeout=300s
+              echo "Deleting AzureKubernetesEngine CR 'default-azurekubernetesengine'..."
+              kubectl delete azurekubernetesengine default-azurekubernetesengine --ignore-not-found --timeout=300s
+              echo "Deleting namespace openshift-lws-operator..."
+              kubectl delete namespace openshift-lws-operator --ignore-not-found --timeout=60s
+              echo "Deleting namespace istio-system..."
+              kubectl delete namespace istio-system --ignore-not-found --timeout=60s
               echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
@@ -3032,7 +3032,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3041,7 +3040,6 @@ rules:
       - azurekubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
@@ -2922,7 +2922,19 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-delete-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -2935,7 +2947,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -2951,8 +2962,6 @@ rules:
       - infrastructure.opendatahub.io
     resources:
       - azurekubernetesengines
-      - coreweavekubernetesengines
-      - awskubernetesengines
     verbs:
       - get
       - create
@@ -3005,6 +3014,37 @@ rules:
     verbs:
       - get
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - kserves
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - azurekubernetesengines
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3015,7 +3055,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3025,6 +3064,27 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-delete-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-delete-hook
+    namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 # Certificate is namespaced to the applications namespace.
@@ -3038,7 +3098,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3062,7 +3121,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3363,4 +3421,62 @@ spec:
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
               
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-delete-crs
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-delete-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: delete-crs
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Deleting Kserve CR 'default-kserve'..."
+              kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
+              echo "Deleting AzureKubernetesEngine CR 'default-azurekubernetesengine'..."
+              kubectl delete azurekubernetesengine default-azurekubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
@@ -3032,6 +3032,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
@@ -2922,7 +2922,19 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-delete-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -2935,7 +2947,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -2951,8 +2962,6 @@ rules:
       - infrastructure.opendatahub.io
     resources:
       - azurekubernetesengines
-      - coreweavekubernetesengines
-      - awskubernetesengines
     verbs:
       - get
       - create
@@ -2995,6 +3004,37 @@ rules:
       - patch
       - update
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - kserves
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - azurekubernetesengines
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3005,7 +3045,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3015,6 +3054,27 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-delete-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-delete-hook
+    namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 # Certificate is namespaced to the applications namespace.
@@ -3028,7 +3088,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3060,7 +3119,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3359,4 +3417,62 @@ spec:
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
               
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-delete-crs
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-delete-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: delete-crs
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Deleting Kserve CR 'default-kserve'..."
+              kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
+              echo "Deleting AzureKubernetesEngine CR 'default-azurekubernetesengine'..."
+              kubectl delete azurekubernetesengine default-azurekubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
@@ -3022,7 +3022,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3031,7 +3030,6 @@ rules:
       - azurekubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
@@ -3022,6 +3022,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -3175,6 +3175,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -32,12 +32,6 @@ kind: Namespace
 metadata:
   name: cert-manager
 ---
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system
----
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -3042,8 +3036,49 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-delete-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3055,7 +3090,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3071,8 +3105,6 @@ rules:
       - infrastructure.opendatahub.io
     resources:
       - azurekubernetesengines
-      - coreweavekubernetesengines
-      - awskubernetesengines
     verbs:
       - get
       - create
@@ -3125,6 +3157,58 @@ rules:
     verbs:
       - get
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - kserves
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - azurekubernetesengines
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - create
+      - patch
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3135,7 +3219,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3145,6 +3228,48 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-delete-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-delete-hook
+    namespace: default
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-install-namespaces-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-install-namespaces-hook
+    namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 # Certificate is namespaced to the applications namespace.
@@ -3158,7 +3283,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3182,7 +3306,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3480,4 +3603,118 @@ spec:
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
               
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-delete-crs
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-delete-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: delete-crs
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Deleting Kserve CR 'default-kserve'..."
+              kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
+              echo "Deleting AzureKubernetesEngine CR 'default-azurekubernetesengine'..."
+              kubectl delete azurekubernetesengine default-azurekubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-install-namespaces
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-install-namespaces-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: create-namespaces
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Ensuring namespace istio-system exists..."
+              kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
+              echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -3175,7 +3175,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3184,7 +3183,6 @@ rules:
       - azurekubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---
@@ -3714,7 +3712,7 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Ensuring namespace istio-system exists..."
-              kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace 'istio-system' exists..."
+              kubectl create namespace 'istio-system' --dry-run=client -o yaml | kubectl apply -f -
               echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -3064,6 +3064,22 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
 # Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
 apiVersion: v1
 kind: Secret

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2924,7 +2924,19 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-delete-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -2937,7 +2949,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -2953,8 +2964,6 @@ rules:
       - infrastructure.opendatahub.io
     resources:
       - azurekubernetesengines
-      - coreweavekubernetesengines
-      - awskubernetesengines
     verbs:
       - get
       - create
@@ -3007,6 +3016,37 @@ rules:
     verbs:
       - get
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - kserves
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - azurekubernetesengines
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3017,7 +3057,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3027,6 +3066,27 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-delete-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-delete-hook
+    namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 # Certificate is namespaced to the applications namespace.
@@ -3040,7 +3100,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3064,7 +3123,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3362,4 +3420,62 @@ spec:
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
               
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-delete-crs
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-delete-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: delete-crs
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Deleting Kserve CR 'default-kserve'..."
+              kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
+              echo "Deleting AzureKubernetesEngine CR 'default-azurekubernetesengine'..."
+              kubectl delete azurekubernetesengine default-azurekubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -3034,6 +3034,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -3034,7 +3034,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3043,7 +3042,6 @@ rules:
       - azurekubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
@@ -2922,7 +2922,19 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-delete-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -2935,7 +2947,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -2951,8 +2962,6 @@ rules:
       - infrastructure.opendatahub.io
     resources:
       - azurekubernetesengines
-      - coreweavekubernetesengines
-      - awskubernetesengines
     verbs:
       - get
       - create
@@ -2995,6 +3004,37 @@ rules:
       - patch
       - update
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - kserves
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - azurekubernetesengines
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3005,7 +3045,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3014,6 +3053,27 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
+    namespace: default
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-delete-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-delete-hook
     namespace: default
 
 ---
@@ -3267,4 +3327,62 @@ spec:
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
               
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-delete-crs
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-delete-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: delete-crs
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Deleting Kserve CR 'default-kserve'..."
+              kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
+              echo "Deleting AzureKubernetesEngine CR 'default-azurekubernetesengine'..."
+              kubectl delete azurekubernetesengine default-azurekubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
@@ -3022,7 +3022,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3031,7 +3030,6 @@ rules:
       - azurekubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
@@ -3022,6 +3022,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
@@ -3188,6 +3188,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/namespace-rhai-cloudmanager-system.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/manager/namespace-rhai-cloudmanager-system.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -20,12 +20,35 @@ metadata:
   name: redhat-ods-operator
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+---
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/serviceaccount-coreweave-cloud-manager-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: aws-cloud-manager-operator
+  name: coreweave-cloud-manager-operator
   namespace: rhai-cloudmanager-system
+imagePullSecrets:
+  - name: rhai-pull-secret
+
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+# TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: llmisvc-controller-manager
+  namespace: redhat-ods-applications
 imagePullSecrets:
   - name: rhai-pull-secret
 
@@ -40,21 +63,125 @@ imagePullSecrets:
   - name: rhai-pull-secret
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/crds/customresourcedefinition-awskubernetesengines.infrastructure.opendatahub.io.yaml
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: cert-manager-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: cert-manager
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: openshift-lws-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: istio-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/crds/customresourcedefinition-coreweavekubernetesengines.infrastructure.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
     helm.sh/resource-policy: keep
-  name: awskubernetesengines.infrastructure.opendatahub.io
+  name: coreweavekubernetesengines.infrastructure.opendatahub.io
 spec:
   group: infrastructure.opendatahub.io
   names:
-    kind: AWSKubernetesEngine
-    listKind: AWSKubernetesEngineList
-    plural: awskubernetesengines
-    singular: awskubernetesengine
+    kind: CoreWeaveKubernetesEngine
+    listKind: CoreWeaveKubernetesEngineList
+    plural: coreweavekubernetesengines
+    singular: coreweavekubernetesengine
   scope: Cluster
   versions:
     - additionalPrinterColumns:
@@ -74,8 +201,8 @@ spec:
       schema:
         openAPIV3Schema:
           description: |-
-            AWSKubernetesEngine is the Schema for the awskubernetesengines API.
-            It represents the configuration for an AWS Kubernetes Service cluster.
+            CoreWeaveKubernetesEngine is the Schema for the CoreWeaveKubernetesEngines API.
+            It represents the configuration for a CoreWeave Kubernetes Engine cluster.
           properties:
             apiVersion:
               description: |-
@@ -95,10 +222,10 @@ spec:
             metadata:
               type: object
             spec:
-              description: AWSKubernetesEngineSpec defines the desired state of AWSKubernetesEngine.
+              description: CoreWeaveKubernetesEngineSpec defines the desired state of CoreWeaveKubernetesEngine.
               properties:
                 dependencies:
-                  description: Dependencies defines the dependency configurations for the AWS Kubernetes Engine.
+                  description: Dependencies defines the dependency configurations for the CoreWeave Kubernetes Engine.
                   properties:
                     certManager:
                       description: CertManager defines the cert-manager operator dependency.
@@ -193,7 +320,7 @@ spec:
                   type: object
               type: object
             status:
-              description: AWSKubernetesEngineStatus defines the observed state of AWSKubernetesEngine.
+              description: CoreWeaveKubernetesEngineStatus defines the observed state of CoreWeaveKubernetesEngine.
               properties:
                 conditions:
                   items:
@@ -259,8 +386,8 @@ spec:
               type: object
           type: object
           x-kubernetes-validations:
-            - message: AWSKubernetesEngine name must be default-awskubernetesengine
-              rule: self.metadata.name == 'default-awskubernetesengine'
+            - message: CoreWeaveKubernetesEngine name must be default-coreweavekubernetesengine
+              rule: self.metadata.name == 'default-coreweavekubernetesengine'
       served: true
       storage: true
       subresources:
@@ -734,11 +861,11 @@ spec:
         status: {}
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrole-rhai-aws-cloud-manager-role.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrole-rhai-coreweave-cloud-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: rhai-aws-cloud-manager-role
+  name: rhai-coreweave-cloud-manager-role
 rules:
   - apiGroups:
       - ""
@@ -827,7 +954,7 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines
+      - coreweavekubernetesengines
     verbs:
       - create
       - delete
@@ -839,13 +966,13 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines/finalizers
+      - coreweavekubernetesengines/finalizers
     verbs:
       - update
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines/status
+      - coreweavekubernetesengines/status
     verbs:
       - get
       - patch
@@ -2431,18 +2558,18 @@ rules:
       - watch
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrolebinding-rhai-aws-cloud-manager-rolebinding.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrolebinding-rhai-coreweave-cloud-manager-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhai-aws-cloud-manager-rolebinding
+  name: rhai-coreweave-cloud-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhai-aws-cloud-manager-role
+  name: rhai-coreweave-cloud-manager-role
 subjects:
   - kind: ServiceAccount
-    name: aws-cloud-manager-operator
+    name: coreweave-cloud-manager-operator
     namespace: rhai-cloudmanager-system
 
 ---
@@ -2461,11 +2588,11 @@ subjects:
     namespace: redhat-ods-operator
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/role-aws-cloud-manager-leader-election-role.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/role-coreweave-cloud-manager-leader-election-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: aws-cloud-manager-leader-election-role
+  name: coreweave-cloud-manager-leader-election-role
   namespace: rhai-cloudmanager-system
 rules:
   - apiGroups:
@@ -2486,19 +2613,19 @@ rules:
       - patch
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/rolebinding-aws-cloud-manager-leader-election-rolebinding.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/rolebinding-coreweave-cloud-manager-leader-election-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: aws-cloud-manager-leader-election-rolebinding
+  name: coreweave-cloud-manager-leader-election-rolebinding
   namespace: rhai-cloudmanager-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: aws-cloud-manager-leader-election-role
+  name: coreweave-cloud-manager-leader-election-role
 subjects:
   - kind: ServiceAccount
-    name: aws-cloud-manager-operator
+    name: coreweave-cloud-manager-operator
     namespace: rhai-cloudmanager-system
 
 ---
@@ -2542,28 +2669,28 @@ spec:
     name: rhai-operator
 
 ---
-# Source: rhai-on-xks-chart/templates/cloudmanager/aws/manager/deployment-aws-cloud-manager-operator.yaml
+# Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/manager/deployment-coreweave-cloud-manager-operator.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
-    name: aws-cloud-manager-operator
-  name: aws-cloud-manager-operator
+    name: coreweave-cloud-manager-operator
+  name: coreweave-cloud-manager-operator
   namespace: rhai-cloudmanager-system
 spec:
   replicas: 1
   selector:
     matchLabels:
       control-plane: controller-manager
-      name: aws-cloud-manager-operator
+      name: coreweave-cloud-manager-operator
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
-        name: aws-cloud-manager-operator
+        name: coreweave-cloud-manager-operator
     spec:
       affinity:
         nodeAffinity:
@@ -2582,12 +2709,12 @@ spec:
                     - key: name
                       operator: In
                       values:
-                        - aws-cloud-manager-operator
+                        - coreweave-cloud-manager-operator
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
         - args:
-            - aws
+            - coreweave
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=0.0.0.0:8080
             - --leader-elect
@@ -2639,7 +2766,7 @@ spec:
               memory: 1Gi
             requests:
               cpu: 100m
-              memory: 512Mi
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -2650,7 +2777,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: aws-cloud-manager-operator
+      serviceAccountName: coreweave-cloud-manager-operator
       terminationGracePeriodSeconds: 10
 
 ---
@@ -2937,6 +3064,35 @@ metadata:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2961,7 +3117,7 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines
+      - coreweavekubernetesengines
     verbs:
       - get
       - create
@@ -3038,12 +3194,33 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - awskubernetesengines
+      - coreweavekubernetesengines
     verbs:
       - get
       - list
       - watch
       - delete
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - create
+      - patch
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3083,6 +3260,27 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rhai-pre-delete-hook
+    namespace: default
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-install-namespaces-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-install-namespaces-hook
     namespace: default
 
 ---
@@ -3194,12 +3392,12 @@ spec:
                   app.kubernetes.io/managed-by: Helm
               spec: {}
               EOF
-              echo "Creating AWSKubernetesEngine CR..."
+              echo "Creating CoreWeaveKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
-              kind: AWSKubernetesEngine
+              kind: CoreWeaveKubernetesEngine
               metadata:
-                name: default-awskubernetesengine
+                name: default-coreweavekubernetesengine
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm
@@ -3214,7 +3412,7 @@ spec:
                   lws:
                     configuration:
                       namespace: openshift-lws-operator
-                    managementPolicy: Unmanaged
+                    managementPolicy: Managed
                   sailOperator:
                     configuration:
                       namespace: istio-system
@@ -3391,13 +3589,13 @@ spec:
                     protocol: HTTP
                     allowedRoutes:
                       namespaces:
-                        from: All
+                        from: Same
                   - name: https
                     port: 443
                     protocol: HTTPS
                     allowedRoutes:
                       namespaces:
-                        from: All
+                        from: Same
                     tls:
                       certificateRefs:
                         - group: ''
@@ -3469,7 +3667,65 @@ spec:
               set -euo pipefail
               echo "Deleting Kserve CR 'default-kserve'..."
               kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
-              echo "Deleting AWSKubernetesEngine CR 'default-awskubernetesengine'..."
-              kubectl delete awskubernetesengine default-awskubernetesengine --ignore-not-found --timeout=300s
+              echo "Deleting CoreWeaveKubernetesEngine CR 'default-coreweavekubernetesengine'..."
+              kubectl delete coreweavekubernetesengine default-coreweavekubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-install-namespaces
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-install-namespaces-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: create-namespaces
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Ensuring namespace openshift-lws-operator exists..."
+              kubectl create namespace openshift-lws-operator --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace istio-system exists..."
+              kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
               echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
@@ -3188,7 +3188,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3197,7 +3196,6 @@ rules:
       - coreweavekubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---
@@ -3723,9 +3721,9 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Ensuring namespace openshift-lws-operator exists..."
-              kubectl create namespace openshift-lws-operator --dry-run=client -o yaml | kubectl apply -f -
-              echo "Ensuring namespace istio-system exists..."
-              kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace 'openshift-lws-operator' exists..."
+              kubectl create namespace 'openshift-lws-operator' --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace 'istio-system' exists..."
+              kubectl create namespace 'istio-system' --dry-run=client -o yaml | kubectl apply -f -
               echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
@@ -3077,6 +3077,22 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
 # Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
 apiVersion: v1
 kind: Secret

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
@@ -3032,7 +3032,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3041,7 +3040,6 @@ rules:
       - coreweavekubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
@@ -2922,7 +2922,19 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-delete-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -2935,7 +2947,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -2950,9 +2961,7 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines
       - coreweavekubernetesengines
-      - awskubernetesengines
     verbs:
       - get
       - create
@@ -3005,6 +3014,37 @@ rules:
     verbs:
       - get
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - kserves
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - coreweavekubernetesengines
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3015,7 +3055,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3025,6 +3064,27 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-delete-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-delete-hook
+    namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 # Certificate is namespaced to the applications namespace.
@@ -3038,7 +3098,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3062,7 +3121,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3362,4 +3420,62 @@ spec:
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
               
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-delete-crs
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-delete-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: delete-crs
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Deleting Kserve CR 'default-kserve'..."
+              kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
+              echo "Deleting CoreWeaveKubernetesEngine CR 'default-coreweavekubernetesengine'..."
+              kubectl delete coreweavekubernetesengine default-coreweavekubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
@@ -3032,6 +3032,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -3175,6 +3175,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -3175,7 +3175,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3184,7 +3183,6 @@ rules:
       - coreweavekubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---
@@ -3710,7 +3708,7 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Ensuring namespace istio-system exists..."
-              kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace 'istio-system' exists..."
+              kubectl create namespace 'istio-system' --dry-run=client -o yaml | kubectl apply -f -
               echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -32,12 +32,6 @@ kind: Namespace
 metadata:
   name: cert-manager
 ---
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system
----
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/serviceaccount-coreweave-cloud-manager-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -3042,8 +3036,49 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-delete-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3055,7 +3090,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3070,9 +3104,7 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines
       - coreweavekubernetesengines
-      - awskubernetesengines
     verbs:
       - get
       - create
@@ -3125,6 +3157,58 @@ rules:
     verbs:
       - get
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - kserves
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - coreweavekubernetesengines
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - create
+      - patch
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3135,7 +3219,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3145,6 +3228,48 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-delete-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-delete-hook
+    namespace: default
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-install-namespaces-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-install-namespaces-hook
+    namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 # Certificate is namespaced to the applications namespace.
@@ -3158,7 +3283,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3182,7 +3306,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3476,4 +3599,118 @@ spec:
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
               
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-delete-crs
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-delete-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: delete-crs
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Deleting Kserve CR 'default-kserve'..."
+              kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
+              echo "Deleting CoreWeaveKubernetesEngine CR 'default-coreweavekubernetesengine'..."
+              kubectl delete coreweavekubernetesengine default-coreweavekubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-install-namespaces
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-install-namespaces-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: create-namespaces
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Ensuring namespace istio-system exists..."
+              kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
+              echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -3064,6 +3064,22 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
 # Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
 apiVersion: v1
 kind: Secret

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -2922,7 +2922,19 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-delete-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -2935,7 +2947,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -2950,9 +2961,7 @@ rules:
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
-      - azurekubernetesengines
       - coreweavekubernetesengines
-      - awskubernetesengines
     verbs:
       - get
       - create
@@ -3005,6 +3014,37 @@ rules:
     verbs:
       - get
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - kserves
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - coreweavekubernetesengines
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3015,7 +3055,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3025,6 +3064,27 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-delete-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-delete-hook
+    namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 # Certificate is namespaced to the applications namespace.
@@ -3038,7 +3098,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3062,7 +3121,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3356,4 +3414,62 @@ spec:
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
               
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-delete-crs
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-delete-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: delete-crs
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Deleting Kserve CR 'default-kserve'..."
+              kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
+              echo "Deleting CoreWeaveKubernetesEngine CR 'default-coreweavekubernetesengine'..."
+              kubectl delete coreweavekubernetesengine default-coreweavekubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -3032,7 +3032,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3041,7 +3040,6 @@ rules:
       - coreweavekubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -3032,6 +3032,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -3188,6 +3188,7 @@ rules:
       - kserves
     verbs:
       - get
+      - list
       - watch
       - delete
   - apiGroups:

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -3188,7 +3188,6 @@ rules:
       - kserves
     verbs:
       - get
-      - list
       - watch
       - delete
   - apiGroups:
@@ -3197,7 +3196,6 @@ rules:
       - azurekubernetesengines
     verbs:
       - get
-      - list
       - watch
       - delete
 ---
@@ -3727,9 +3725,9 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Ensuring namespace custom-lws exists..."
-              kubectl create namespace custom-lws --dry-run=client -o yaml | kubectl apply -f -
-              echo "Ensuring namespace custom-istio exists..."
-              kubectl create namespace custom-istio --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace 'custom-lws' exists..."
+              kubectl create namespace 'custom-lws' --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace 'custom-istio' exists..."
+              kubectl create namespace 'custom-istio' --dry-run=client -o yaml | kubectl apply -f -
               echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -32,12 +32,6 @@ kind: Namespace
 metadata:
   name: cert-manager
 ---
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: custom-istio
----
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -140,6 +134,19 @@ kind: Secret
 metadata:
   name: rhai-pull-secret
   namespace: cert-manager
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: custom-lws
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -3042,8 +3049,49 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-delete-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3055,7 +3103,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3071,8 +3118,6 @@ rules:
       - infrastructure.opendatahub.io
     resources:
       - azurekubernetesengines
-      - coreweavekubernetesengines
-      - awskubernetesengines
     verbs:
       - get
       - create
@@ -3125,6 +3170,58 @@ rules:
     verbs:
       - get
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - kserves
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - infrastructure.opendatahub.io
+    resources:
+      - azurekubernetesengines
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - create
+      - patch
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3135,7 +3232,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3145,6 +3241,48 @@ subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
     namespace: default
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-delete-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-delete-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-delete-hook
+    namespace: default
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-install-namespaces-hook
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-install-namespaces-hook
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-install-namespaces-hook
+    namespace: default
+
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 # Certificate is namespaced to the applications namespace.
@@ -3158,7 +3296,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -3182,7 +3319,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3276,7 +3412,7 @@ spec:
                   lws:
                     configuration:
                       namespace: custom-lws
-                    managementPolicy: Unmanaged
+                    managementPolicy: Managed
                   sailOperator:
                     configuration:
                       namespace: custom-istio
@@ -3480,4 +3616,120 @@ spec:
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
               
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-delete-crs
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-delete-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: delete-crs
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Deleting Kserve CR 'default-kserve'..."
+              kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
+              echo "Deleting AzureKubernetesEngine CR 'default-azurekubernetesengine'..."
+              kubectl delete azurekubernetesengine default-azurekubernetesengine --ignore-not-found --timeout=300s
+              echo "Done."
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-install-namespaces
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-install-namespaces-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: create-namespaces
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Ensuring namespace custom-lws exists..."
+              kubectl create namespace custom-lws --dry-run=client -o yaml | kubectl apply -f -
+              echo "Ensuring namespace custom-istio exists..."
+              kubectl create namespace custom-istio --dry-run=client -o yaml | kubectl apply -f -
+              echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -3077,6 +3077,22 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
 # Source: rhai-on-xks-chart/templates/hooks/pre-install-namespaces-rbac.yaml
 apiVersion: v1
 kind: Secret

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -7,6 +7,12 @@ installCRDs: true
 # Common labels applied to all resources
 labels: {}
 
+# Behavior on helm uninstall
+uninstall:
+  # Delete dependency namespaces (e.g. istio-system) created by pre-install hooks.
+  # Disabled by default: these namespaces may contain user workloads.
+  cleanupNamespaces: false
+
 # RHAI Operator configuration
 rhaiOperator:
   # Operator namespace

--- a/scripts/snapshot-config.yaml
+++ b/scripts/snapshot-config.yaml
@@ -88,7 +88,19 @@ charts:
           - rhaiOperator.namespace=rhai-operator
           - rhaiOperator.applicationsNamespace=rhai-applications
           - azure.kubernetesEngine.spec.dependencies.lws.configuration.namespace=custom-lws
+          - azure.kubernetesEngine.spec.dependencies.lws.managementPolicy=Managed
           - azure.kubernetesEngine.spec.dependencies.sailOperator.configuration.namespace=custom-istio
+
+      - name: azure-with-cleanup-namespaces
+        setFlags:
+          - azure.enabled=true
+          - uninstall.cleanupNamespaces=true
+
+      - name: azure-with-all-deps-managed
+        setFlags:
+          - azure.enabled=true
+          - imagePullSecret.dockerConfigJson=testauth
+          - azure.kubernetesEngine.spec.dependencies.lws.managementPolicy=Managed
 
       - name: azure-with-related-images
         setFlags:
@@ -136,6 +148,12 @@ charts:
           - coreweave.enabled=true
           - imagePullSecret.dockerConfigJson=testauth
 
+      - name: coreweave-with-all-deps-managed
+        setFlags:
+          - coreweave.enabled=true
+          - imagePullSecret.dockerConfigJson=testauth
+          - coreweave.kubernetesEngine.spec.dependencies.lws.managementPolicy=Managed
+
       - name: coreweave-with-allowed-routes-selector
         setFlags:
           - coreweave.enabled=true
@@ -150,6 +168,12 @@ charts:
         setFlags:
           - aws.enabled=true
           - imagePullSecret.dockerConfigJson=testauth
+
+      - name: aws-with-all-deps-managed
+        setFlags:
+          - aws.enabled=true
+          - imagePullSecret.dockerConfigJson=testauth
+          - aws.kubernetesEngine.spec.dependencies.lws.managementPolicy=Managed
 
       - name: aws-with-allowed-routes-all
         setFlags:


### PR DESCRIPTION
This PR depends on https://github.com/opendatahub-io/opendatahub-operator/pull/3591 to be merged

## Description

- Add a `pre-delete` Helm hook that deletes Custom Resources (Kserve, KubernetesEngine CRs) before chart uninstall, with optional namespace cleanup via `uninstall.cleanupNamespaces`
- Centralize provider and component CR definitions into a registry pattern (`_crs-definitions.tpl`), eliminating per-provider duplication in install/uninstall templates and making new providers a single-entry addition
- Add pre-install namespace creation hook for managed dependency namespaces with pull secret support
- Expand e2e verification script (`verify.sh`) into a full lifecycle test harness covering install, verify, uninstall, and post-uninstall cleanup validation
- Add new snapshot test cases for all-deps-managed and cleanup-namespaces scenarios

Jira task: https://issues.redhat.com/browse/RHOAIENG-65198

## Has it been tested?

- [ ] Installed on a real cluster to verify the changes

## Merge criteria

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hook-based namespace setup plus pre-delete cleanup of selected custom resources.
  * Added optional image pull secret handling across install and verification flows.
  * Introduced `uninstall.cleanupNamespaces` to control whether dependency namespaces are removed on uninstall.
* **Bug Fixes**
  * Improved Helm verification with selectable, ordered tests; better diagnostics; and recovery when releases are in broken states.
  * Strengthened cloud/provider selection and custom resource enablement logic.
* **Documentation**
  * Updated chart guidance and value documentation for CR metadata/templating contracts.
* **Tests**
  * Updated chart snapshots and verification suite coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->