### PR TITLE
fix: add pullsecret for all the deployments need in xks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,8 +307,7 @@ helm-verify-xks: ## Verify rhai-on-xks-chart installation and lifecycle. Use XKS
 
 .PHONY: helm-install-verify-xks
 helm-install-verify-xks: ## Install and verify rhai-on-xks-chart
-	# TODO(RHOAIENG-63729): remove -f values-e2e.yaml once a runner with sufficient resources is available
-	VALUES_FILE=$(or $(XKS_VALUES_FILE),$(XKS_CHART_PATH)/test/values-e2e.yaml) $(MAKE) helm-verify-xks
+	$(MAKE) helm-verify-xks
 
 .PHONY: helm-upgrade-verify-xks
 helm-upgrade-verify-xks: ## Upgrade test: install previous version, upgrade to current, verify

--- a/charts/rhai-on-xks-chart/scripts/verify-helpers.sh
+++ b/charts/rhai-on-xks-chart/scripts/verify-helpers.sh
@@ -7,7 +7,7 @@
 RELEASE_NAME="${RELEASE_NAME:-rhai-on-xks}"
 NAMESPACE="${NAMESPACE:-rhai-on-xks}"
 CLOUD_PROVIDER="${CLOUD_PROVIDER:-azure}"
-TIMEOUT="${TIMEOUT:-300}"
+TIMEOUT="${TIMEOUT:-600}"
 CHART="${CHART:-./charts/rhai-on-xks-chart}"
 VALUES_FILE="${VALUES_FILE:-}"
 PULL_SECRET="${PULL_SECRET:-}"
