### PR TITLE
fix: make post-install hook backoffLimit configurable

### DIFF
--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/hook-weight: "1"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 3
+  backoffLimit: {{ .Values.hooks.postInstallCrs.backoffLimit | default 5 }}
   template:
     metadata:
       labels:

--- a/charts/rhai-on-xks-chart/values.schema.json
+++ b/charts/rhai-on-xks-chart/values.schema.json
@@ -151,6 +151,11 @@
               "type": "boolean",
               "description": "Enable post-install CR creation hook",
               "default": true
+            },
+            "backoffLimit": {
+              "type": "integer",
+              "description": "Max retries for the post-install CRs hook job. Increase when components.aigateway.enabled=true.",
+              "default": 5
             }
           },
           "additionalProperties": false

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -59,6 +59,10 @@ hooks:
       memory: 64Mi
   postInstallCrs:
     enabled: true
+    # Max retries for the post-install CRs hook job.
+    # Increase when components.aigateway.enabled=true, as the aigateways CRD
+    # is registered by the operator at startup (not shipped in the chart).
+    backoffLimit: 5
 
 # Cluster wise config for gateway for tls, shared config for all components section below
 gateway:


### PR DESCRIPTION
 - Makes backoffLimit on the post-install CRs hook job configurable via hooks.postInstallCrs.backoffLimit (default: 5, was hardcoded 3)                                                   
  - Allows override at install time: --set hooks.postInstallCrs.backoffLimit=10                                                                                                          
                                              
  Problem                                     
                                                                                                                                                                                           
  When components.aigateway.enabled=true, the post-install hook waits for aigateways.components.platform.opendatahub.io CRD. Unlike kserves (shipped in templates/crds/), this CRD is only 
  registered by the operator at startup. The operator can't start until cert-manager issues its webhook cert, creating a dependency chain:                                                 
                                                                                                                                                                                           
  cloud manager → cert-manager → webhook cert → operator starts → registers aigateways CRD → hook proceeds                                                                                 
                                                                                                                                                                                         
  With backoffLimit: 3, the hook fails before the operator starts. Increasing to 5 (configurable) gives enough headroom.                                                                   
                                                                                                                                                                                           
  Test plan                                                                                                                                                                                
                                                                                                                                                                                           
  - helm install with --set components.aigateway.enabled=true succeeds without pre-applying the CRD                                                                                        
  - helm install without aigateway still works (no regression)                                                                                                                             
  - --set hooks.postInstallCrs.backoffLimit=10 overrides the default         

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable retry limit for the post-install setup job.
  * The default retry limit is now 5 attempts, with an option to increase it for longer component startup times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->