### PR TITLE
fix: upgrade testing on aws

### DIFF
--- a/.github/workflows/rhai-on-xks-chart-test.yaml
+++ b/.github/workflows/rhai-on-xks-chart-test.yaml
@@ -110,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cloud_provider: [azure, coreweave, aws]
+        cloud_provider: [azure, coreweave] # TODO: add aws once 3.5 GA is the starting version, as AWS is not supported in 3.4.x
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
AWS is introduced in 3.5-ea.1, so upgrade testing from 3.4 to 3.5 cannot verify it. We should add it again once the base version is 3.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated upgrade testing to run on Azure and CoreWeave environments.
  * Removed AWS from the upgrade-test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->