@@ -354,12 +354,24 @@ helm_deploy() {
     ${helm_extra[@]+"${helm_extra[@]}"} \
     ${extra_args[@]+"${extra_args[@]}"} \
     --timeout 10m; then
-    log "Helm deploy failed — dumping hook job logs..."
+    log "Helm deploy failed — dumping debug info..."
     local hook_jobs=(rhai-post-install-crs rhai-post-create-gateway rhai-post-create-maas-gateway rhai-pre-delete-crs)
     for job in "${hook_jobs[@]}"; do
       if kubectl get "job/${job}" -n "$NAMESPACE" &>/dev/null; then
-        echo "  --- job: ${job} ---"
-        kubectl logs "job/${job}" -n "$NAMESPACE" --tail=100 2>/dev/null || true
+        echo "  === job: ${job} ==="
+        kubectl describe "job/${job}" -n "$NAMESPACE" 2>/dev/null || true
+        echo "  --- job logs (all containers): ${job} ---"
+        kubectl logs "job/${job}" -n "$NAMESPACE" --all-containers --tail=100 2>/dev/null || true
+        for pod in $(kubectl get pods -n "$NAMESPACE" -l "job-name=${job}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+          local phase
+          phase=$(kubectl get pod "${pod}" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null)
+          if [[ "$phase" != "Succeeded" ]]; then
+            echo "  --- pod: ${pod} (${phase}) ---"
+            kubectl describe pod "${pod}" -n "$NAMESPACE" 2>/dev/null || true
+            echo "  --- previous logs: ${pod} ---"
+            kubectl logs "${pod}" -n "$NAMESPACE" --all-containers --previous --tail=50 2>/dev/null || true
+          fi
+        done
       fi
     done
     return 1

--- a/charts/rhai-on-xks-chart/templates/pull-secret.yaml
+++ b/charts/rhai-on-xks-chart/templates/pull-secret.yaml
@@ -29,13 +29,39 @@ metadata:
 {{- end }}
 {{- end }}
 {{- if and .Values.enabled (include "rhai-on-xks-chart.imagePullSecretEnabled" .) }}
+{{- /*
+  TODO: Temporary solution (RHOAIENG-79301). The operator creates component controller
+  workloads from manifests that do not set imagePullSecrets (written for OCP, which has a
+  node-level pull secret). On XKS those pods cannot pull private images. We pre-create each
+  operator-managed ServiceAccount with imagePullSecrets so every pod using it inherits the
+  secret at admission (covers Deployments, Jobs, and CronJobs uniformly). This is SSA-safe:
+  the operator never declares imagePullSecrets, so its Server-Side Apply preserves this field.
+  Retire this once the operator injects imagePullSecrets for XKS itself.
+*/}}
+{{- $appNs := .Values.rhaiOperator.applicationsNamespace }}
+{{- $secret := include "rhai-on-xks-chart.imagePullSecretName" . }}
+{{- $serviceAccounts := list }}
+{{- if .Values.components.kserve.enabled }}
+  {{- $serviceAccounts = append $serviceAccounts (dict "name" "kserve-controller-manager" "namespace" $appNs) }}
+  {{- $serviceAccounts = append $serviceAccounts (dict "name" "kserve-module-controller-manager" "namespace" $appNs) }}
+  {{- $serviceAccounts = append $serviceAccounts (dict "name" "llmisvc-controller-manager" "namespace" $appNs) }}
+{{- end }}
+{{- if .Values.components.aigateway.enabled }}
+  {{- $serviceAccounts = append $serviceAccounts (dict "name" "ai-gateway-operator" "namespace" $appNs) }}
+  {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-controller" "namespace" $appNs) }}
+  {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-api" "namespace" $appNs) }}
+  {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-api-cleanup" "namespace" $appNs) }}
+  {{- $serviceAccounts = append $serviceAccounts (dict "name" "odh-dashboard-maas" "namespace" $appNs) }}
+  {{- $serviceAccounts = append $serviceAccounts (dict "name" "llm-d-batch-gateway-operator" "namespace" $appNs) }}
+{{- end }}
+{{- range $sa := $serviceAccounts }}
 ---
-# TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: llmisvc-controller-manager
-  namespace: {{ .Values.rhaiOperator.applicationsNamespace }}
+  name: {{ $sa.name }}
+  namespace: {{ $sa.namespace }}
 imagePullSecrets:
-  - name: {{ include "rhai-on-xks-chart.imagePullSecretName" . }}
+  - name: {{ $secret }}
+{{- end }}
 {{- end }}

--- a/charts/rhai-on-xks-chart/templates/pull-secret.yaml
+++ b/charts/rhai-on-xks-chart/templates/pull-secret.yaml
@@ -42,17 +42,23 @@ metadata:
 {{- $secret := include "rhai-on-xks-chart.imagePullSecretName" . }}
 {{- $serviceAccounts := list }}
 {{- if .Values.components.kserve.enabled }}
-  {{- $serviceAccounts = append $serviceAccounts (dict "name" "kserve-controller-manager" "namespace" $appNs) }}
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "kserve-module-controller-manager" "namespace" $appNs) }}
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "llmisvc-controller-manager" "namespace" $appNs) }}
 {{- end }}
 {{- if .Values.components.aigateway.enabled }}
+  {{- $aigw := .Values.components.aigateway }}
+  {{- /* The AIGateway module operator is always deployed when the module is enabled. */}}
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "ai-gateway-operator" "namespace" $appNs) }}
+  {{- /* MaaS (maas-controller/maas-api) is deployed only when modelsAsAService is Managed. */}}
+  {{- if eq (dig "spec" "modelsAsAService" "managementState" "" $aigw) "Managed" }}
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-controller" "namespace" $appNs) }}
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-api" "namespace" $appNs) }}
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-api-cleanup" "namespace" $appNs) }}
-  {{- $serviceAccounts = append $serviceAccounts (dict "name" "odh-dashboard-maas" "namespace" $appNs) }}
+  {{- end }}
+  {{- /* The batch-gateway operator is deployed only when batchGateway is Managed. */}}
+  {{- if eq (dig "spec" "batchGateway" "managementState" "" $aigw) "Managed" }}
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "llm-d-batch-gateway-operator" "namespace" $appNs) }}
+  {{- end }}
 {{- end }}
 {{- range $sa := $serviceAccounts }}
 ---

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
@@ -90,7 +90,24 @@ imagePullSecrets:
 
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
-# TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kserve-controller-manager
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kserve-module-controller-manager
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
@@ -93,15 +93,6 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kserve-controller-manager
-  namespace: redhat-ods-applications
-imagePullSecrets:
-  - name: rhai-pull-secret
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
   name: kserve-module-controller-manager
   namespace: redhat-ods-applications
 imagePullSecrets:

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -79,7 +79,24 @@ imagePullSecrets:
 
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
-# TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kserve-controller-manager
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kserve-module-controller-manager
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -82,15 +82,6 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kserve-controller-manager
-  namespace: redhat-ods-applications
-imagePullSecrets:
-  - name: rhai-pull-secret
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
   name: kserve-module-controller-manager
   namespace: redhat-ods-applications
 imagePullSecrets:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
