### PR TITLE
[RHAISTRAT-1477] chore(RHOAIENG-66142): update kueue operator channel to stable-v1.4

### DIFF
--- a/charts/rhai-on-openshift-chart/api-docs.md
+++ b/charts/rhai-on-openshift-chart/api-docs.md
@@ -98,7 +98,7 @@ A Helm chart for installing ODH/RHOAI dependencies and component configurations
 | dependencies.jobSet.config.spec | object | `{"logLevel":"Normal","operatorLogLevel":"Normal"}` | JobSetOperator CR spec (user can add any fields supported by the CR) |
 | dependencies.jobSet.dependencies | object | `{"certManager":true}` | Dependencies required by job-set |
 | dependencies.jobSet.enabled | string | `"auto"` | Enable job-set: auto (if needed), true (always), false (never) |
-| dependencies.kueue | object | `{"config":{"spec":{"config":{"integrations":{"frameworks":["Deployment","Pod","PyTorchJob","RayCluster","RayJob","StatefulSet","TrainJob"]}},"managementState":"Managed"}},"dependencies":{"certManager":true},"enabled":"auto","olm":{"channel":"stable-v1.3","name":"kueue-operator","namespace":"openshift-kueue-operator"}}` | Kueue operator |
+| dependencies.kueue | object | `{"config":{"spec":{"config":{"integrations":{"frameworks":["Deployment","Pod","PyTorchJob","RayCluster","RayJob","StatefulSet","TrainJob"]}},"managementState":"Managed"}},"dependencies":{"certManager":true},"enabled":"auto","olm":{"channel":"stable-v1.4","name":"kueue-operator","namespace":"openshift-kueue-operator"}}` | Kueue operator |
 | dependencies.kueue.config.spec | object | `{"config":{"integrations":{"frameworks":["Deployment","Pod","PyTorchJob","RayCluster","RayJob","StatefulSet","TrainJob"]}},"managementState":"Managed"}` | Kueue CR spec (user can add any fields) |
 | dependencies.kueue.dependencies | object | `{"certManager":true}` | Dependencies required by kueue |
 | dependencies.kueue.enabled | string | `"auto"` | Enable kueue: auto (if needed), true (always), false (never) |

--- a/charts/rhai-on-openshift-chart/test/snapshots/all-components-managed.snap.yaml
+++ b/charts/rhai-on-openshift-chart/test/snapshots/all-components-managed.snap.yaml
@@ -463,7 +463,7 @@ metadata:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
 spec:
-  channel: stable-v1.3
+  channel: stable-v1.4
   installPlanApproval: Automatic
   name: kueue-operator
   source: redhat-operators

--- a/charts/rhai-on-openshift-chart/values.yaml
+++ b/charts/rhai-on-openshift-chart/values.yaml
@@ -459,7 +459,7 @@ dependencies:
     dependencies:
       certManager: true
     olm:
-      channel: stable-v1.3
+      channel: stable-v1.4
       name: kueue-operator
       namespace: openshift-kueue-operator
     config:

--- a/components/operators/kueue-operator/subscription.yaml
+++ b/components/operators/kueue-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kueue-operator
   namespace: openshift-kueue-operator
 spec:
-  channel: stable-v1.3
+  channel: stable-v1.4
   name: kueue-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## Description

Update the Kueue operator subscription channel from `stable-v1.3` to `stable-v1.4` (RHBoK 1.4 / upstream Kueue v0.18) in both:

- **Kustomize configuration**: `components/operators/kueue-operator/subscription.yaml`
- **OCP helm chart**: `charts/rhai-on-openshift-chart/values.yaml`

Regenerated chart snapshots and api-docs to reflect the channel change. Snapshot regeneration also picked up pre-existing whitespace staleness in other snapshot files.

Jira: https://issues.redhat.com/browse/RHOAIENG-66142

### Companion PR

- **opendatahub-operator**: https://github.com/opendatahub-io/opendatahub-operator/pull/3843 (updates e2e test channel constant — merge first)

### Merge order

The opendatahub-operator PR should be merged **before** this one, so e2e tests validate against Kueue 1.4 before production clusters subscribe to the new channel.

## How Has This Been Tested?

- `make chart-snapshots` — regenerated successfully
- `make chart-test` — all 33 snapshot tests pass
- `make helm-docs` — api-docs regenerated successfully

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Kueue operator subscription channel from `stable-v1.3` to `stable-v1.4`.
  * Updated the related deployment configuration and documentation to reflect the new channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->