### PR TITLE
fix: align sail-operator Chart.yaml appVersion with deployed bundle v…

### DIFF
--- a/charts/dependencies/sail-operator/Chart.yaml
+++ b/charts/dependencies/sail-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: sail-operator
 description: Red Hat Sail Operator (OSSM 3.x) for Kubernetes
 type: application
 version: 1.0.0
-appVersion: "3.2.3"
+appVersion: "3.3.3"
 keywords:
   - istio
   - service-mesh

--- a/charts/dependencies/sail-operator/api-docs.md
+++ b/charts/dependencies/sail-operator/api-docs.md
@@ -1,6 +1,6 @@
 # sail-operator
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.3](https://img.shields.io/badge/AppVersion-3.2.3-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.3.3](https://img.shields.io/badge/AppVersion-3.3.3-informational?style=flat-square)
 
 Red Hat Sail Operator (OSSM 3.x) for Kubernetes
 


### PR DESCRIPTION
 ## Summary
  - Chart.yaml appVersion was 3.2.3 while values.yaml bundle.version                                                                                                                                                                                                                                                                                                                        
    is 3.3.3, causing `helm list` to show a stale APP VERSION       
  - Updated appVersion to 3.3.3 to match the actual deployed OSSM version                                                                                                                                                                                                                                                                                                                   
  - Regenerated chart snapshots (18 files) to reflect the change                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                            
  ## Details                                                                                                                                                                                                                                                                                                                                                                                
  appVersion is metadata only — not referenced in any templates.                                                                                                                                                                                                                                                                                                                            
  The deployed OSSM version comes from values.yaml bundle.version,                                                                                                                                                                                                                                                                                                                          
  which was already correct at 3.3.3.                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                            
  ## Test plan                                                                                                                                                                                                                                                                                                                                                                              
  - [x] `make validate-yaml` — pass                                                                                                                                                                                                                                                                                                                                                         
  - [x] `make chart-snapshots` — regenerated                                                                                                                                                                                                                                                                                                                                                
  - [x] `make chart-test` — pass     

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Sail Operator chart to version 3.3.3.
  * Updated the displayed Sail Operator version in the API documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->