@@ -90,7 +90,24 @@ imagePullSecrets:
 
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
-# TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kserve-controller-manager
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kserve-module-controller-manager
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
@@ -93,15 +93,6 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kserve-controller-manager
-  namespace: redhat-ods-applications
-imagePullSecrets:
-  - name: rhai-pull-secret
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
   name: kserve-module-controller-manager
   namespace: redhat-ods-applications
 imagePullSecrets:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
@@ -82,15 +82,6 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kserve-controller-manager
-  namespace: redhat-ods-applications
-imagePullSecrets:
-  - name: rhai-pull-secret
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
   name: kserve-module-controller-manager
   namespace: redhat-ods-applications
 imagePullSecrets:
@@ -137,24 +128,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: maas-api-cleanup
-  namespace: redhat-ods-applications
-imagePullSecrets:
-  - name: rhai-pull-secret
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: odh-dashboard-maas
-  namespace: redhat-ods-applications
-imagePullSecrets:
-  - name: rhai-pull-secret
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: llm-d-batch-gateway-operator
   namespace: redhat-ods-applications
 imagePullSecrets:
   - name: rhai-pull-secret

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
@@ -15,7 +15,7 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: rhai-applications
+  name: redhat-ods-applications
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -27,7 +27,7 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: rhai-operator
+  name: redhat-ods-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -61,18 +61,7 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: custom-lws
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    helm.sh/resource-policy: keep
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: custom-istio
+  name: istio-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -94,7 +83,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kserve-controller-manager
-  namespace: rhai-applications
+  namespace: redhat-ods-applications
 imagePullSecrets:
   - name: rhai-pull-secret
 ---
@@ -103,7 +92,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kserve-module-controller-manager
-  namespace: rhai-applications
+  namespace: redhat-ods-applications
 imagePullSecrets:
   - name: rhai-pull-secret
 ---
@@ -112,7 +101,61 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: llmisvc-controller-manager
-  namespace: rhai-applications
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ai-gateway-operator
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: maas-controller
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: maas-api
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: maas-api-cleanup
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: odh-dashboard-maas
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: llm-d-batch-gateway-operator
+  namespace: redhat-ods-applications
 imagePullSecrets:
   - name: rhai-pull-secret
 
@@ -122,7 +165,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rhai-operator-controller-manager
-  namespace: rhai-operator
+  namespace: redhat-ods-operator
 imagePullSecrets:
   - name: rhai-pull-secret
 
@@ -132,7 +175,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: rhai-pull-secret
-  namespace: rhai-operator
+  namespace: redhat-ods-operator
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -145,7 +188,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: rhai-pull-secret
-  namespace: rhai-applications
+  namespace: redhat-ods-applications
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -210,20 +253,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: rhai-pull-secret
-  namespace: custom-lws
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: dGVzdGF1dGg=
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rhai-pull-secret
-  namespace: custom-istio
+  namespace: istio-system
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -2418,7 +2448,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rhai-operator-controller-manager
-    namespace: rhai-operator
+    namespace: redhat-ods-operator
 
 ---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/role-azure-cloud-manager-leader-election-role.yaml
@@ -2469,7 +2499,7 @@ metadata:
   labels:
     name: rhods-operator
   name: rhai-operator-controller-manager-metrics-service
