### PR TITLE
feat: retain application namespace on helm uninstall

### DIFF
--- a/charts/rhai-on-xks-chart/scripts/verify.sh
+++ b/charts/rhai-on-xks-chart/scripts/verify.sh
@@ -538,17 +538,10 @@ test_4_uninstall_lifecycle() {
   assert_not_exists "istiod deployment" deployment/istiod -n istio-system
   assert_no_stuck_istiorevision
 
-  # Dependency namespaces persist (cleanupNamespaces=false)
+  # All namespaces persist (cleanupNamespaces=false, keep annotation)
   assert_exists "istio-system namespace (persists)" namespace/istio-system
-
-  # Wait for helm-managed namespaces to finish terminating before re-install
-  log "Waiting for terminating namespaces to be fully gone..."
   for ns in redhat-ods-operator redhat-ods-applications "${CM_NS}"; do
-    if kubectl get namespace "$ns" &>/dev/null; then
-      log "  waiting for namespace/$ns to terminate..."
-      kubectl wait --for=delete "namespace/$ns" --timeout=120s 2>/dev/null \
-        || warn "namespace/$ns still terminating after 120s"
-    fi
+    assert_exists "${ns} namespace (persists)" "namespace/${ns}"
   done
 
   # Phase B: reinstall with cleanupNamespaces=true, then uninstall
@@ -564,6 +557,8 @@ test_4_uninstall_lifecycle() {
   assert_not_exists "${CM_NS} namespace" "namespace/${CM_NS}"
   assert_not_exists "istio-system namespace" namespace/istio-system
   assert_not_exists "cert-manager-operator namespace" namespace/cert-manager-operator
+  assert_not_exists "redhat-ods-operator namespace" namespace/redhat-ods-operator
+  assert_not_exists "redhat-ods-applications namespace" namespace/redhat-ods-applications
 }
 
 # ─── Main ───────────────────────────────────────────────────────────────────

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/aws/manager/namespace-rhai-cloudmanager-system.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/aws/manager/namespace-rhai-cloudmanager-system.yaml
@@ -3,4 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.aws.cloudManager.namespace }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 {{- end }}

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/azure/manager/namespace-rhai-cloudmanager-system.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/azure/manager/namespace-rhai-cloudmanager-system.yaml
@@ -3,4 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.azure.cloudManager.namespace }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 {{- end }}

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/coreweave/manager/namespace-rhai-cloudmanager-system.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/coreweave/manager/namespace-rhai-cloudmanager-system.yaml
@@ -3,4 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.coreweave.cloudManager.namespace }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 {{- end }}

--- a/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-job.yaml
@@ -4,6 +4,13 @@
 {{- $providerKECR := include "rhai-on-xks-chart.enabledProviderKECR" . }}
 {{- $managedDepNamespaces := (include "rhai-on-xks-chart.kubernetesEngineDependencyNamespaces" (dict "root" . "managedOnly" true) | fromJson).items }}
 {{- $depNamespaces := concat (.Values.imagePullSecret.dependencyNamespaces | default list) $managedDepNamespaces | uniq }}
+{{- $provider := include "rhai-on-xks-chart.activeProvider" . | fromYaml }}
+{{- $coreNamespaces := list .Values.rhaiOperator.namespace .Values.rhaiOperator.applicationsNamespace }}
+{{- if $provider }}
+  {{- with (index $provider "cloudManagerNamespace") }}
+    {{- $coreNamespaces = append $coreNamespaces . }}
+  {{- end }}
+{{- end }}
 {{- if or $componentCRs $providerKECR }}
 apiVersion: batch/v1
 kind: Job
@@ -51,6 +58,13 @@ spec:
 
               {{- if $.Values.uninstall.cleanupNamespaces }}
               {{- range $ns := $depNamespaces }}
+              {{- if not (regexMatch "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$" $ns) }}
+              {{- fail (printf "invalid namespace name %q: must be a valid DNS-1123 label" $ns) }}
+              {{- end }}
+              echo "Deleting namespace '{{ $ns }}'..."
+              kubectl delete namespace '{{ $ns }}' --ignore-not-found --timeout=60s
+              {{- end }}
+              {{- range $ns := $coreNamespaces }}
               {{- if not (regexMatch "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$" $ns) }}
               {{- fail (printf "invalid namespace name %q: must be a valid DNS-1123 label" $ns) }}
               {{- end }}

--- a/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
@@ -5,6 +5,12 @@
 {{- $keResource := include "rhai-on-xks-chart.keResourceName" . }}
 {{- if or $componentCRs $providerKECR }}
 {{- $provider := include "rhai-on-xks-chart.activeProvider" . | fromYaml }}
