### PR TITLE
RHOAIENG-73747: harden xKS chart test workflow authorization

### DIFF
--- a/.github/workflows/rhai-on-xks-chart-test.yaml
+++ b/.github/workflows/rhai-on-xks-chart-test.yaml
@@ -15,16 +15,48 @@ permissions:
 
 jobs:
   e2e-test:
-    if: >-
-      github.event_name == 'push' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'run-xks-e2e') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-xks-e2e'))
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         cloud_provider: [azure, coreweave, aws]
     steps:
+      - name: Check authorization
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-xks-e2e') }}
+        run: |
+          TRUSTED_BOTS=("github-actions[bot]" "red-hat-konflux[bot]" "jira-autofix[bot]")
+
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            echo "Push to main — running automatically"
+            exit 0
+          fi
+          if [[ "$AUTHOR_ASSOCIATION" =~ ^(OWNER|MEMBER|COLLABORATOR)$ ]]; then
+            echo "Trusted contributor — running automatically"
+            exit 0
+          fi
+          for bot in "${TRUSTED_BOTS[@]}"; do
+            if [[ "$AUTHOR_LOGIN" == "$bot" ]]; then
+              echo "Trusted bot — running automatically"
+              exit 0
+            fi
+          done
+          if [[ "$EVENT_ACTION" == "labeled" && ( "$LABEL_NAME" == "lgtm" || "$LABEL_NAME" == "approved" ) ]]; then
+            echo "Reviewer approval ($LABEL_NAME) — running automatically"
+            exit 0
+          fi
+          if [[ "$HAS_LABEL" == "true" ]]; then
+            echo "External contributor — approved via 'run-xks-e2e' label"
+            exit 0
+          fi
+          echo "::error::xKS e2e tests required. A maintainer must add the 'run-xks-e2e' label after reviewing the code."
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
## Description

This PR replaces the job-level `if:` label gate in `rhai-on-xks-chart-test.yaml` with an in-job "Check authorization" step.

A job-level `if:` has two properties worth naming directly:

- A skipped job and a passing job report the same status. An unauthorized PR's job skipped, so its required check passed.
- The `run-xks-e2e` label stays on the PR through `synchronize` events. It also authorizes commits pushed after the label was added.

[RHOAIENG-58789](https://redhat.atlassian.net/browse/RHOAIENG-58789) built a hardened pattern for this in opendatahub-operator's xKS workflows first (opendatahub-operator#3743, opendatahub-operator#3767). This PR brings that pattern to odh-gitops, the third workflow named in [RHOAIENG-58789](https://redhat.atlassian.net/browse/RHOAIENG-58789)'s original scope.

The new step runs before checkout. It trusts:

- `OWNER`/`MEMBER`/`COLLABORATOR`, via `author_association`.
- `github-actions[bot]`, `red-hat-konflux[bot]`, and `jira-autofix[bot]`, by login. `author_association` reports these as `CONTRIBUTOR` or `NONE`. Checked against PRs in this repo (#119, #107, #103).
- `lgtm` or `approved`, at the exact `labeled` event.
- `run-xks-e2e`, whenever it's present on the PR, not only at the `labeled` event.

Everyone else fails the step. An unauthorized run now exits 1, a real failing check.

Accepting `run-xks-e2e` whenever present reopens the `synchronize` behavior described above, for external contributors specifically. opendatahub-operator#3767 made the same choice: `author_association` also reports org members with private visibility as `CONTRIBUTOR`, and that false negative affected more PRs than the `synchronize` behavior did.

This workflow also triggers on `push` to `main`, which opendatahub-operator's xKS workflows don't. I added an explicit `push` branch so post-merge runs stay auto-trusted.

GitHub context values in the shell block are read via `env:`, for CWE-78 defense in depth.

Merge-commit checkout (opendatahub-operator's `get-merge-commit` pattern) isn't part of this PR. GitHub's pwn-request guidance and the actions/checkout v7 changelog treat head-SHA and merge-commit checkout as equally unsafe without an authorization gate. It improves test fidelity, not security.

Jira task: [RHOAIENG-73747](https://redhat.atlassian.net/browse/RHOAIENG-73747)

## Has it been tested?

This is a workflow-only change. There's no local harness for `pull_request_target` payloads.

I traced the authorization logic against these scenarios:

| Scenario | Expected |
|---|---|
| Push to `main` touching `charts/rhai-on-xks-chart/**` | Auto-runs |
| Org member opens or updates a PR | Auto-runs via `author_association` |
| `github-actions[bot]` bundle-sync PR opens | Auto-runs via trusted login |
| `red-hat-konflux[bot]` or `jira-autofix[bot]` PR opens | Auto-runs via trusted login |
| External contributor opens a PR with no label | Check fails |
| Maintainer adds `run-xks-e2e` to an external PR | Runs on that event, stays enabled while the label remains |
| Maintainer adds `lgtm` on a fresh `labeled` event | Auto-runs |
| External PR gets a new commit while neither label is present | Check fails |

I'm listed in this repo's `platform` OWNERS alias, so opening this PR should exercise the "trusted contributor" path live. I can't self-test the external-contributor scenarios, so only after the PR is merged.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


[RHOAIENG-58789]: https://redhat.atlassian.net/browse/RHOAIENG-58789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-58789]: https://redhat.atlassian.net/browse/RHOAIENG-58789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-73747]: https://redhat.atlassian.net/browse/RHOAIENG-73747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated test gating for the xKS end-to-end workflow.
  * The workflow now checks authorization during the job run and stops early with a clear error if the required approval or label is missing.
  * Trusted contributors, approved reviews, certain bot accounts, push events, and labeled pull requests continue to proceed automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->