-  namespace: rhai-operator
+  namespace: redhat-ods-operator
 spec:
   ports:
     - name: http
@@ -2492,7 +2522,7 @@ metadata:
     app.kubernetes.io/name: rhai-operator-webhook-service
     app.kubernetes.io/part-of: rhai-operator
   name: rhai-operator-webhook-service
-  namespace: rhai-operator
+  namespace: redhat-ods-operator
 spec:
   ports:
     - port: 443
@@ -2555,7 +2585,7 @@ spec:
             - /cloudmanager
           env:
             - name: RHAI_OPERATOR_NAMESPACE
-              value: rhai-operator
+              value: redhat-ods-operator
             - name: RHAI_WEBHOOK_CERT_SECRET_NAME
               value: rhai-operator-controller-webhook-cert
             - name: RHAI_WEBHOOK_SERVICE_NAME
@@ -2621,7 +2651,7 @@ metadata:
   labels:
     name: rhai-operator
   name: rhai-operator
-  namespace: rhai-operator
+  namespace: redhat-ods-operator
 spec:
   replicas: 1
   selector:
@@ -2707,7 +2737,7 @@ spec:
             - name: RHAI_DISABLE_SETUPCONTROLLER_SERVICE
               value: "true"
             - name: RHAI_APPLICATIONS_NAMESPACE
-              value: "rhai-applications"
+              value: "redhat-ods-applications"
             - name: RHAI_VERSION
               value: "3.5.0-ea.2"
             - name: ODH_PLATFORM_TYPE
@@ -2874,6 +2904,15 @@ rules:
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
+      - aigateways
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
       - kserves
     verbs:
       - get
@@ -2936,6 +2975,60 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    resourceNames:
+      - redhat-ods-applications
+    verbs:
+      - get
+      - create
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    resourceNames:
+      - authorino
+    verbs:
+      - get
+      - patch
+  - apiGroups:
       - config.opendatahub.io
     resources:
       - platforms
@@ -2957,6 +3050,15 @@ metadata:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
+  - apiGroups:
+      - components.platform.opendatahub.io
+    resources:
+      - aigateways
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -3030,7 +3132,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: rhai-post-install-hook-cert
-  namespace: rhai-applications
+  namespace: redhat-ods-applications
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -3053,7 +3155,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: rhai-post-install-hook-cert
-  namespace: rhai-applications
+  namespace: redhat-ods-applications
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm
@@ -3140,11 +3242,11 @@ spec:
                     managementPolicy: Managed
                   lws:
                     configuration:
-                      namespace: custom-lws
-                    managementPolicy: Managed
+                      namespace: openshift-lws-operator
+                    managementPolicy: Unmanaged
                   sailOperator:
                     configuration:
-                      namespace: custom-istio
+                      namespace: istio-system
                     managementPolicy: Managed
               EOF
               echo "Waiting for CRD platforms.config.opendatahub.io to be established..."
@@ -3160,8 +3262,30 @@ spec:
                   app.kubernetes.io/managed-by: Helm
               spec:
                 modules:
+                  aigateway:
+                    managementState: Managed
                   kserve:
                     managementState: Managed
+              EOF
+              echo "Waiting for CRD aigateways.components.platform.opendatahub.io to exist..."
+              elapsed=0; while [ $elapsed -lt 300 ]; do
+                kubectl get crd/aigateways.components.platform.opendatahub.io &>/dev/null && break
+                sleep 5; elapsed=$((elapsed + 5))
+              done
+              echo "Waiting for CRD aigateways.components.platform.opendatahub.io to be established..."
+              kubectl wait --for condition=established --timeout=300s crd/aigateways.components.platform.opendatahub.io
+              echo "Creating AIGateway CR..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: components.platform.opendatahub.io/v1alpha1
+              kind: AIGateway
+              metadata:
+                name: default-aigateway
+                labels:
+                  helm.sh/chart: HELM_CHART_VERSION_REDACTED
+                  app.kubernetes.io/managed-by: Helm
+              spec:
+                modelsAsAService:
+                  managementState: Managed
               EOF
               echo "Waiting for CRD kserves.components.platform.opendatahub.io to exist..."
               elapsed=0; while [ $elapsed -lt 300 ]; do
