### PR TITLE
fix(xks): propagate pull secret to redhat-ai-gateway-infra namespace

### DIFF
--- a/charts/rhai-on-xks-chart/templates/_helpers.tpl
+++ b/charts/rhai-on-xks-chart/templates/_helpers.tpl
@@ -111,6 +111,9 @@ Usage:
     {{- end }}
   {{- end }}
 {{- end }}
+{{- if and .root.Values.components.aigateway.enabled (eq (dig "spec" "modelsAsAService" "managementState" "" .root.Values.components.aigateway) "Managed") }}
+  {{- $namespaces = append $namespaces "redhat-ai-gateway-infra" }}
+{{- end }}
 {{- dict "items" ($namespaces | uniq) | toJson }}
 {{- end -}}
 

--- a/charts/rhai-on-xks-chart/templates/pull-secret.yaml
+++ b/charts/rhai-on-xks-chart/templates/pull-secret.yaml
@@ -54,6 +54,7 @@ metadata:
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-controller" "namespace" $appNs) }}
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-api" "namespace" $appNs) }}
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-api-cleanup" "namespace" $appNs) }}
+  {{- $serviceAccounts = append $serviceAccounts (dict "name" "payload-processing" "namespace" "redhat-ai-gateway-infra") }}
   {{- end }}
   {{- /* The batch-gateway operator is deployed only when batchGateway is Managed. */}}
   {{- if eq (dig "spec" "batchGateway" "managementState" "" $aigw) "Managed" }}

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
@@ -68,6 +68,17 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 ---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: redhat-ai-gateway-infra
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+---
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -129,6 +140,15 @@ kind: ServiceAccount
 metadata:
   name: maas-api-cleanup
   namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: payload-processing
+  namespace: redhat-ai-gateway-infra
 imagePullSecrets:
   - name: rhai-pull-secret
 
@@ -227,6 +247,19 @@ kind: Secret
 metadata:
   name: rhai-pull-secret
   namespace: istio-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: dGVzdGF1dGg=
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhai-pull-secret
+  namespace: redhat-ai-gateway-infra
   labels:
     helm.sh/chart: HELM_CHART_VERSION_REDACTED
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
## Summary
- `maas-controller` creates `payload-processing` and `payload-pre-processing` deployments in the `redhat-ai-gateway-infra` namespace
- When using private registries (`registry.redhat.io`), these pods fail with `ImagePullBackOff` because the namespace lacks a pull secret
- Add `redhat-ai-gateway-infra` to `imagePullSecret.dependencyNamespaces` so the chart pre-creates both the namespace and pull secret
- Pre-create the `payload-processing` ServiceAccount with `imagePullSecrets` so pods inherit credentials at admission time

## Test plan
- [x] Confirmed `redhat-ai-gateway-infra` namespace is created by maas-controller on AKS
- [x] Confirmed payload-processing uses ServiceAccount `payload-processing`
- [ ] Validate `helm template` renders the pull secret and SA correctly
- [ ] Validate pods in redhat-ai-gateway-infra can pull from registry.redhat.io

Ref: [RHOAIENG-79301](https://redhat.atlassian.net/browse/RHOAIENG-79301)

Made with [Cursor](https://cursor.com)

[RHOAIENG-79301]: https://redhat.atlassian.net/browse/RHOAIENG-79301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image pull secret distribution for managed MaaS deployments.
  * Ensured the payload-processing service can access required container images when the AI Gateway is enabled.
  * Added support for creating and cleaning up the AI Gateway infrastructure namespace and its pull secret across supported deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->