### PR TITLE
chore: bump rhai-on-xks-chart version to 3.5.0 GA

### DIFF
--- a/charts/rhai-on-xks-chart/Chart.yaml
+++ b/charts/rhai-on-xks-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rhai-on-xks-chart
 description: RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes services (AWS, Azure, CoreWeave).
 type: application
-version: 3.5.0-ea.2
-appVersion: 3.5.0-ea.2
+version: 3.5.0
+appVersion: 3.5.0

--- a/charts/rhai-on-xks-chart/api-docs.md
+++ b/charts/rhai-on-xks-chart/api-docs.md
@@ -1,6 +1,6 @@
 # rhai-on-xks-chart
 
-![Version: 3.5.0-ea.2](https://img.shields.io/badge/Version-3.5.0--ea.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.0-ea.2](https://img.shields.io/badge/AppVersion-3.5.0--ea.2-informational?style=flat-square)
+![Version: 3.5.0](https://img.shields.io/badge/Version-3.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.0](https://img.shields.io/badge/AppVersion-3.5.0-informational?style=flat-square)
 
 RHAI on XKS Helm chart for non-OLM installation on non-OpenShift Kubernetes services (AWS, Azure, CoreWeave).
 

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
@@ -2489,7 +2489,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
@@ -2322,7 +2322,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
@@ -2322,7 +2322,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -2465,7 +2465,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -2322,7 +2322,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
@@ -2489,7 +2489,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
@@ -2322,7 +2322,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
@@ -2322,7 +2322,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
@@ -2322,7 +2322,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
@@ -2534,7 +2534,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
@@ -2322,7 +2322,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
@@ -2322,7 +2322,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -2465,7 +2465,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2322,7 +2322,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
@@ -2322,7 +2322,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
@@ -2489,7 +2489,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
@@ -2322,7 +2322,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -2465,7 +2465,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -2322,7 +2322,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "redhat-ods-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -2489,7 +2489,7 @@ spec:
             - name: RHAI_APPLICATIONS_NAMESPACE
               value: "rhai-applications"
             - name: RHAI_VERSION
-              value: "3.5.0-ea.2"
+              value: "3.5.0"
             - name: ODH_PLATFORM_TYPE
               value: XKS
             - name: RHAI_CA_SECRET_NAME


### PR DESCRIPTION
 Bumps `version` and `appVersion` in `charts/rhai-on-xks-chart/Chart.yaml`
  from `3.5.0-ea.2` to `3.5.0` to reflect the GA release.

  The 3.5.0 GA chart has been published to `quay.io/rhoai/rhai-on-xks-chart`
  (tag `v3.5.0`). This change keeps the chart source in sync with the
  published artifact.

  Also regenerates helm snapshots.

  ## Test plan

  - [ ] `make chart-test CHART_NAME=rhai-on-xks-chart` — all snapshot tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Updated the chart metadata and runtime configuration from pre-release 3.5.0-ea.2 to stable 3.5.0.
  * Applied the stable 3.5.0 version consistently across supported deployment scenarios.
* **Tests**
  * Refreshed rendered deployment snapshots to match the stable 3.5.0 configuration.
* **Documentation**
  * Updated the chart version badge in the API documentation to reflect 3.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->