@@ -3245,7 +3369,7 @@ spec:
               INTERVAL=5
               
               # Quoted once here so untrusted values can never reach the shell unquoted.
-              APP_NAMESPACE="rhai-applications"
+              APP_NAMESPACE="redhat-ods-applications"
               
               # general wait function for resource to be ready in the cluster
               wait_for() {
@@ -3291,7 +3415,7 @@ spec:
               kind: ConfigMap
               metadata:
                 name: inference-gateway-config
-                namespace: "rhai-applications"
+                namespace: "redhat-ods-applications"
               data:
                 deployment: |
                   spec:
@@ -3323,7 +3447,7 @@ spec:
               kind: Certificate
               metadata:
                 name: inference-gateway-cert
-                namespace: "rhai-applications"
+                namespace: "redhat-ods-applications"
               spec:
                 secretName: "inference-gateway-cert-secret"
                 issuerRef:
@@ -3331,8 +3455,8 @@ spec:
                   kind: "ClusterIssuer"
                   group: cert-manager.io
                 dnsNames:
-                  - "*.rhai-applications.svc.cluster.local"
-                  - "*.rhai-applications.svc"
+                  - "*.redhat-ods-applications.svc.cluster.local"
+                  - "*.redhat-ods-applications.svc"
               EOF
               echo "Certificate 'inference-gateway-cert' created."
               
@@ -3347,7 +3471,7 @@ spec:
               kind: Gateway
               metadata:
                 name: inference-gateway
-                namespace: "rhai-applications"
+                namespace: "redhat-ods-applications"
               spec:
                 gatewayClassName: istio
                 listeners:
@@ -3378,6 +3502,237 @@ spec:
                     name: inference-gateway-config
               EOF
               echo "Gateway CR 'inference-gateway' created successfully."
+              
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/post-install-maas-gateway-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-post-create-maas-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "3"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-post-install-hook
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: create-maas-gateway
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              TIMEOUT=300
+              INTERVAL=5
+              
+              APP_NAMESPACE="redhat-ods-applications"
+              MAAS_GW_NAMESPACE="redhat-ods-applications"
+              
+              wait_for() {
+                local desc="$1"; shift
+                local elapsed=0
+                echo "Waiting for ${desc}..."
+                until "$@" >/dev/null 2>&1; do
+                  if [ "$elapsed" -ge "$TIMEOUT" ]; then
+                    echo "ERROR: Timed out waiting for ${desc} after ${TIMEOUT}s"
+                    exit 1
+                  fi
+                  echo "${desc} not yet available, retrying in ${INTERVAL}s... (${elapsed}/${TIMEOUT}s)"
+                  sleep "$INTERVAL"
+                  elapsed=$((elapsed + INTERVAL))
+                done
+                echo "${desc} is available."
+              }
+              
+              maas_gw_cert_ready() {
+                [ "$(kubectl get certificate maas-gateway-cert -n "$MAAS_GW_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)" = "True" ]
+              }
+              
+              echo "=== MaaS Gateway Setup ==="
+              
+              echo "Step 1: Create MaaS gateway namespace..."
+              kubectl create namespace "$MAAS_GW_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+              
+              echo "Step 2: Create CA bundle ConfigMaps..."
+              wait_for "cert-manager CA secret" kubectl get secret rhai-ca -n cert-manager
+              kubectl get secret rhai-ca -n cert-manager -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/ca.crt
+              kubectl create configmap rhai-ca-bundle --from-file=ca.crt=/tmp/ca.crt -n "$APP_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+              kubectl create configmap rhai-ca-bundle --from-file=ca.crt=/tmp/ca.crt -n "$MAAS_GW_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+              echo "CA bundle ConfigMaps created."
+              
+              echo "Step 3: Create MaaS gateway config ConfigMap..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: maas-gateway-config
+                namespace: "redhat-ods-applications"
+              data:
+                deployment: |
+                  spec:
+                    template:
+                      spec:
+                        volumes:
+                        - name: rhai-ca-bundle
+                          configMap:
+                            name: rhai-ca-bundle
+                        containers:
+                        - name: istio-proxy
+                          volumeMounts:
+                          - name: rhai-ca-bundle
+                            mountPath: /var/run/secrets/opendatahub
+                            readOnly: true
+                          - name: rhai-ca-bundle
+                            mountPath: /var/run/secrets/rhai
+                            readOnly: true
+                service: |
+                  metadata:
+                    annotations:
+                      service.beta.kubernetes.io/port_80_health-probe_protocol: tcp
+              EOF
+              echo "MaaS gateway ConfigMap created."
+              echo "Step 4: Create MaaS gateway TLS Certificate..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: cert-manager.io/v1
+              kind: Certificate
+              metadata:
+                name: maas-gateway-cert
+                namespace: "redhat-ods-applications"
+              spec:
+                secretName: "maas-gateway-cert-secret"
+                issuerRef:
+                  name: "rhai-ca-issuer"
+                  kind: "ClusterIssuer"
+                  group: cert-manager.io
+                dnsNames:
+                  - "*.redhat-ods-applications.svc.cluster.local"
+                  - "*.redhat-ods-applications.svc"
+              EOF
+              wait_for "MaaS gateway Certificate to be Ready" maas_gw_cert_ready
+              
+              echo "Step 5: Create MaaS API serving Certificate..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: cert-manager.io/v1
+              kind: Certificate
+              metadata:
+                name: maas-api-serving-cert
+                namespace: "redhat-ods-applications"
+              spec:
+                secretName: maas-api-serving-cert
+                issuerRef:
+                  name: "rhai-ca-issuer"
+                  kind: "ClusterIssuer"
+                  group: cert-manager.io
+                dnsNames:
+                  - "maas-api.redhat-ods-applications.svc"
+                  - "maas-api.redhat-ods-applications.svc.cluster.local"
+              EOF
+              
+              echo "Step 6: Create MaaS Gateway..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: "maas-default-gateway"
+                namespace: "redhat-ods-applications"
+              spec:
+                gatewayClassName: "istio"
+                listeners:
+                  - name: http
+                    port: 80
+                    protocol: HTTP
+                    allowedRoutes:
+                      namespaces:
+                        from: Same
+                  - name: https
+                    port: 443
+                    protocol: HTTPS
+                    allowedRoutes:
+                      namespaces:
+                        from: Same
+                    tls:
+                      certificateRefs:
+                        - group: ''
+                          kind: Secret
+                          name: "maas-gateway-cert-secret"
+                      mode: Terminate
+                infrastructure:
+                  parametersRef:
+                    group: ""
+                    kind: ConfigMap
+                    name: maas-gateway-config
+              EOF
+              echo "MaaS Gateway created successfully."
+              
+              echo "Step 7: Copy pull secret to MaaS gateway namespace..."
+              if kubectl get secret rhai-pull-secret -n "$APP_NAMESPACE" >/dev/null 2>&1; then
+                DOCKER_CONFIG=$(kubectl get secret rhai-pull-secret -n "$APP_NAMESPACE" -o jsonpath='{.data.\.dockerconfigjson}')
+                kubectl create secret generic rhai-pull-secret \
+                  --from-literal=.dockerconfigjson="$(echo "$DOCKER_CONFIG" | base64 -d)" \
+                  --type=kubernetes.io/dockerconfigjson \
+                  -n "$MAAS_GW_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+                echo "Pull secret copied."
+              else
+                echo "No rhai-pull-secret found, skipping."
+              fi
+              
+              echo "Step 8: Configure Authorino CA trust for MaaS API callbacks..."
+              KUADRANT_NS="kuadrant-system"
+              if kubectl get namespace "$KUADRANT_NS" >/dev/null 2>&1; then
+                kubectl create configmap rhai-ca-bundle --from-file=ca.crt=/tmp/ca.crt \
+                  -n "$KUADRANT_NS" --dry-run=client -o yaml | kubectl apply -f -
+              
+                kubectl patch deployment authorino -n "$KUADRANT_NS" --type=json -p='[
+                  {"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"rhai-ca","configMap":{"name":"rhai-ca-bundle"}}},
+                  {"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"rhai-ca","mountPath":"/etc/pki/tls/custom","readOnly":true}},
+                  {"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"SSL_CERT_FILE","value":"/etc/pki/tls/custom/ca.crt"}}
+                ]'
+                echo "Authorino CA trust configured."
+              else
+                echo "Kuadrant namespace not found, skipping Authorino CA trust."
+              fi
+              
+              echo "=== MaaS Gateway setup complete ==="
               
 
 ---
@@ -3432,6 +3787,8 @@ spec:
             - -c
             - |
               set -euo pipefail
+              echo "Deleting AIGateway CR 'default-aigateway'..."
+              kubectl delete aigateway default-aigateway --ignore-not-found --timeout=300s
               echo "Deleting Kserve CR 'default-kserve'..."
               kubectl delete kserve default-kserve --ignore-not-found --timeout=300s
               echo "Deleting Platform CR 'default'..."

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -79,7 +79,24 @@ imagePullSecrets:
 
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
-# TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kserve-controller-manager
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kserve-module-controller-manager
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -82,15 +82,6 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kserve-controller-manager
-  namespace: redhat-ods-applications
-imagePullSecrets:
-  - name: rhai-pull-secret
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
   name: kserve-module-controller-manager
   namespace: redhat-ods-applications
 imagePullSecrets:

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
@@ -90,7 +90,24 @@ imagePullSecrets:
 
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
-# TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kserve-controller-manager
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kserve-module-controller-manager
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
@@ -93,15 +93,6 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kserve-controller-manager
-  namespace: redhat-ods-applications
-imagePullSecrets:
-  - name: rhai-pull-secret
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
   name: kserve-module-controller-manager
   namespace: redhat-ods-applications
 imagePullSecrets:

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -79,7 +79,24 @@ imagePullSecrets:
 
 ---
 # Source: rhai-on-xks-chart/templates/pull-secret.yaml
-# TODO: This is a temporary solution to inject the pull secret into the llmisvc-controller-manager service account.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kserve-controller-manager
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kserve-module-controller-manager
+  namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -82,15 +82,6 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kserve-controller-manager
-  namespace: redhat-ods-applications
-imagePullSecrets:
-  - name: rhai-pull-secret
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
   name: kserve-module-controller-manager
   namespace: redhat-ods-applications
 imagePullSecrets:

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -93,15 +93,6 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kserve-controller-manager
-  namespace: rhai-applications
-imagePullSecrets:
-  - name: rhai-pull-secret
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
   name: kserve-module-controller-manager
   namespace: rhai-applications
 imagePullSecrets:

--- a/scripts/snapshot-config.yaml
+++ b/scripts/snapshot-config.yaml
@@ -193,3 +193,9 @@ charts:
         setFlags:
           - azure.enabled=true
           - components.aigateway.enabled=true
+
+      - name: azure-with-maas-and-pull-secret
+        setFlags:
+          - azure.enabled=true
+          - components.aigateway.enabled=true
+          - imagePullSecret.dockerConfigJson=testauth


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

we need to think about how to do this in the future
if the inejction is in ODH operator, it is strange as we have started modulare arch whcih like the sub-component batch and maas should be done in their own logic.


Jira task: <!--- Link your JIRA and related links here for reference. -->

ref https://redhat.atlassian.net/browse/RHOAIENG-79301

## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->

- [ ] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull-secret injection now supports creating multiple operator-managed ServiceAccounts, including KServe controller components, when the related components are enabled.
* **Bug Fixes**
  * Ensured the configured image pull secret is consistently referenced by the relevant ServiceAccounts across supported environments.
* **Tests**
  * Updated rendered-manifest snapshots to include the new KServe-related ServiceAccount and validate correct pull-secret references (including Azure with MaaS scenarios).
* **Chores**
  * Increased verification timeout and improved Helm hook failure diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->