### PR TITLE
[RHAISTRAT-1377] fix: reorder post-install hook to apply KE and Platform CRs before co…

### DIFF
--- a/charts/rhai-on-xks-chart/templates/hooks/_crs-definitions.tpl
+++ b/charts/rhai-on-xks-chart/templates/hooks/_crs-definitions.tpl
@@ -170,12 +170,34 @@ Do NOT range over this and access fields with .field syntax — use crApplyComma
 {{- end -}}
 
 {{/*
-Emit kubectl apply commands for all enabled component CRs and provider KE CRs.
+Emit kubectl apply commands for provider KE CR, Platform CR, then component CRs.
+Provider KE CR is applied first to trigger dependency deployment (cert-manager, istio, etc.).
+Platform CR is applied next to trigger module operators (e.g. ai-gateway-operator).
+Component CRs are applied last, after their CRDs are registered by the operators.
 Include with: {{- include "rhai-on-xks-chart.crApplyCommands" . | nindent 14 }}
-Component CRs are applied before provider KE CRs.
 */}}
 {{- define "rhai-on-xks-chart.crApplyCommands" -}}
 {{- $root := . }}
+{{- $provider := include "rhai-on-xks-chart.activeProvider" . | fromYaml }}
+{{- if and $provider (index $provider "keEnabled") }}
+echo "Creating {{ index $provider "keKind" }} CR..."
+kubectl apply -f - <<'EOF'
+apiVersion: infrastructure.opendatahub.io/v1alpha1
+kind: {{ index $provider "keKind" }}
+metadata:
+  name: {{ index $provider "keName" }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" $root | nindent 4 }}
+{{- $spec := index $provider "keSpec" }}
+{{- if $spec }}
+spec:
+  {{- $spec | toYaml | nindent 2 }}
+{{- else }}
+spec: {}
+{{- end }}
+EOF
+{{- end }}
+{{- include "rhai-on-xks-chart.moduleApplyCommands" $root }}
 {{- $compRegistry := include "rhai-on-xks-chart.componentCRRegistry" . | fromYaml }}
 {{- range $name := keys $compRegistry | sortAlpha }}
   {{- $meta := index $compRegistry $name }}
@@ -199,25 +221,6 @@ spec: {}
 {{- end }}
 EOF
   {{- end }}
-{{- end }}
-{{- $provider := include "rhai-on-xks-chart.activeProvider" . | fromYaml }}
-{{- if and $provider (index $provider "keEnabled") }}
-echo "Creating {{ index $provider "keKind" }} CR..."
-kubectl apply -f - <<'EOF'
-apiVersion: infrastructure.opendatahub.io/v1alpha1
-kind: {{ index $provider "keKind" }}
-metadata:
-  name: {{ index $provider "keName" }}
-  labels:
-    {{- include "rhai-on-xks-chart.labels" $root | nindent 4 }}
-{{- $spec := index $provider "keSpec" }}
-{{- if $spec }}
-spec:
-  {{- $spec | toYaml | nindent 2 }}
-{{- else }}
-spec: {}
-{{- end }}
-EOF
 {{- end }}
 {{- end -}}
 

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-job.yaml
@@ -43,7 +43,6 @@ spec:
             - |
               set -euo pipefail
               {{- include "rhai-on-xks-chart.crApplyCommands" . | trimPrefix "\n" | nindent 14 }}
-              {{- include "rhai-on-xks-chart.moduleApplyCommands" . | nindent 14 }}
               echo "Done."
 {{- end }}
 {{- end }}

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
@@ -3387,19 +3387,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating AWSKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3426,7 +3413,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3435,6 +3421,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
@@ -3212,19 +3212,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating AWSKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3251,7 +3238,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3260,6 +3246,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
@@ -3212,19 +3212,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating AWSKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3251,7 +3238,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3260,6 +3246,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -3363,19 +3363,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating AWSKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3402,7 +3389,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3411,6 +3397,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -3212,19 +3212,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating AWSKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3251,7 +3238,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3260,6 +3246,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
@@ -3387,19 +3387,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating AzureKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3426,7 +3413,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3435,6 +3421,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
@@ -3212,19 +3212,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating AzureKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3251,7 +3238,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3260,6 +3246,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
@@ -3228,19 +3228,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating AzureKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3267,7 +3254,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3276,6 +3262,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
@@ -3212,19 +3212,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating AzureKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3251,7 +3238,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3260,6 +3246,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
@@ -3284,6 +3284,48 @@ spec:
             - -c
             - |
               set -euo pipefail
+              echo "Creating AzureKubernetesEngine CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: infrastructure.opendatahub.io/v1alpha1
+              kind: AzureKubernetesEngine
+              metadata:
+                name: default-azurekubernetesengine
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec:
+                dependencies:
+                  certManager:
+                    configuration: {}
+                    managementPolicy: Managed
+                  gatewayAPI:
+                    configuration: {}
+                    managementPolicy: Managed
+                  lws:
+                    configuration:
+                      namespace: openshift-lws-operator
+                    managementPolicy: Unmanaged
+                  sailOperator:
+                    configuration:
+                      namespace: istio-system
+                    managementPolicy: Managed
+              EOF
+              echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
+              echo "Creating Platform CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: config.opendatahub.io/v1alpha1
+              kind: Platform
+              metadata:
+                name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec:
+                modules:
+                  aigateway:
+                    managementState: Managed
+              EOF
               echo "Waiting for CRD aigateways.components.platform.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/aigateways.components.platform.opendatahub.io
               echo "Creating AIGateway CR..."
@@ -3311,49 +3353,6 @@ spec:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm
               spec: {}
-              EOF
-              echo "Creating AzureKubernetesEngine CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: infrastructure.opendatahub.io/v1alpha1
-              kind: AzureKubernetesEngine
-              metadata:
-                name: default-azurekubernetesengine
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec:
-                dependencies:
-                  certManager:
-                    configuration: {}
-                    managementPolicy: Managed
-                  gatewayAPI:
-                    configuration: {}
-                    managementPolicy: Managed
-                  lws:
-                    configuration:
-                      namespace: openshift-lws-operator
-                    managementPolicy: Unmanaged
-                  sailOperator:
-                    configuration:
-                      namespace: istio-system
-                    managementPolicy: Managed
-              EOF
-              
-              echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
-              echo "Creating Platform CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: config.opendatahub.io/v1alpha1
-              kind: Platform
-              metadata:
-                name: default
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec:
-                modules:
-                  aigateway:
-                    managementState: Managed
               EOF
               echo "Done."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
@@ -3212,19 +3212,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating AzureKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3251,7 +3238,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3260,6 +3246,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -3363,19 +3363,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating AzureKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3402,7 +3389,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3411,6 +3397,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -3214,19 +3214,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating AzureKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3253,7 +3240,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3262,6 +3248,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
@@ -3159,19 +3159,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating AzureKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3198,7 +3185,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3207,6 +3193,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
@@ -3387,19 +3387,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating CoreWeaveKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3426,7 +3413,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3435,6 +3421,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
@@ -3212,19 +3212,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating CoreWeaveKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3251,7 +3238,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3260,6 +3246,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -3363,19 +3363,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating CoreWeaveKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3402,7 +3389,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3411,6 +3397,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -3212,19 +3212,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating CoreWeaveKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3251,7 +3238,6 @@ spec:
                       namespace: istio-system
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3260,6 +3246,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -3387,19 +3387,6 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
-              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
-              echo "Creating Kserve CR..."
-              kubectl apply -f - <<'EOF'
-              apiVersion: components.platform.opendatahub.io/v1alpha1
-              kind: Kserve
-              metadata:
-                name: default-kserve
-                labels:
-                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
-                  app.kubernetes.io/managed-by: Helm
-              spec: {}
-              EOF
               echo "Creating AzureKubernetesEngine CR..."
               kubectl apply -f - <<'EOF'
               apiVersion: infrastructure.opendatahub.io/v1alpha1
@@ -3426,7 +3413,6 @@ spec:
                       namespace: custom-istio
                     managementPolicy: Managed
               EOF
-              
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
               kubectl wait --for condition=established --timeout=300s crd/platforms.config.opendatahub.io
               echo "Creating Platform CR..."
@@ -3435,6 +3421,19 @@ spec:
               kind: Platform
               metadata:
                 name: default
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec: {}
+              EOF
+              echo "Waiting for CRD kserves.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/kserves.components.platform.opendatahub.io
+              echo "Creating Kserve CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: Kserve
+              metadata:
+                name: default-kserve
                 labels:
                   helm.sh/chart: HELM_CHART_VERSION_REDACTED
                   app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
 Reorders the post-install hook script so provider KubernetesEngine CR and Platform CR are applied before the component CRD waits.                                                                                                                                                       
                                                                                                                                                                                                                  
  Fixes: [RHOAIENG-78311](https://redhat.atlassian.net/browse/RHOAIENG-78311)                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                  
  Problem                                                                                                                                                                                                                                                                                 
                                                      
  helm upgrade --install with components.aigateway.enabled=true fails. The hook script waits for aigateways CRD (alphabetically first), but that CRD is only registered after:                                                                                                            
  1. AzureKubernetesEngine CR triggers cert-manager → operator starts                                                                                                                                                                                                                     
  2. Platform CR with aigateway: Managed triggers ai-gateway-operator → registers CRD                                                                                                                             
                                                                                                                                                                                                                                                                                          
  Both CRs were applied after the CRD wait, creating a circular dependency.                                                                                                                                       
                                                                                                                                                                                                                                                                                          
  Fix                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                          
  Reorder from: Component CRD waits → KE CR → Platform CR                                                                                                                                                                                                                                 
  To: KE CR → Platform CR → Component CRD waits                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                          
  Test plan                                           
                                                                                                                                                                                                                                                                                          
  - helm upgrade --install with components.aigateway.enabled=true on AKS — succeeds                           
  - helm upgrade --install without aigateway (default) — no regression                                                                                                                                                                                                                    
  - Works on CoreWeave and EKS          

[RHOAIENG-78311]: https://redhat.atlassian.net/browse/RHOAIENG-78311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the deployment sequence for Kubernetes custom resources during installation and upgrades.
  * Updated reconciliation to apply the enabled provider resource before platform/module resources.
  * Refined post-install/post-upgrade hook behavior to apply the full intended set of resources in a consistent order.
  * Reordered KServe vs. Platform creation to improve readiness and reduce timing-related issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->