### PR TITLE
chore: sync manifests from odh operator new update in xks

### DIFF
--- a/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
+++ b/charts/rhai-on-xks-chart/scripts/helmtemplate-config.yaml
@@ -90,6 +90,9 @@ rules:
         value: '{{ .Values.rhaiOperator.applicationsNamespace | quote }}'
       - path: .spec.template.spec.containers[name=rhods-operator].env[name=RHAI_VERSION].value
         value: '{{ .Chart.AppVersion | quote }}'
+      # Remove hardcoded kuberay operator image
+      - action: delete
+        path: .spec.template.spec.containers[name=rhods-operator].env[name=RELATED_IMAGE_*]
       # Add related images env vars
       - path: .spec.template.spec.containers[name=rhods-operator].env
         appendWith: |

--- a/charts/rhai-on-xks-chart/scripts/update-bundle.sh
+++ b/charts/rhai-on-xks-chart/scripts/update-bundle.sh
@@ -29,7 +29,7 @@ CHART_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 NAMESPACE="redhat-ods-operator"
 
 # helmtemplate-generator Go module
-HELMTEMPLATE_GENERATOR_PKG="github.com/davidebianchi/helmtemplate-generator@7d76ac29fe5f7cdc6a6c9b953f8dc715ee348bef"
+HELMTEMPLATE_GENERATOR_PKG="github.com/davidebianchi/helmtemplate-generator@973126b06de3511e82325428c5948a163d7d5c1e"
 
 # Cloud mappings: <cloud_name> <kustomize_subdir> <output_subdir>
 CLOUD_TARGETS=(

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrole-rhai-aws-cloud-manager-role.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/aws/rbac/clusterrole-rhai-aws-cloud-manager-role.yaml
@@ -168,6 +168,21 @@ rules:
   - apiGroups:
       - rbac.authorization.k8s.io
     resourceNames:
+      - metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
       - openshift-lws-operator-clusterrole
     resources:
       - clusterroles

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrole-rhai-azure-cloud-manager-role.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/azure/rbac/clusterrole-rhai-azure-cloud-manager-role.yaml
@@ -168,6 +168,21 @@ rules:
   - apiGroups:
       - rbac.authorization.k8s.io
     resourceNames:
+      - metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
       - openshift-lws-operator-clusterrole
     resources:
       - clusterroles

--- a/charts/rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrole-rhai-coreweave-cloud-manager-role.yaml
+++ b/charts/rhai-on-xks-chart/templates/cloudmanager/coreweave/rbac/clusterrole-rhai-coreweave-cloud-manager-role.yaml
@@ -168,6 +168,21 @@ rules:
   - apiGroups:
       - rbac.authorization.k8s.io
     resourceNames:
+      - metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
       - openshift-lws-operator-clusterrole
     resources:
       - clusterroles

--- a/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
+++ b/charts/rhai-on-xks-chart/templates/crds/customresourcedefinition-platforms.config.opendatahub.io.yaml
@@ -151,6 +151,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:

--- a/charts/rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
+++ b/charts/rhai-on-xks-chart/templates/rbac/clusterrole-rhods-operator-role.yaml
@@ -245,19 +245,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -266,13 +264,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -284,10 +275,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -307,16 +296,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -337,10 +325,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -366,17 +352,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -420,7 +395,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -454,24 +428,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -579,18 +538,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -648,27 +595,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -704,49 +633,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -804,47 +690,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -861,32 +706,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1038,12 +857,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -1075,13 +890,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -1096,7 +904,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -1286,63 +1093,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -1351,18 +1101,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
@@ -602,6 +602,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -835,6 +871,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1203,19 +1254,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1224,13 +1273,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1242,10 +1284,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1265,16 +1305,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1295,10 +1334,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1324,17 +1361,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1378,7 +1404,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1412,24 +1437,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1537,18 +1547,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1606,27 +1604,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1662,49 +1642,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1762,47 +1699,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1819,32 +1715,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1996,12 +1866,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -2033,13 +1899,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -2054,7 +1913,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2244,63 +2102,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2309,18 +2110,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
@@ -435,6 +435,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -668,6 +704,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1036,19 +1087,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1057,13 +1106,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1075,10 +1117,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1098,16 +1138,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1128,10 +1167,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1157,17 +1194,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1211,7 +1237,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1245,24 +1270,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1370,18 +1380,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1439,27 +1437,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1495,49 +1475,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1595,47 +1532,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1652,32 +1548,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1829,12 +1699,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -1866,13 +1732,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -1887,7 +1746,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2077,63 +1935,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2142,18 +1943,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
@@ -435,6 +435,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -668,6 +704,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1036,19 +1087,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1057,13 +1106,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1075,10 +1117,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1098,16 +1138,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1128,10 +1167,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1157,17 +1194,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1211,7 +1237,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1245,24 +1270,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1370,18 +1380,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1439,27 +1437,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1495,49 +1475,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1595,47 +1532,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1652,32 +1548,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1829,12 +1699,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -1866,13 +1732,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -1887,7 +1746,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2077,63 +1935,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2142,18 +1943,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -578,6 +578,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -811,6 +847,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1179,19 +1230,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1200,13 +1249,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1218,10 +1260,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1241,16 +1281,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1271,10 +1310,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1300,17 +1337,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1354,7 +1380,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1388,24 +1413,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1513,18 +1523,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1582,27 +1580,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1638,49 +1618,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1738,47 +1675,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1795,32 +1691,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1972,12 +1842,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -2009,13 +1875,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -2030,7 +1889,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2220,63 +2078,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2285,18 +2086,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -435,6 +435,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -668,6 +704,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1036,19 +1087,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1057,13 +1106,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1075,10 +1117,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1098,16 +1138,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1128,10 +1167,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1157,17 +1194,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1211,7 +1237,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1245,24 +1270,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1370,18 +1380,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1439,27 +1437,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1495,49 +1475,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1595,47 +1532,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1652,32 +1548,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1829,12 +1699,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -1866,13 +1732,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -1887,7 +1746,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2077,63 +1935,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2142,18 +1943,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
@@ -602,6 +602,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -835,6 +871,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1203,19 +1254,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1224,13 +1273,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1242,10 +1284,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1265,16 +1305,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1295,10 +1334,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1324,17 +1361,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1378,7 +1404,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1412,24 +1437,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1537,18 +1547,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1606,27 +1604,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1662,49 +1642,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1762,47 +1699,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1819,32 +1715,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1996,12 +1866,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -2033,13 +1899,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -2054,7 +1913,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2244,63 +2102,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2309,18 +2110,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
@@ -435,6 +435,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -668,6 +704,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1036,19 +1087,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1057,13 +1106,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1075,10 +1117,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1098,16 +1138,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1128,10 +1167,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1157,17 +1194,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1211,7 +1237,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1245,24 +1270,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1370,18 +1380,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1439,27 +1437,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1495,49 +1475,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1595,47 +1532,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1652,32 +1548,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1829,12 +1699,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -1866,13 +1732,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -1887,7 +1746,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2077,63 +1935,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2142,18 +1943,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
@@ -435,6 +435,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -668,6 +704,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1036,19 +1087,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1057,13 +1106,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1075,10 +1117,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1098,16 +1138,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1128,10 +1167,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1157,17 +1194,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1211,7 +1237,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1245,24 +1270,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1370,18 +1380,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1439,27 +1437,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1495,49 +1475,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1595,47 +1532,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1652,32 +1548,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1829,12 +1699,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -1866,13 +1732,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -1887,7 +1746,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2077,63 +1935,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2142,18 +1943,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
@@ -435,6 +435,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -668,6 +704,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1036,19 +1087,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1057,13 +1106,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1075,10 +1117,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1098,16 +1138,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1128,10 +1167,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1157,17 +1194,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1211,7 +1237,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1245,24 +1270,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1370,18 +1380,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1439,27 +1437,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1495,49 +1475,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1595,47 +1532,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1652,32 +1548,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1829,12 +1699,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -1866,13 +1732,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -1887,7 +1746,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2077,63 +1935,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2142,18 +1943,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
@@ -614,6 +614,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -847,6 +883,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1215,19 +1266,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1236,13 +1285,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1254,10 +1296,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1277,16 +1317,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1307,10 +1346,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1336,17 +1373,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1390,7 +1416,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1424,24 +1449,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1549,18 +1559,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1618,27 +1616,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1674,49 +1654,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1774,47 +1711,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1831,32 +1727,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -2008,12 +1878,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -2045,13 +1911,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -2066,7 +1925,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2256,63 +2114,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2321,18 +2122,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
@@ -435,6 +435,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -668,6 +704,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1036,19 +1087,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1057,13 +1106,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1075,10 +1117,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1098,16 +1138,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1128,10 +1167,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1157,17 +1194,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1211,7 +1237,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1245,24 +1270,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1370,18 +1380,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1439,27 +1437,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1495,49 +1475,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1595,47 +1532,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1652,32 +1548,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1829,12 +1699,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -1866,13 +1732,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -1887,7 +1746,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2077,63 +1935,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2142,18 +1943,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
@@ -435,6 +435,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -668,6 +704,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1036,19 +1087,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1057,13 +1106,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1075,10 +1117,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1098,16 +1138,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1128,10 +1167,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1157,17 +1194,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1211,7 +1237,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1245,24 +1270,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1370,18 +1380,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1439,27 +1437,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1495,49 +1475,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1595,47 +1532,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1652,32 +1548,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1829,12 +1699,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -1866,13 +1732,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -1887,7 +1746,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2077,63 +1935,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2142,18 +1943,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -578,6 +578,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -811,6 +847,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1179,19 +1230,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1200,13 +1249,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1218,10 +1260,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1241,16 +1281,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1271,10 +1310,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1300,17 +1337,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1354,7 +1380,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1388,24 +1413,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1513,18 +1523,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1582,27 +1580,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1638,49 +1618,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1738,47 +1675,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1795,32 +1691,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1972,12 +1842,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -2009,13 +1875,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -2030,7 +1889,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2220,63 +2078,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2285,18 +2086,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -435,6 +435,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -668,6 +704,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1036,19 +1087,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1057,13 +1106,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1075,10 +1117,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1098,16 +1138,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1128,10 +1167,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1157,17 +1194,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1211,7 +1237,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1245,24 +1270,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1370,18 +1380,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1439,27 +1437,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1495,49 +1475,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1595,47 +1532,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1652,32 +1548,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1829,12 +1699,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -1866,13 +1732,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -1887,7 +1746,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2077,63 +1935,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2142,18 +1943,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
@@ -435,6 +435,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -668,6 +704,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1036,19 +1087,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1057,13 +1106,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1075,10 +1117,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1098,16 +1138,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1128,10 +1167,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1157,17 +1194,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1211,7 +1237,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1245,24 +1270,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1370,18 +1380,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1439,27 +1437,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1495,49 +1475,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1595,47 +1532,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1652,32 +1548,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1829,12 +1699,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -1866,13 +1732,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -1887,7 +1746,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2077,63 +1935,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2142,18 +1943,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
@@ -602,6 +602,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -835,6 +871,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1203,19 +1254,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1224,13 +1273,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1242,10 +1284,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1265,16 +1305,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1295,10 +1334,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1324,17 +1361,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1378,7 +1404,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1412,24 +1437,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1537,18 +1547,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1606,27 +1604,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1662,49 +1642,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1762,47 +1699,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1819,32 +1715,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1996,12 +1866,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -2033,13 +1899,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -2054,7 +1913,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2244,63 +2102,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2309,18 +2110,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
@@ -435,6 +435,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -668,6 +704,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1036,19 +1087,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1057,13 +1106,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1075,10 +1117,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1098,16 +1138,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1128,10 +1167,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1157,17 +1194,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1211,7 +1237,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1245,24 +1270,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1370,18 +1380,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1439,27 +1437,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1495,49 +1475,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1595,47 +1532,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1652,32 +1548,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1829,12 +1699,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -1866,13 +1732,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -1887,7 +1746,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2077,63 +1935,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2142,18 +1943,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -578,6 +578,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -811,6 +847,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1179,19 +1230,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1200,13 +1249,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1218,10 +1260,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1241,16 +1281,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1271,10 +1310,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1300,17 +1337,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1354,7 +1380,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1388,24 +1413,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1513,18 +1523,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1582,27 +1580,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1638,49 +1618,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1738,47 +1675,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1795,32 +1691,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1972,12 +1842,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -2009,13 +1875,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -2030,7 +1889,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2220,63 +2078,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2285,18 +2086,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -435,6 +435,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -668,6 +704,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1036,19 +1087,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1057,13 +1106,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1075,10 +1117,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1098,16 +1138,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1128,10 +1167,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1157,17 +1194,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1211,7 +1237,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1245,24 +1270,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1370,18 +1380,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1439,27 +1437,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1495,49 +1475,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1595,47 +1532,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1652,32 +1548,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1829,12 +1699,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -1866,13 +1732,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -1887,7 +1746,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2077,63 +1935,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2142,18 +1943,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -602,6 +602,42 @@ spec:
                           pattern: ^(Managed|Unmanaged|Force|Removed)$
                           type: string
                       type: object
+                    ogx:
+                      description: OGX controls the OGX module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches controls the workbenches module operator lifecycle.
+                      properties:
+                        managementState:
+                          description: |-
+                            Set to one of the following values:
+
+                            - "Managed" : the operator is actively managing the component and trying to keep it active.
+                                          It will only upgrade the component if it is safe to do so
+
+                            - "Removed" : the operator is actively managing the component and will not install it,
+                                          or if it is installed, the operator will try to remove it
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
                   type: object
               type: object
             status:
@@ -835,6 +871,21 @@ rules:
     resourceNames:
       - cert-manager-operator-controller-manager-clusterrole
       - cert-manager-operator-metrics-reader
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - metrics-reader
     resources:
       - clusterroles
     verbs:
@@ -1203,19 +1254,17 @@ rules:
   - apiGroups:
       - build.openshift.io
     resources:
-      - buildconfigs/instantiate
       - builds
     verbs:
-      - create
       - delete
       - get
       - list
-      - patch
       - watch
   - apiGroups:
       - cert-manager.io
     resources:
       - certificates
+      - issuers
     verbs:
       - create
       - delete
@@ -1224,13 +1273,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - issuers
-    verbs:
-      - create
-      - patch
   - apiGroups:
       - components.platform.opendatahub.io
     resources:
@@ -1242,10 +1284,8 @@ rules:
       - kueues
       - mcplifecycleoperators
       - mlflowoperators
-      - modelcontrollers
       - modelmeshservings
       - modelregistries
-      - modelsasservices
       - ogxs
       - rays
       - sparkoperators
@@ -1265,16 +1305,15 @@ rules:
       - components.platform.opendatahub.io
     resources:
       - aigateways/finalizers
+      - dashboards/finalizers
       - datasciencepipelines/finalizers
       - feastoperators/finalizers
       - kserves/finalizers
       - kueues/finalizers
       - mcplifecycleoperators/finalizers
       - mlflowoperators/finalizers
-      - modelcontrollers/finalizers
       - modelmeshservings/finalizers
       - modelregistries/finalizers
-      - modelsasservices/finalizers
       - ogxs/finalizers
       - rays/finalizers
       - sparkoperators/finalizers
@@ -1295,10 +1334,8 @@ rules:
       - kueues/status
       - mcplifecycleoperators/status
       - mlflowoperators/status
-      - modelcontrollers/status
       - modelmeshservings/status
       - modelregistries/status
-      - modelsasservices/status
       - ogxs/status
       - rays/status
       - sparkoperators/status
@@ -1324,17 +1361,6 @@ rules:
       - codeflares/status
     verbs:
       - get
-  - apiGroups:
-      - components.platform.opendatahub.io
-    resources:
-      - dashboards/finalizers
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - config.opendatahub.io
     resources:
@@ -1378,7 +1404,6 @@ rules:
       - console.openshift.io
     resources:
       - consolelinks
-      - odhquickstarts
     verbs:
       - create
       - delete
@@ -1412,24 +1437,9 @@ rules:
       - dashboard.opendatahub.io
     resources:
       - acceleratorprofiles
-      - odhapplications
-      - odhdocuments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - dashboard.opendatahub.io
-    resources:
-      - hardwareprofiles
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - datasciencecluster.opendatahub.io
@@ -1537,18 +1547,6 @@ rules:
       - patch
       - watch
   - apiGroups:
-      - extensions.kuadrant.io
-    resources:
-      - telemetrypolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - features.opendatahub.io
     resources:
       - featuretrackers
@@ -1606,27 +1604,9 @@ rules:
   - apiGroups:
       - image.openshift.io
     resources:
-      - imagestreamtags
       - registry/metrics
     verbs:
       - get
-  - apiGroups:
-      - inference.networking.k8s.io
-    resources:
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - inference.networking.x-k8s.io
-    resources:
-      - inferencemodels
-      - inferencepools
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - infrastructure.opendatahub.io
     resources:
@@ -1662,49 +1642,6 @@ rules:
       - get
       - list
       - patch
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - kedacontrollers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - keda.sh
-    resources:
-      - triggerauthentications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - authpolicies
-      - ratelimitpolicies
-      - telemetrypolicies
-      - tokenratelimitpolicies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kuadrant.io
-    resources:
-      - kuadrants
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - kubeflow.org
@@ -1762,47 +1699,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - configs/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - maas.opendatahub.io
-    resources:
-      - maastenantconfigs/status
-    verbs:
-      - get
-  - apiGroups:
       - machinelearning.seldon.io
     resources:
       - seldondeployments
@@ -1819,32 +1715,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - mlflow.opendatahub.io
-    resources:
-      - mlflows/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - modelregistry.opendatahub.io
     resources:
@@ -1996,12 +1866,8 @@ rules:
     resources:
       - odhdashboardconfigs
     verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - opentelemetry.io
@@ -2033,13 +1899,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - operator.authorino.kuadrant.io
-    resources:
-      - authorinos
-    verbs:
-      - get
-      - list
-  - apiGroups:
       - operator.openshift.io
     resources:
       - consoles
@@ -2054,7 +1913,6 @@ rules:
       - operator.openshift.io
     resources:
       - jobsetoperators
-      - leaderworkersetoperators
     verbs:
       - get
       - list
@@ -2244,63 +2102,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes
-      - clusterservingruntimes/finalizers
-      - clusterstoragecontainers
-      - clusterstoragecontainers/finalizers
-      - inferencegraphs
-      - inferenceservices
-      - inferenceservices/finalizers
-      - llminferenceserviceconfigs
-      - localmodelnodegroups
-      - predictors
-      - servingruntimes
-      - servingruntimes/finalizers
-      - trainedmodels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - clusterservingruntimes/status
-      - clusterstoragecontainers/status
-      - inferencegraphs/status
-      - inferenceservices/status
-      - predictors/status
-      - trainedmodels/status
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceserviceconfigs/status
-      - predictors/finalizers
-      - servingruntimes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - serving.kserve.io
-    resources:
-      - llminferenceservices
-      - llminferenceservices/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - snapshot.storage.k8s.io
     resources:
       - volumesnapshots
@@ -2309,18 +2110,6 @@ rules:
       - delete
       - get
       - patch
-  - apiGroups:
-      - telemetry.istio.io
-    resources:
-      - telemetries
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
   - apiGroups:
       - template.openshift.io
     resources:


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

Jira task: <!--- Link your JIRA and related links here for reference. -->l

## Has it been tested?
<!--- Please describe in detail how you tested your changes. -->

- [ ] Installed on a real cluster to verify the changes

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle management options for OGX and Workbenches platform modules.
  * Enabled cloud managers to access metrics-reader permissions.
* **Improvements**
  * Updated operator permissions to support current platform resources, including model registries and job set operators.
  * Removed access to retired integrations and obsolete resources.
  * Narrowed dashboard, image registry, build, and related permissions to reduce unnecessary access.
  * Improved deployment image configuration by removing hardcoded related-image settings before applying configured values.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->