### PR TITLE
fix: remove namespace from istio resource, as it is a cluster resource

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -174,7 +174,6 @@ apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: default
-  namespace: istio-system
 spec:
   namespace: istio-system
   version: v1.27-latest

--- a/charts/dependencies/sail-operator/templates/istio.yaml
+++ b/charts/dependencies/sail-operator/templates/istio.yaml
@@ -2,7 +2,6 @@ apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: default
-  namespace: {{ .Values.namespace }}
 spec:
   namespace: {{ .Values.namespace }}
   version: v1.27-latest

--- a/charts/dependencies/sail-operator/test/snapshots/default.snap.yaml
+++ b/charts/dependencies/sail-operator/test/snapshots/default.snap.yaml
@@ -563,7 +563,6 @@ apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: default
-  namespace: istio-system
 spec:
   namespace: istio-system
   version: v1.27-latest


### PR DESCRIPTION
Istio resource is cluster wide: https://github.com/opendatahub-io/odh-gitops/blob/5fe2714d0ecaf5fafaf414952caf521ea9ebdaaf/charts/dependencies/sail-operator/crds/customresourcedefinition-istios-sailoperator-io.yaml#L1-L16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the generated Istio resource so the namespace is now set in the correct place.
  * Updated the rendered output to include the expected resource name and remove an outdated namespace entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->