### PR TITLE
[RHAISTRAT-1209] feat: retain dependency namespaces on helm uninstall

### DIFF
--- a/charts/rhai-on-openshift-chart/templates/definitions/_operator.tpl
+++ b/charts/rhai-on-openshift-chart/templates/definitions/_operator.tpl
@@ -16,6 +16,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     {{- include "rhoai-dependencies.labels" .root | nindent 4 }}
 {{- end }}

--- a/charts/rhai-on-openshift-chart/test/snapshots/all-components-managed.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/all-components-managed.snap.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cert-manager-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -13,6 +15,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-cluster-observability-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -22,6 +26,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-jobset-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -31,6 +37,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-kueue-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -40,6 +48,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-nfd
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -49,6 +59,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: nvidia-gpu-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -58,6 +70,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-opentelemetry-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -67,6 +81,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kuadrant-system
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -76,6 +92,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-tempo-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -85,6 +103,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: opendatahub-operator-system
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-openshift-chart/test/snapshots/default.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/default.snap.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: opendatahub-operator-system
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-openshift-chart/test/snapshots/enable-llm-d-wva.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/enable-llm-d-wva.snap.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cert-manager-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -13,6 +15,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-keda
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -22,6 +26,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-jobset-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -31,6 +37,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kuadrant-system
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -40,6 +48,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: opendatahub-operator-system
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-openshift-chart/test/snapshots/inference-only.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/inference-only.snap.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cert-manager-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -13,6 +15,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kuadrant-system
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -22,6 +26,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-openshift-chart/test/snapshots/profile-with-customization.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/profile-with-customization.snap.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cert-manager-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -13,6 +15,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-jobset-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -22,6 +26,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kuadrant-system
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -31,6 +37,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-openshift-chart/test/snapshots/skip-crd-check-odh.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/skip-crd-check-odh.snap.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: opendatahub-operator-system
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-openshift-chart/test/snapshots/skip-crd-check-rhoai.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/skip-crd-check-rhoai.snap.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: redhat-ods-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-openshift-chart/test/snapshots/with-rhcl-config.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/with-rhcl-config.snap.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cert-manager-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -13,6 +15,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-jobset-operator
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -22,6 +26,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kuadrant-system
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -31,6 +37,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: opendatahub-operator-system
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
## Description
- Add `helm.sh/resource-policy: keep` annotation to dependency namespaces in `rhai-on-openshift-chart` so they are not deleted on `helm uninstall` or when a dependency is switched to Unmanaged
- This prevents data loss and stuck-namespace issues when operators leave finalizers on resources inside those namespaces

Jira task: https://redhat.atlassian.net/browse/RHOAIENG-76214

## Has it been tested?
- [ ] Installed on a real cluster to verify the changes
- Snapshots need regeneration with `make chart-snapshots CHART_NAME=rhai-on-openshift-chart`

## Merge criteria
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Helm-managed namespaces are now preserved during release upgrades and removals.
  - This applies consistently across dependency and operator namespaces in supported deployment configurations.

- **Tests**
  - Updated rendered deployment snapshots to verify the namespace retention policy across multiple configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->