### PR TITLE
fix(RHOAIENG-78604): propagate pull secret to RHCL namespaces

### DIFF
--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -87,6 +87,8 @@ RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes serv
 | hooks.resources.requests.memory | string | `"64Mi"` |  |
 | imagePullSecret.dependencyNamespaces[0] | string | `"cert-manager-operator"` |  |
 | imagePullSecret.dependencyNamespaces[1] | string | `"cert-manager"` |  |
+| imagePullSecret.dependencyNamespaces[2] | string | `"kuadrant-operators"` |  |
+| imagePullSecret.dependencyNamespaces[3] | string | `"kuadrant-system"` |  |
 | imagePullSecret.dockerConfigJson | string | `""` |  |
 | imagePullSecret.name | string | `"rhai-pull-secret"` |  |
 | installCRDs | bool | `true` |  |

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
@@ -61,6 +61,28 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: kuadrant-operators
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
   name: openshift-lws-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -181,6 +203,32 @@ kind: Secret
 metadata:
   name: rhai-pull-secret
   namespace: cert-manager
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: kuadrant-operators
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: kuadrant-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -61,6 +61,28 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: kuadrant-operators
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
   name: istio-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -170,6 +192,32 @@ kind: Secret
 metadata:
   name: rhai-pull-secret
   namespace: cert-manager
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: kuadrant-operators
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: kuadrant-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
@@ -61,6 +61,28 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: kuadrant-operators
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
   name: openshift-lws-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -181,6 +203,32 @@ kind: Secret
 metadata:
   name: rhai-pull-secret
   namespace: cert-manager
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: kuadrant-operators
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: kuadrant-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
@@ -2772,6 +2772,8 @@ rules:
     resourceNames:
       - cert-manager-operator
       - cert-manager
+      - kuadrant-operators
+      - kuadrant-system
       - istio-system
       - redhat-ods-operator
       - redhat-ods-applications
@@ -3267,6 +3269,10 @@ spec:
               kubectl delete namespace 'cert-manager-operator' --ignore-not-found --timeout=60s
               echo "Deleting namespace 'cert-manager'..."
               kubectl delete namespace 'cert-manager' --ignore-not-found --timeout=60s
+              echo "Deleting namespace 'kuadrant-operators'..."
+              kubectl delete namespace 'kuadrant-operators' --ignore-not-found --timeout=60s
+              echo "Deleting namespace 'kuadrant-system'..."
+              kubectl delete namespace 'kuadrant-system' --ignore-not-found --timeout=60s
               echo "Deleting namespace 'istio-system'..."
               kubectl delete namespace 'istio-system' --ignore-not-found --timeout=60s
               echo "Deleting namespace 'redhat-ods-operator'..."

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -61,6 +61,28 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: kuadrant-operators
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
   name: istio-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -170,6 +192,32 @@ kind: Secret
 metadata:
   name: rhai-pull-secret
   namespace: cert-manager
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: kuadrant-operators
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: kuadrant-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
@@ -61,6 +61,28 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: kuadrant-operators
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
   name: openshift-lws-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -181,6 +203,32 @@ kind: Secret
 metadata:
   name: rhai-pull-secret
   namespace: cert-manager
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: kuadrant-operators
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: kuadrant-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -61,6 +61,28 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: kuadrant-operators
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
   name: istio-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -170,6 +192,32 @@ kind: Secret
 metadata:
   name: rhai-pull-secret
   namespace: cert-manager
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: kuadrant-operators
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: kuadrant-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -61,6 +61,28 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: kuadrant-operators
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
   name: custom-lws
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
@@ -181,6 +203,32 @@ kind: Secret
 metadata:
   name: rhai-pull-secret
   namespace: cert-manager
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: kuadrant-operators
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: kuadrant-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -264,3 +264,5 @@ imagePullSecret:
   dependencyNamespaces:
     - cert-manager-operator
     - cert-manager
+    - kuadrant-operators
+    - kuadrant-system


### PR DESCRIPTION
## Summary

- Add `kuadrant-operators` and `kuadrant-system` to `imagePullSecret.dependencyNamespaces` in the xKS chart values
- This ensures the pull secret is pre-created in RHCL operator/operand namespaces before pods start
- Fixes `ImagePullBackOff` errors for RHCL operator pods and Authorino operands on xKS clusters

## Problem

On xKS clusters, the RHCL operator deploys into `kuadrant-operators` (operator) and `kuadrant-system` (operand). The Helm chart's pull-secret template already handles creating the image pull secret in all `dependencyNamespaces`, but these two RHCL namespaces were missing from the default list.

This caused pods to fail with `ImagePullBackOff` because the `rhai-pull-secret` referenced in their ServiceAccounts did not exist in those namespaces.

## Test plan

- [ ] `make chart-test CHART_NAME=rhai-on-xks-chart` passes (snapshots updated)
- [ ] `helm template` with `--set-file imagePullSecret.dockerConfigJson=...` shows secrets in `kuadrant-operators` and `kuadrant-system`
- [ ] Deploy on AKS cluster — RHCL pods pull images without `ImagePullBackOff`