### PR TITLE
fix(xks): bundle MaaS and Kuadrant CRDs in chart for fresh installs

### DIFF
--- a/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+++ b/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
@@ -1,0 +1,231 @@
+{{- if .Values.installCRDs }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+++ b/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
@@ -1,0 +1,480 @@
+{{- if .Values.installCRDs }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+++ b/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
@@ -1,0 +1,383 @@
+{{- if .Values.installCRDs }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+++ b/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
@@ -1,0 +1,485 @@
+{{- if .Values.installCRDs }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+++ b/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
@@ -1,0 +1,251 @@
+{{- if .Values.installCRDs }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+++ b/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
@@ -1,0 +1,268 @@
+{{- if .Values.installCRDs }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+++ b/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
@@ -1,0 +1,245 @@
+{{- if .Values.installCRDs }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+++ b/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
@@ -1,0 +1,360 @@
+{{- if .Values.installCRDs }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+++ b/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
@@ -1,0 +1,189 @@
+{{- if .Values.installCRDs }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
@@ -449,6 +449,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
@@ -282,6 +282,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
@@ -282,6 +282,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -425,6 +425,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -282,6 +282,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
@@ -449,6 +449,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
@@ -282,6 +282,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
@@ -282,6 +282,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
@@ -282,6 +282,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
@@ -461,6 +461,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
@@ -282,6 +282,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
@@ -282,6 +282,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -425,6 +425,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -282,6 +282,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
@@ -282,6 +282,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
@@ -449,6 +449,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
@@ -282,6 +282,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -425,6 +425,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -282,6 +282,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -449,6 +449,2898 @@ spec:
         status: {}
 
 ---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_kuadrants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: kuadrants.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[0].reason
+      name: Status
+      priority: 2
+      type: string
+    - jsonPath: .status.mtlsAuthorino
+      name: mTLS Authorino
+      type: boolean
+    - jsonPath: .status.mtlsLimitador
+      name: mTLS Limitador
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties:
+              components:
+                description: Components configures optional Kuadrant components
+                properties:
+                  developerPortal:
+                    description: DeveloperPortal enables the developer portal integration
+                      including APIProduct and APIKeyRequest CRDs
+                    properties:
+                      enabled:
+                        type: boolean
+                    type: object
+                type: object
+              mtls:
+                description: |-
+                  MTLS is an optional entry which when enabled is set to true, kuadrant-operator
+                  will add the configuration required to enable mTLS between an Istio provided
+                  gateway and the Kuadrant components.
+                properties:
+                  authorino:
+                    type: boolean
+                  enable:
+                    type: boolean
+                  limitador:
+                    type: boolean
+                type: object
+              observability:
+                description: |-
+                  Observability configures telemetry and monitoring settings for Kuadrant components.
+                  When enabled, it configures logging, tracing, and other observability features for both
+                  the control plane and data plane components.
+                properties:
+                  dataPlane:
+                    description: DataPlane configures observability settings for the
+                      data plane components.
+                    properties:
+                      defaultLevels:
+                        description: |-
+                          DefaultLevels specifies the default logging levels and their activation predicates.
+                          Each entry defines a log level (debug, info, warn, error) and an optional CEL expression
+                          that determines when that level should be active for a given request.
+                        items:
+                          description: |-
+                            LogLevel defines a logging level with its activation predicate
+                            Only one field should be set per LogLevel entry
+                          properties:
+                            debug:
+                              description: Debug level - highest verbosity
+                              type: string
+                            error:
+                              description: Error level - lowest verbosity
+                              type: string
+                            info:
+                              description: Info level
+                              type: string
+                            warn:
+                              description: Warn level
+                              type: string
+                          type: object
+                        type: array
+                      httpHeaderIdentifier:
+                        description: |-
+                          HTTPHeaderIdentifier specifies the HTTP header name used to identify and correlate
+                          requests in logs and traces (e.g., "x-request-id", "x-correlation-id").
+                          If set, this header value will be included in log output for request correlation.
+                        type: string
+                    type: object
+                  enable:
+                    description: |-
+                      Enable controls whether observability features are active.
+                      When false, no additional logging or tracing configuration is applied.
+                    type: boolean
+                  tracing:
+                    description: Tracing configures distributed tracing for request
+                      flows through the system.
+                    properties:
+                      defaultEndpoint:
+                        description: |-
+                          DefaultEndpoint is the default URL of the tracing collector backend where spans should be sent.
+                          This endpoint is used by Auth (Authorino), RateLimiting (Limitador) and WASM services for exporting trace data.
+                          If tracing endpoints have been configured directly in Authorino or Limitador CRs, those take precedence
+                          over this default value.
+                          Note: Per-gateway overrides are not currently supported.
+                        type: string
+                      insecure:
+                        description: Insecure controls whether to skip TLS certificate
+                          verification.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KuadrantStatus defines the observed state of Kuadrant
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              mtlsAuthorino:
+                description: Mtls Authorino reflects the mtls feature state regarding
+                  comms with authorino.
+                type: boolean
+              mtlsLimitador:
+                description: Mtls Limitador reflects the mtls feature state regarding
+                  comms with limitador.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_ratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: ratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: RateLimitPolicy
+    listKind: RateLimitPolicyList
+    plural: ratelimitpolicies
+    singular: ratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitPolicy enables rate limiting for service workloads in
+          a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policiy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: Limit represents a complete rate limit configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of limits indexed by a unique
+                  name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: Limit represents a complete rate limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of limits indexed by a unique
+                      name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute',
+                    'GRPCRoute' and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'GRPCRoute' || self.kind
+                    == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tlspolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Type of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.kind
+      name: TargetRefKind
+      priority: 2
+      type: string
+    - description: Name of the referenced Gateway API resource
+      jsonPath: .spec.targetRef.name
+      name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: |-
+                  CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to avoid
+                  generating invalid CSRs.
+                  This value is ignored by TLS clients when any subject alt name is set.
+                  This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
+                type: string
+              duration:
+                description: |-
+                  The requested 'duration' (i.e. lifetime) of the Certificate. This option
+                  may be ignored/overridden by some issuer types. If unset this defaults to
+                  90 days. Certificate will be renewed either 2/3 through its duration or
+                  `renewBefore` period before its expiry, whichever is later. Minimum
+                  accepted duration is 1 hour. Value must be in units accepted by Go
+                  time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: |-
+                  IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will be used.
+                  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
+                  provided name will be used.
+                  The `name` field in this stanza is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: |-
+                      Algorithm is the private key algorithm of the corresponding private key
+                      for this certificate.
+
+                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                      If `algorithm` is specified and `size` is not provided,
+                      key size of 2048 will be used for `RSA` key algorithm and
+                      key size of 256 will be used for `ECDSA` key algorithm.
+                      key size is ignored when using the `Ed25519` key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: |-
+                      The private key cryptography standards (PKCS) encoding for this
+                      certificate's private key to be encoded in.
+
+                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                      and PKCS#8, respectively.
+                      Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: |-
+                      RotationPolicy controls how private keys should be regenerated when a
+                      re-issuance is being processed.
+
+                      If set to `Never`, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exist but it
+                      does not have the correct algorithm or size, a warning will be raised
+                      to await user intervention.
+                      If set to `Always`, a private key matching the specified requirements
+                      will be generated whenever a re-issuance occurs.
+                      Default is `Never` for backward compatibility.
+                    enum:
+                    - Never
+                    - Always
+                    type: string
+                  size:
+                    description: |-
+                      Size is the key bit size of the corresponding private key for this certificate.
+
+                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                      and will default to `2048` if not specified.
+                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                      and will default to `256` if not specified.
+                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: |-
+                  How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of the
+                  issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration
+                  https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of CertificateRequest revisions
+                  that are maintained in the Certificate's history. Each revision represents
+                  a single `CertificateRequest` created by this Certificate, either when it
+                  was created, renewed, or Spec was changed. Revisions will be removed by
+                  oldest first if the number of revisions exceeds this number. If set,
+                  revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+                  revisions will not be garbage collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'Gateway'
+                  rule: self.kind == 'Gateway'
+              usages:
+                description: |-
+                  Usages is the set of x509 usages that are requested for the certificate.
+                  Defaults to `digital signature` and `key encipherment` if not specified.
+                items:
+                  description: |-
+                    KeyUsage specifies valid usage contexts for keys.
+                    See:
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                    https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                    Valid KeyUsage values are as follows:
+                    "signing",
+                    "digital signature",
+                    "content commitment",
+                    "key encipherment",
+                    "key agreement",
+                    "data encipherment",
+                    "cert sign",
+                    "crl sign",
+                    "encipher only",
+                    "decipher only",
+                    "any",
+                    "server auth",
+                    "client auth",
+                    "code signing",
+                    "email protection",
+                    "s/mime",
+                    "ipsec end system",
+                    "ipsec tunnel",
+                    "ipsec user",
+                    "timestamping",
+                    "ocsp signing",
+                    "microsoft sgc",
+                    "netscape sgc"
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the policy
+
+                  If configuring the policy fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  observedGeneration is the most recently observed generation of the
+                  TLSPolicy.  When the TLSPolicy is updated, the controller updates the
+                  corresponding configuration. If an update fails, that failure is
+                  recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-kuadrant.io_tokenratelimitpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
+  name: tokenratelimitpolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TokenRateLimitPolicy
+    listKind: TokenRateLimitPolicyList
+    plural: tokenratelimitpolicies
+    singular: tokenratelimitpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TokenRateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TokenRateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
+      priority: 2
+      type: string
+    - description: Kind of the object to which the policy applies
+      jsonPath: .spec.targetRef.kind
+      name: TargetKind
+      priority: 2
+      type: string
+    - description: Name of the object to which the policy applies
+      jsonPath: .spec.targetRef.name
+      name: TargetName
+      priority: 2
+      type: string
+    - description: 'Name of the section within the object to which the policy applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TokenRateLimitPolicy enables token-based rate limiting for service
+          workloads in a Gateway API network
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaults:
+                description: |-
+                  Rules to apply as defaults. Can be overridden by more specific policy rules lower in the hierarchy and by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              limits:
+                additionalProperties:
+                  description: TokenLimit represents a complete token-based rate limit
+                    configuration
+                  properties:
+                    counters:
+                      description: Counters defines additional rate limit counters
+                        based on CEL expressions which can reference well known selectors
+                      items:
+                        properties:
+                          expression:
+                            description: |-
+                              Expression defines one CEL expression
+                              Expression can use well known attributes
+                              Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                              Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                              They are named by a dot-separated path (e.g. request.path)
+                              Example: "request.path" -> The path portion of the URL
+                            minLength: 1
+                            type: string
+                        required:
+                        - expression
+                        type: object
+                      type: array
+                    rates:
+                      description: Rates holds the list of limit rates for token-based
+                        limiting
+                      items:
+                        description: Rate defines the actual rate limit that will
+                          be used when there is a match
+                        properties:
+                          limit:
+                            description: Limit defines the max value allowed for a
+                              given period of time
+                            type: integer
+                          window:
+                            description: Window defines the time period for which
+                              the Limit specified above applies.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      type: array
+                    when:
+                      description: |-
+                        When holds a list of "limit-level" `Predicate`s for token-based conditions
+                        Called also "soft" conditions as route selectors must also match
+                      items:
+                        description: Predicate defines one CEL expression that must
+                          be evaluated to bool
+                        properties:
+                          predicate:
+                            minLength: 1
+                            type: string
+                        required:
+                        - predicate
+                        type: object
+                      type: array
+                  type: object
+                description: Limits holds the struct of token-based limits indexed
+                  by a unique name
+                type: object
+              overrides:
+                description: |-
+                  Rules to apply as overrides. Override all policy rules lower in the hierarchy. Can be overridden by less specific policy overrides.
+                  Use one of: defaults, overrides, or bare set of policy rules (implicit defaults).
+                properties:
+                  limits:
+                    additionalProperties:
+                      description: TokenLimit represents a complete token-based rate
+                        limit configuration
+                      properties:
+                        counters:
+                          description: Counters defines additional rate limit counters
+                            based on CEL expressions which can reference well known
+                            selectors
+                          items:
+                            properties:
+                              expression:
+                                description: |-
+                                  Expression defines one CEL expression
+                                  Expression can use well known attributes
+                                  Attributes: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                                  Well-known selectors: https://github.com/Kuadrant/architecture/blob/main/rfcs/0001-rlp-v2.md#well-known-selectors
+                                  They are named by a dot-separated path (e.g. request.path)
+                                  Example: "request.path" -> The path portion of the URL
+                                minLength: 1
+                                type: string
+                            required:
+                            - expression
+                            type: object
+                          type: array
+                        rates:
+                          description: Rates holds the list of limit rates for token-based
+                            limiting
+                          items:
+                            description: Rate defines the actual rate limit that will
+                              be used when there is a match
+                            properties:
+                              limit:
+                                description: Limit defines the max value allowed for
+                                  a given period of time
+                                type: integer
+                              window:
+                                description: Window defines the time period for which
+                                  the Limit specified above applies.
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                type: string
+                            required:
+                            - limit
+                            - window
+                            type: object
+                          type: array
+                        when:
+                          description: |-
+                            When holds a list of "limit-level" `Predicate`s for token-based conditions
+                            Called also "soft" conditions as route selectors must also match
+                          items:
+                            description: Predicate defines one CEL expression that
+                              must be evaluated to bool
+                            properties:
+                              predicate:
+                                minLength: 1
+                                type: string
+                            required:
+                            - predicate
+                            type: object
+                          type: array
+                      type: object
+                    description: Limits holds the struct of token-based limits indexed
+                      by a unique name
+                    type: object
+                  strategy:
+                    default: atomic
+                    description: Strategy defines the merge strategy to apply when
+                      merging this policy with other policies.
+                    enum:
+                    - atomic
+                    - merge
+                    type: string
+                  when:
+                    description: |-
+                      Overall conditions for the policy to be enforced.
+                      If omitted, the policy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the policy to be enforced.
+                    items:
+                      description: Predicate defines one CEL expression that must
+                        be evaluated to bool
+                      properties:
+                        predicate:
+                          minLength: 1
+                          type: string
+                      required:
+                      - predicate
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: Reference to the object to which this policy applies.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  sectionName:
+                    description: |-
+                      SectionName is the name of a section within the target resource. When
+                      unspecified, this targetRef targets the entire resource. In the following
+                      resources, SectionName is interpreted as the following:
+
+                      * Gateway: Listener name
+                      * HTTPRoute: HTTPRouteRule name
+                      * Service: Port name
+
+                      If a SectionName is specified, but does not exist on the targeted object,
+                      the Policy must fail to attach, and the policy implementation should record
+                      a `ResolvedRefs` or similar Condition in the Policy's status.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+              when:
+                description: |-
+                  Overall conditions for the policy to be enforced.
+                  If omitted, the policy will be enforced at all requests to the protected routes.
+                  If present, all conditions must match for the policy to be enforced.
+                items:
+                  description: Predicate defines one CEL expression that must be evaluated
+                    to bool
+                  properties:
+                    predicate:
+                      minLength: 1
+                      type: string
+                  required:
+                  - predicate
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: Implicit and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.limits))'
+            - message: Overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.defaults) && has(self.overrides))'
+            - message: Overrides and implicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.limits))'
+            - message: At least one spec.limits must be defined
+              rule: '!(has(self.overrides) || has(self.defaults)) ? has(self.limits)
+                && size(self.limits) > 0 : true'
+            - message: At least one spec.overrides.limits must be defined
+              rule: 'has(self.overrides) ? has(self.overrides.limits) && size(self.overrides.limits)
+                > 0 : true'
+            - message: At least one spec.defaults.limits must be defined
+              rule: 'has(self.defaults) ? has(self.defaults.limits) && size(self.defaults.limits)
+                > 0 : true'
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Represents the observations of a foo's current state.
+                  Known .status.conditions.type are: "Available"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_aitenants.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: aitenants.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: AITenant
+    listKind: AITenantList
+    plural: aitenants
+    shortNames:
+    - ait
+    singular: aitenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Tenant namespace
+      jsonPath: .status.tenantNamespace
+      name: Tenant Namespace
+      type: string
+    - description: Gateway name
+      jsonPath: .status.gatewayRef.name
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          AITenant bootstraps one tenant slice: a tenant namespace, an existing
+          network-admin-provisioned Gateway reference, the MaaS tenant config object,
+          and tenant-admin Roles.
+
+          The AITenant name is used as a suffix for per-tenant maas-api resources
+          (e.g., "maas-api-{tenant-name}"). To fit within the Kubernetes 63-character
+          resource name limit while using the longest base name ("maas-api-auth-policy" = 21 chars),
+          AITenant names are restricted to 41 characters maximum (21 + 1 separator + 41 = 63).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AITenantSpec defines the tenant bootstrap contract.
+            properties:
+              gateway:
+                description: Gateway references the network-admin-provisioned Gateway
+                  API Gateway for this tenant.
+                properties:
+                  name:
+                    description: |-
+                      Name is the Gateway name. If omitted, the AITenant name is used. The
+                      namespace comes from controller configuration and is reported in status.
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              oidc:
+                description: |-
+                  OIDC contains non-MaaS-specific OIDC settings for this AI Gateway tenant.
+                  AITenant is the source of truth for this derived platform context; the
+                  bridge Tenant config object owns MaaS-specific user config only.
+                properties:
+                  clientId:
+                    description: ClientID is the OAuth2 client ID.
+                    maxLength: 256
+                    minLength: 1
+                    pattern: ^\S+$
+                    type: string
+                  issuerUrl:
+                    description: IssuerURL is the OIDC issuer URL (e.g. https://keycloak.example.com/realms/maas).
+                    maxLength: 2048
+                    minLength: 9
+                    pattern: ^https://\S+$
+                    type: string
+                  ttl:
+                    default: 300
+                    description: TTL is the JWKS cache duration in seconds.
+                    minimum: 30
+                    type: integer
+                required:
+                - clientId
+                - issuerUrl
+                type: object
+              rbac:
+                description: |-
+                  RBAC is retained only for compatibility with existing AITenant manifests.
+                  The controller ignores this field and does not create RoleBindings from it.
+
+                  Deprecated: create standard Kubernetes RoleBindings that reference the
+                  controller-created tenant-admin Roles instead.
+                properties:
+                  admins:
+                    description: |-
+                      Admins are ignored by the controller and retained only for schema compatibility.
+
+                      Deprecated: create Kubernetes RoleBindings directly.
+                    items:
+                      description: |-
+                        AITenantRBACSubject mirrors RBAC Subject for the deprecated spec.rbac schema.
+
+                        Deprecated: this field is ignored; create Kubernetes RoleBindings directly.
+                      properties:
+                        kind:
+                          description: Kind is the RBAC subject kind.
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          description: Name is the subject name.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is required only for ServiceAccount
+                            subjects.
+                          maxLength: 63
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 128
+                    type: array
+                type: object
+            type: object
+          status:
+            description: AITenantStatus defines the observed tenant bootstrap state.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayRef:
+                description: GatewayRef is the resolved existing Gateway reference.
+                properties:
+                  name:
+                    default: maas-default-gateway
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                  namespace:
+                    default: openshift-ingress
+                    maxLength: 63
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
+                    type: string
+                type: object
+              phase:
+                description: Phase is a high-level lifecycle phase for the tenant
+                  bootstrap.
+                enum:
+                - Pending
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              tenantNamespace:
+                description: TenantNamespace is the reconciled tenant namespace.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: AITenant name must be at most 41 characters (required for per-tenant
+            resource naming with 63-character Kubernetes limit)
+          rule: self.metadata.name.size() <= 41
+        - message: AITenant name must be a valid DNS-1123 label (lowercase alphanumeric
+            and hyphens, starting and ending with alphanumeric)
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasauthpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasauthpolicies.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSAuthPolicy
+    listKind: MaaSAuthPolicyList
+    plural: maasauthpolicies
+    singular: maasauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.authPolicies[*].name
+      name: AuthPolicies
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSAuthPolicy is the Schema for the maasauthpolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSAuthPolicySpec defines the desired state of MaaSAuthPolicy
+            properties:
+              meteringMetadata:
+                description: MeteringMetadata contains billing and tracking information
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for billing attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      billing
+                    type: string
+                type: object
+              modelRefs:
+                description: ModelRefs is a list of models (by name and namespace)
+                  that this policy grants access to
+                items:
+                  description: ModelRef references a MaaSModelRef by name and namespace.
+                  properties:
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                minItems: 1
+                type: array
+              subjects:
+                description: Subjects defines who has access (OR logic - any match
+                  grants access)
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names
+                    items:
+                      type: string
+                    type: array
+                type: object
+                x-kubernetes-validations:
+                - message: at least one group or user must be specified in subjects
+                  rule: size(self.groups) > 0 || size(self.users) > 0
+            required:
+            - modelRefs
+            - subjects
+            type: object
+          status:
+            description: MaaSAuthPolicyStatus defines the observed state of MaaSAuthPolicy
+            properties:
+              authPolicies:
+                description: AuthPolicies lists the underlying Kuadrant AuthPolicies
+                  and their status.
+                items:
+                  description: |-
+                    AuthPolicyRefStatus reports the status of a generated Kuadrant AuthPolicy.
+                    Embeds ResourceRefStatus for common fields (Ready, Reason, Message).
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this AuthPolicy
+                        targets.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    modelNamespace:
+                      description: ModelNamespace is the namespace of the MaaSModelRef.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - modelNamespace
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the policy
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maasmodelrefs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maasmodelrefs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSModelRef
+    listKind: MaaSModelRefList
+    plural: maasmodelrefs
+    singular: maasmodelref
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.httpRouteName
+      name: HTTPRoute
+      type: string
+    - jsonPath: .status.httpRouteGatewayName
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSModelRef is the Schema for the maasmodelrefs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSModelSpec defines the desired state of MaaSModelRef
+            properties:
+              endpointOverride:
+                description: |-
+                  EndpointOverride, when set, overrides the endpoint URL that the controller
+                  would otherwise discover from the backend (e.g. LLMInferenceService status
+                  or Gateway/HTTPRoute).
+                type: string
+              modelRef:
+                description: ModelRef references the actual model endpoint
+                properties:
+                  kind:
+                    description: |-
+                      Kind determines which backend handles this model reference.
+                      LLMInferenceService: references a KServe LLMInferenceService.
+                      ExternalModel: references an ExternalModel CR containing provider config.
+                    enum:
+                    - LLMInferenceService
+                    - ExternalModel
+                    type: string
+                  name:
+                    description: |-
+                      Name is the name of the model resource.
+                      For LLMInferenceService, this is the InferenceService name.
+                      For ExternalModel, this is the ExternalModel CR name.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              tenantRef:
+                description: |-
+                  TenantRef is the name of the AITenant this model belongs to.
+                  When omitted, the model is assigned to the default tenant.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+            required:
+            - modelRef
+            type: object
+          status:
+            description: |-
+              MaaSModelStatus defines the observed state of MaaSModelRef.
+
+              Phase semantics with governance:
+                - Pending: the model is not yet ready — either the backend is initializing
+                  or no active MaaSSubscription + MaaSAuthPolicy pairing has been found.
+                - Ready: the model backend is healthy AND at least one governance pairing
+                  (MaaSSubscription + MaaSAuthPolicy) is active. Authorized inference is possible.
+                - Unhealthy: the model has active governance but the backend (routes, gateways,
+                  or inference service) has a runtime/health failure. GovernanceAttached remains
+                  True while RuntimeReady is False.
+                - Failed: a non-recoverable reconciliation error occurred.
+                - Invalid: the resource spec is missing or structurally invalid.
+
+              Condition types:
+                - Ready: overall readiness (True only when both governance and runtime are healthy).
+                - GovernanceAttached: whether the model is covered by at least one active
+                  MaaSSubscription + MaaSAuthPolicy pairing. No admin CR names, namespaces,
+                  or UIDs appear in any status field.
+                - RuntimeReady: whether the model backend is healthy and serving, independent
+                  of governance state.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the model's state.
+                  Condition types include:
+                    - Ready: overall readiness (governance + runtime).
+                    - GovernanceAttached: active MaaSSubscription + MaaSAuthPolicy pairing exists.
+                    - RuntimeReady: backend is healthy and serving.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint is the endpoint URL for the model
+                type: string
+              httpRouteGatewayName:
+                description: HTTPRouteGatewayName is the name of the Gateway that
+                  the HTTPRoute references
+                type: string
+              httpRouteGatewayNamespace:
+                description: HTTPRouteGatewayNamespace is the namespace of the Gateway
+                  that the HTTPRoute references
+                type: string
+              httpRouteHostnames:
+                description: HTTPRouteHostnames are the hostnames configured on the
+                  HTTPRoute
+                items:
+                  type: string
+                type: array
+              httpRouteName:
+                description: HTTPRouteName is the name of the HTTPRoute associated
+                  with this model
+                type: string
+              httpRouteNamespace:
+                description: HTTPRouteNamespace is the namespace of the HTTPRoute
+                  associated with this model
+                type: string
+              phase:
+                description: |-
+                  Phase represents the current phase of the model.
+                  Pending = awaiting governance pairing or backend readiness.
+                  Ready = governed and runtime-healthy.
+                  Unhealthy = governed but runtime-failed.
+                  Failed = reconciliation error.
+                  Invalid = bad spec.
+                enum:
+                - Pending
+                - Ready
+                - Unhealthy
+                - Failed
+                - Invalid
+                type: string
+              resolvedModelAlias:
+                description: |-
+                  ResolvedModelAlias is the model identity used in body-based routing headers.
+                  For LLMInferenceService: publishers/{namespace}/models/{spec.model.name}.
+                  For ExternalModel: the targetModel from spec.externalProviderRefs[0].targetModel.
+                  The maas-api uses this for reverse-lookup when matching subscription model refs.
+                type: string
+              resolvedTenantRef:
+                description: |-
+                  ResolvedTenantRef is the name of the AITenant this model was resolved to.
+                  Set from spec.tenantRef when provided, or left empty for models using the
+                  default tenant.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maassubscriptions.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maassubscriptions.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaaSSubscription
+    listKind: MaaSSubscriptionList
+    plural: maassubscriptions
+    singular: maassubscription
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MaaSSubscription is the Schema for the maassubscriptions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaaSSubscriptionSpec defines the desired state of MaaSSubscription
+            properties:
+              modelRefs:
+                description: ModelRefs defines which models are included with per-model
+                  token rate limits
+                items:
+                  description: ModelSubscriptionRef defines a model reference with
+                    rate limits
+                  properties:
+                    billingRate:
+                      description: BillingRate defines the cost per token
+                      properties:
+                        perToken:
+                          description: PerToken is the cost per token
+                          type: string
+                      required:
+                      - perToken
+                      type: object
+                    name:
+                      description: Name is the name of the MaaSModelRef
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the MaaSModelRef
+                        lives
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    tokenRateLimits:
+                      description: TokenRateLimits defines token-based rate limits
+                        for this model
+                      items:
+                        description: TokenRateLimit defines a token rate limit
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is the maximum number of tokens allowed within the window.
+                              Must be between 1 and 1,000,000,000 (1 billion).
+                            format: int64
+                            maximum: 1000000000
+                            minimum: 1
+                            type: integer
+                          window:
+                            description: |-
+                              Window is the time window for rate limiting (e.g., "1m", "1h", "24h").
+                              Allowed units: s (seconds), m (minutes), h (hours). Days (d) are not
+                              supported; use hours instead (e.g., "24h" for one day).
+                              The numeric part must be between 1 and 9999.
+                            maxLength: 5
+                            minLength: 2
+                            pattern: ^[1-9]\d{0,3}(s|m|h)$
+                            type: string
+                        required:
+                        - limit
+                        - window
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - tokenRateLimits
+                  type: object
+                minItems: 1
+                type: array
+              owner:
+                description: Owner defines who owns this subscription
+                properties:
+                  groups:
+                    description: Groups is a list of Kubernetes group names that own
+                      this subscription
+                    items:
+                      description: GroupReference references a Kubernetes group
+                      properties:
+                        name:
+                          description: Name is the name of the group
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  users:
+                    description: Users is a list of Kubernetes user names that own
+                      this subscription
+                    items:
+                      type: string
+                    type: array
+                type: object
+              priority:
+                default: 0
+                description: |-
+                  Priority determines subscription priority when user has multiple subscriptions
+                  Higher numbers have higher priority. Defaults to 0.
+                format: int32
+                type: integer
+              tokenMetadata:
+                description: TokenMetadata contains metadata for token attribution
+                  and metering
+                properties:
+                  costCenter:
+                    description: CostCenter is the cost center for usage attribution
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels are additional labels for tracking and metrics
+                    type: object
+                  organizationId:
+                    description: OrganizationID is the organization identifier for
+                      metering and billing
+                    type: string
+                type: object
+            required:
+            - modelRefs
+            - owner
+            type: object
+          status:
+            description: MaaSSubscriptionStatus defines the observed state of MaaSSubscription
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the subscription's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelRefStatuses:
+                description: ModelRefStatuses reports the status of each referenced
+                  MaaSModelRef
+                items:
+                  description: ModelRefStatus reports the status of a referenced MaaSModelRef.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of the subscription
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                - Invalid
+                type: string
+              tokenRateLimitStatuses:
+                description: TokenRateLimitStatuses reports the status of each generated
+                  TokenRateLimitPolicy
+                items:
+                  description: TokenRateLimitStatus reports the status of a generated
+                    TokenRateLimitPolicy.
+                  properties:
+                    message:
+                      description: Message is a human-readable description of the
+                        status
+                      maxLength: 1024
+                      type: string
+                    model:
+                      description: Model is the MaaSModelRef name this TokenRateLimitPolicy
+                        targets
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name of the referenced resource
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced resource
+                      maxLength: 63
+                      type: string
+                    ready:
+                      description: Ready indicates whether the resource is valid and
+                        healthy
+                      type: boolean
+                    reason:
+                      description: Reason is a machine-readable reason code
+                      enum:
+                      - Reconciled
+                      - ReconcileFailed
+                      - PartialFailure
+                      - Valid
+                      - NotFound
+                      - GetFailed
+                      - Accepted
+                      - AcceptedEnforced
+                      - NotAccepted
+                      - Enforced
+                      - NotEnforced
+                      - BackendNotReady
+                      - ConditionsNotFound
+                      - InvalidSpec
+                      - Unknown
+                      - NoPairingFound
+                      - GovernancePaired
+                      - GovernanceGap
+                      - RuntimeHealthy
+                      - RuntimeHealthFailure
+                      type: string
+                  required:
+                  - model
+                  - name
+                  - namespace
+                  - ready
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+# Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-maas.opendatahub.io_maastenantconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: maastenantconfigs.maas.opendatahub.io
+spec:
+  group: maas.opendatahub.io
+  names:
+    kind: MaasTenantConfig
+    listKind: MaasTenantConfigList
+    plural: maastenantconfigs
+    singular: maastenantconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.infraNamespace
+      name: InfraNamespace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MaasTenantConfig is the namespace-scoped singleton for MaaS-specific tenant settings.
+          Platform context such as Gateway and OIDC belongs to AITenant; this object only
+          owns MaaS runtime configuration such as API key policy and telemetry settings.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MaasTenantConfigSpec defines MaaS-owned tenant configuration.
+            properties:
+              apiKeys:
+                description: APIKeys contains configuration for API key management.
+                properties:
+                  maxExpirationDays:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              telemetry:
+                description: Telemetry contains configuration for telemetry and metrics
+                  collection.
+                properties:
+                  enabled:
+                    default: true
+                    type: boolean
+                  metrics:
+                    description: TenantMetricsConfig defines optional metric dimensions.
+                    properties:
+                      captureGroup:
+                        default: false
+                        type: boolean
+                      captureModelUsage:
+                        default: true
+                        type: boolean
+                      captureOrganization:
+                        default: true
+                        type: boolean
+                      captureUser:
+                        default: false
+                        description: |-
+                          CaptureUser adds a "user" dimension to telemetry metrics containing
+                          the authenticated user ID. Defaults to false. Enabling this may
+                          have GDPR / privacy implications — ensure compliance before use.
+                        type: boolean
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MaasTenantConfigStatus defines the observed state of MaasTenantConfig.
+            properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations.
+                  Types mirror ODH modelsasservice / maas-controller status for DSC aggregation: Ready,
+                  DependenciesAvailable, MaaSPrerequisitesAvailable, DeploymentsAvailable, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              infraNamespace:
+                description: |-
+                  InfraNamespace is the infrastructure namespace where maas-api and the
+                  maas-db-config secret are deployed for this tenant.
+                  When credential rotation is needed, update the maas-db-config secret
+                  in this namespace.
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              phase:
+                description: Phase is a high-level lifecycle phase for the platform
+                  reconcile.
+                enum:
+                - Pending
+                - Active
+                - Degraded
+                - Failed
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: MaasTenantConfig name must be default-tenant
+          rule: self.metadata.name == 'default-tenant'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
 # Source: rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
## Summary
On a fresh xKS cluster (no pre-existing CRDs), two issues prevent successful deployment:

1. **ai-gateway-operator deploy action drops MaaS CRDs**: The AGO's `odh-stable` image contains all 10 CRDs, and the kustomization includes them, but the opendatahub-operator deploy framework only applies 5 of 10 during Server-Side Apply. Missing: `aitenants`, `maasauthpolicies`, `maasmodelrefs`, `maassubscriptions`, `maastenantconfigs`.

2. **Kuadrant operator never installs its policy CRDs**: The operator expects `tokenratelimitpolicies`, `ratelimitpolicies`, `tlspolicies`, and `kuadrants` to already exist but never installs them on non-OLM platforms. It logs `"if kind is a CRD, it should be installed before calling Start"` indefinitely.

Both issues only manifest on truly fresh clusters. On subsequent deploys, CRDs persist from previous installs.

### Fix
Bundle the 9 missing CRDs directly in the chart's `templates/crds/` directory, gated behind `.Values.installCRDs` (default: true). This ensures CRDs exist before any operator starts, matching the standard Helm pattern for vanilla Kubernetes.

## Test plan
- [x] `helm lint` passes
- [x] Confirmed these CRDs are missing on fresh AKS deployment
- [x] Confirmed manual application of these CRDs resolves both maas-controller and Kuadrant operator failures
- [ ] Full E2E: `helm upgrade --install` on clean cluster deploys all pods without manual CRD patching

Ref: [RHOAIENG-79301](https://redhat.atlassian.net/browse/RHOAIENG-79301)

Made with [Cursor](https://cursor.com)

[RHOAIENG-79301]: https://redhat.atlassian.net/browse/RHOAIENG-79301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