### PR TITLE
fix(RHOAIENG-79510): inject imagePullSecrets into default SA in kuadrant-system

### DIFF
--- a/charts/dependencies/rhcl-operator/templates/serviceaccount-default-operand.yaml
+++ b/charts/dependencies/rhcl-operator/templates/serviceaccount-default-operand.yaml
@@ -3,6 +3,8 @@ kind: ServiceAccount
 metadata:
   name: default
   namespace: {{ .Values.operandNamespace }}
+  annotations:
+    helm.sh/resource-policy: keep
 {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/charts/dependencies/rhcl-operator/templates/serviceaccount-default-operand.yaml
+++ b/charts/dependencies/rhcl-operator/templates/serviceaccount-default-operand.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: {{ .Values.operandNamespace }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}

--- a/charts/dependencies/rhcl-operator/test/snapshots/default.snap.yaml
+++ b/charts/dependencies/rhcl-operator/test/snapshots/default.snap.yaml
@@ -32,6 +32,16 @@ imagePullSecrets:
   - name: rhai-pull-secret
 
 ---
+# Source: rhcl-operator/templates/serviceaccount-default-operand.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: kuadrant-system
+imagePullSecrets:
+  - name: rhai-pull-secret
+
+---
 # Source: rhcl-operator/templates/serviceaccount-developer-portal-controller-manager.yaml
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/dependencies/rhcl-operator/test/snapshots/default.snap.yaml
+++ b/charts/dependencies/rhcl-operator/test/snapshots/default.snap.yaml
@@ -38,6 +38,8 @@ kind: ServiceAccount
 metadata:
   name: default
   namespace: kuadrant-system
+  annotations:
+    helm.sh/resource-policy: keep
 imagePullSecrets:
   - name: rhai-pull-secret
 


### PR DESCRIPTION
## Summary

- Limitador operand pods in `kuadrant-system` use the `default` ServiceAccount which has no `imagePullSecrets` configured
- This causes `ImagePullBackOff` for `registry.redhat.io/rhcl-1/limitador-rhel9` on fresh xKS clusters where registry authentication is required
- Authorino works because the `authorino-authorino` SA (created by `serviceaccount-components.yaml`) inherits pull secrets from values
- Adds a new template that patches the `default` SA in the operand namespace with `imagePullSecrets`, matching the existing pattern

## Root Cause

The Kuadrant operator creates Limitador pods but does not set `imagePullSecrets` on them (unlike Authorino which gets it via its dedicated SA). This is a Kuadrant operator limitation.

## Workaround

Same pattern as the existing `llmisvc-controller-manager` SA workaround in the main xKS chart — patch the SA used by Limitador pods.

## Test plan

- [x] `helm lint charts/dependencies/rhcl-operator` passes
- [x] `make chart-test` passes (all snapshots)
- [ ] Deploy on fresh AKS cluster with `--set-file imagePullSecret.dockerConfigJson=...`
- [ ] Verify Limitador pods pull successfully from `registry.redhat.io`

Fixes: https://issues.redhat.com/browse/RHOAIENG-79510


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic creation of a default Kubernetes ServiceAccount in the configured namespace.
  * Includes a “keep” resource policy annotation so it persists across Helm upgrades/removals.
  * Supports optional image pull secrets when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->