+{{- $coreNamespaces := list .Values.rhaiOperator.namespace .Values.rhaiOperator.applicationsNamespace }}
+{{- if $provider }}
+  {{- with (index $provider "cloudManagerNamespace") }}
+    {{- $coreNamespaces = append $coreNamespaces . }}
+  {{- end }}
+{{- end }}
 {{- if include "rhai-on-xks-chart.imagePullSecretEnabled" . }}
 {{- $hookAnnotations := dict "helm.sh/hook" "pre-delete" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" }}
 {{ include "rhai-on-xks-chart.imagePullSecretResource" (dict "root" . "namespace" .Release.Namespace "annotations" $hookAnnotations) }}
@@ -33,13 +39,15 @@ metadata:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
-  {{- if and .Values.uninstall.cleanupNamespaces $depNamespaces }}
+  {{- if .Values.uninstall.cleanupNamespaces }}
+  {{- $allCleanupNamespaces := concat $depNamespaces $coreNamespaces | uniq }}
+  {{- if $allCleanupNamespaces }}
   - apiGroups:
       - ""
     resources:
       - namespaces
     resourceNames:
-      {{- range $ns := $depNamespaces }}
+      {{- range $ns := $allCleanupNamespaces }}
       - {{ $ns }}
       {{- end }}
     verbs:
@@ -47,6 +55,7 @@ rules:
       - list
       - watch
       - delete
+  {{- end }}
   {{- end }}
   {{- $compRegistry := include "rhai-on-xks-chart.componentCRRegistry" . | fromYaml }}
   {{- range $name := keys $compRegistry | sortAlpha }}

--- a/charts/rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
+++ b/charts/rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -3,4 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.rhaiOperator.applicationsNamespace }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 {{- end }}

--- a/charts/rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
+++ b/charts/rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -3,4 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.rhaiOperator.namespace }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 {{- end }}

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/aws/rbac/serviceaccount-aws-cloud-manager-operator.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml
@@ -3024,6 +3039,9 @@ rules:
       - cert-manager-operator
       - cert-manager
       - istio-system
+      - redhat-ods-operator
+      - redhat-ods-applications
+      - rhai-cloudmanager-system
     verbs:
       - get
       - list
@@ -3484,5 +3502,11 @@ spec:
               kubectl delete namespace 'cert-manager' --ignore-not-found --timeout=60s
               echo "Deleting namespace 'istio-system'..."
               kubectl delete namespace 'istio-system' --ignore-not-found --timeout=60s
+              echo "Deleting namespace 'redhat-ods-operator'..."
+              kubectl delete namespace 'redhat-ods-operator' --ignore-not-found --timeout=60s
+              echo "Deleting namespace 'redhat-ods-applications'..."
+              kubectl delete namespace 'redhat-ods-applications' --ignore-not-found --timeout=60s
+              echo "Deleting namespace 'rhai-cloudmanager-system'..."
+              kubectl delete namespace 'rhai-cloudmanager-system' --ignore-not-found --timeout=60s
               echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/serviceaccount-coreweave-cloud-manager-operator.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/serviceaccount-coreweave-cloud-manager-operator.yaml

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -4,6 +4,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-cloudmanager-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-applications.yaml
@@ -11,6 +16,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-applications
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/manager/namespace-redhat-ods-operator.yaml
@@ -18,6 +28,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhai-operator
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
 
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml


### PR DESCRIPTION
## Description

- Add `helm.sh/resource-policy: keep` annotation to `redhat-ods-operator`, `redhat-ods-applications`, and `rhai-cloudmanager-system` namespace templates so they are preserved on `helm uninstall` (same pattern as dependency namespaces from #127)
- Extend pre-delete hook to also clean up core namespaces when `uninstall.cleanupNamespaces: true`
- Update e2e verify.sh to assert core namespaces persist (Phase A) and are deleted with cleanup enabled (Phase B)

Jira task: https://issues.redhat.com/browse/RHOAIENG-76226

## Has it been tested?

- [x] Snapshot tests regenerated and verified annotations present on all namespace resources
- [ ] Installed on a real cluster to verify the changes

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uninstall behavior so default cleanup preserves required namespaces.
  * Added optional full cleanup for operator, applications, and cloud manager namespaces when enabled.
  * Standardized namespace labels and retention metadata across supported cloud providers.
* **Tests**
  * Updated verification coverage and rendered configuration snapshots to validate namespace retention and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->