### PR TITLE
fix(RHOAIENG-78604): add imagePullSecret creation to RHCL chart

### DIFF
--- a/charts/dependencies/rhcl-operator/api-docs.md
+++ b/charts/dependencies/rhcl-operator/api-docs.md
@@ -15,6 +15,8 @@ Red Hat Connectivity Link (Kuadrant) operators for vanilla Kubernetes (without O
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | bundle.version | string | `"1.3.0"` |  |
+| imagePullSecret.dockerConfigJson | string | `""` |  |
+| imagePullSecret.name | string | `"rhai-pull-secret"` |  |
 | imagePullSecrets[0].name | string | `"rhai-pull-secret"` |  |
 | operandNamespace | string | `"kuadrant-system"` |  |
 | operatorNamespace | string | `"kuadrant-operators"` |  |

--- a/charts/dependencies/rhcl-operator/templates/pull-secret.yaml
+++ b/charts/dependencies/rhcl-operator/templates/pull-secret.yaml
@@ -7,8 +7,6 @@ kind: Secret
 metadata:
   name: {{ $.Values.imagePullSecret.name }}
   namespace: {{ $ns }}
-  labels:
-    app.kubernetes.io/managed-by: Helm
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ $.Values.imagePullSecret.dockerConfigJson | b64enc }}

--- a/charts/dependencies/rhcl-operator/templates/pull-secret.yaml
+++ b/charts/dependencies/rhcl-operator/templates/pull-secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.imagePullSecret.dockerConfigJson }}
+{{- $namespaces := list .Values.operatorNamespace .Values.operandNamespace | uniq }}
+{{- range $ns := $namespaces }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $.Values.imagePullSecret.name }}
+  namespace: {{ $ns }}
+  labels:
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ $.Values.imagePullSecret.dockerConfigJson | b64enc }}
+{{- end }}
+{{- end }}

--- a/charts/dependencies/rhcl-operator/values.yaml
+++ b/charts/dependencies/rhcl-operator/values.yaml
@@ -5,5 +5,12 @@ operandNamespace: kuadrant-system
 imagePullSecrets:
   - name: rhai-pull-secret
 
+# Optional: provide dockerConfigJson to create the pull secret in RHCL namespaces.
+# If empty, no secret is created (assumes it is provided externally or not needed).
+# Use --set-file imagePullSecret.dockerConfigJson=path/to/auth.json
+imagePullSecret:
+  name: rhai-pull-secret
+  dockerConfigJson: ""
+
 bundle:
   version: "1.3.0"


### PR DESCRIPTION
## Summary

- Adds pull secret creation directly to the RHCL operator chart (`charts/dependencies/rhcl-operator/`)
- When `imagePullSecret.dockerConfigJson` is provided, creates the secret in both `kuadrant-operators` and `kuadrant-system` namespaces
- When not provided, nothing is created — chart works without a pull secret as well

This approach keeps install order independent: RHCL chart can be installed before or after the main xks chart without requiring external secret propagation.

Supersedes #143 (which put the logic in the xks chart instead).

## Why

On xKS clusters with private registries, RHCL operator pods fail to pull images because the pull secret only existed in the main chart's namespaces. Per review feedback on #143, the RHCL chart should own its own pull secret creation rather than relying on the xks chart to propagate it.

## Test plan

- [ ] `helm template` with `--set imagePullSecret.dockerConfigJson=<value>` renders Secret in both namespaces
- [ ] `helm template` without `dockerConfigJson` renders no Secret
- [ ] E2E: install RHCL chart with pull secret on a private-registry cluster

Fixes: https://redhat.atlassian.net/browse/RHOAIENG-78604


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable image pull secret support for RHCL Operator deployments.
  * Automatically creates the required registry secret in operator and operand namespaces when Docker credentials are provided.
  * Added configuration options for the secret name and Docker authentication data.

* **Documentation**
  * Documented the new image pull secret settings and their default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->