### PR TITLE
fix: namespace generation from operator

### DIFF
--- a/charts/rhai-on-xks-chart/scripts/helmtemplate-config-cloudmanager.yaml
+++ b/charts/rhai-on-xks-chart/scripts/helmtemplate-config-cloudmanager.yaml
@@ -23,6 +23,14 @@ rules:
     changes:
       - path: .metadata.name
         value: '{{ .Values.CLOUD_NAME.cloudManager.namespace }}'
+      - action: delete
+        path: .metadata.labels
+      - path: .metadata.labels
+        replaceWith: |
+          labels:
+            {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+      - path: .metadata.annotations["helm.sh/resource-policy"]
+        value: keep
 
   # Replace namespace in RoleBinding/ClusterRoleBinding subjects
   - match:

--- a/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
+++ b/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
@@ -24,6 +24,12 @@ rules:
         value: '{{ .Values.rhaiOperator.namespace }}'
       - action: delete
         path: .metadata.labels
+      - path: .metadata.labels
+        replaceWith: |
+          labels:
+            {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+      - path: .metadata.annotations["helm.sh/resource-policy"]
+        value: keep
 
   - match:
       kinds:
@@ -34,6 +40,14 @@ rules:
     changes:
       - path: .metadata.name
         value: '{{ .Values.rhaiOperator.applicationsNamespace }}'
+      - action: delete
+        path: .metadata.labels
+      - path: .metadata.labels
+        replaceWith: |
+          labels:
+            {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+      - path: .metadata.annotations["helm.sh/resource-policy"]
+        value: keep
 
   # Replace namespace in RoleBinding/ClusterRoleBinding subjects
   - match:


### PR DESCRIPTION
Ensure the bundle is generated correctly from opendatahub-operator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated Kubernetes Namespace metadata by applying consistent chart labels.
  * Preserved generated Namespace resources during Helm uninstall operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->