### PR TITLE
fix(xKS): add opendatahub-ca-issuer ClusterIssuer for module operator compatibility

### DIFF
--- a/charts/rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+++ b/charts/rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
@@ -1,0 +1,14 @@
+{{/*
+Compatibility ClusterIssuer: module operators (e.g. ai-gateway-operator) reference
+"opendatahub-ca-issuer" which exists on OCP but not on xKS.
+This creates an alias backed by the same CA secret used by rhai-ca-issuer.
+*/}}
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: rhai-ca

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-all-deps-managed.snap.yaml
@@ -2596,6 +2596,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-all.snap.yaml
@@ -2429,6 +2429,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-allowed-routes-same.snap.yaml
@@ -2429,6 +2429,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws-with-pull-secret.snap.yaml
@@ -2572,6 +2572,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/aws.snap.yaml
@@ -2429,6 +2429,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-all-deps-managed.snap.yaml
@@ -2596,6 +2596,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-byo-issuer.snap.yaml
@@ -2429,6 +2429,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-cleanup-namespaces.snap.yaml
@@ -2429,6 +2429,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-gateway-hostname.snap.yaml
@@ -2429,6 +2429,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
@@ -2641,6 +2641,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
@@ -2429,6 +2429,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-namespaced-issuer.snap.yaml
@@ -2429,6 +2429,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-pull-secret.snap.yaml
@@ -2572,6 +2572,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-related-images.snap.yaml
@@ -2431,6 +2431,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-tls-disabled.snap.yaml
@@ -2429,6 +2429,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-all-deps-managed.snap.yaml
@@ -2596,6 +2596,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-allowed-routes-selector.snap.yaml
@@ -2429,6 +2429,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave-with-pull-secret.snap.yaml
@@ -2572,6 +2572,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/coreweave.snap.yaml
@@ -2429,6 +2429,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1

--- a/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/with-custom-namespace.snap.yaml
@@ -2596,6 +2596,19 @@ spec:
             medium: Memory
             sizeLimit: 10Mi
           name: tmp
+
+---
+# Source: rhai-on-xks-chart/templates/manager/clusterissuer-opendatahub-ca.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: opendatahub-ca-issuer
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ca:
+    secretName: rhai-ca
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: v1


### PR DESCRIPTION
## Summary

- Adds `opendatahub-ca-issuer` ClusterIssuer to the xKS chart, backed by the same `rhai-ca` CA secret
- On OCP, the ODH operator creates this ClusterIssuer. Module operators (ai-gateway-operator/KServe) reference it when creating webhook certificates (e.g. `llmisvc-webhook-server-cert`)
- On xKS, this issuer was missing, causing all operator-managed certificates to fail with "ClusterIssuer not found"

## Root Cause

The `ai-gateway-operator` deploys KServe manifests that reference `opendatahub-ca-issuer` (the OCP-standard name). The xKS chart creates `rhai-ca-issuer` but not the compatibility alias, so certs like `llmisvc-webhook-server-cert` can never be issued.

Since the xKS chart fulfills the platform-setup role that the ODH operator plays on OCP, it should provide the same `opendatahub-ca-issuer` name backed by the same CA.

## Verification

```bash
kubectl get clusterissuer opendatahub-ca-issuer
# NAME                    READY   AGE
# opendatahub-ca-issuer   True    5s

kubectl get certificate llmisvc-webhook-server -n redhat-ods-applications
# NAME                     READY   SECRET                          AGE
# llmisvc-webhook-server   True    llmisvc-webhook-server-cert     30s
```

@davidebianchi - The AGO KServe manifests reference `opendatahub-ca-issuer` which only exists on OCP. On xKS, should the chart provide this as a compatibility alias (this PR), or should the operator be updated to use `RHAI_ISSUER_REF_NAME`?

## Test plan

- [x] Snapshots regenerated
- [ ] Deploy on fresh AKS cluster — `llmisvc-webhook-server-cert` gets issued successfully


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cluster-wide certificate issuer named `opendatahub-ca-issuer`.
  * Configured the issuer to use the existing `rhai-ca` secret for certificate signing.

* **Tests**
  * Updated deployment rendering snapshots to include the new certificate issuer across supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->