### PR TITLE
fix(RHOAIENG-78603): Authorino TLS automation, hook RBAC, maas-api cert namespace, allowedRoutes docs

### DIFF
--- a/charts/rhai-on-xks-chart/files/create-maas-gateway.sh
+++ b/charts/rhai-on-xks-chart/files/create-maas-gateway.sh
@@ -99,12 +99,13 @@ wait_for "MaaS gateway Certificate to be Ready" maas_gw_cert_ready
 {{- end }}
 
 echo "Step 5: Create MaaS API serving Certificate..."
-kubectl apply -f - <<'EOF'
+INFRA_NS="redhat-ai-gateway-infra"
+kubectl apply -f - <<EOF
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: maas-api-serving-cert
-  namespace: {{ $appNs | quote }}
+  namespace: ${INFRA_NS}
 spec:
   secretName: maas-api-serving-cert
   issuerRef:
@@ -112,8 +113,8 @@ spec:
     kind: {{ $tls.issuerRef.kind | quote }}
     group: cert-manager.io
   dnsNames:
-    - "maas-api.{{ $appNs }}.svc"
-    - "maas-api.{{ $appNs }}.svc.cluster.local"
+    - "maas-api.${INFRA_NS}.svc"
+    - "maas-api.${INFRA_NS}.svc.cluster.local"
 EOF
 
 echo "Step 6: Create MaaS Gateway..."
@@ -178,6 +179,48 @@ if kubectl get namespace "$KUADRANT_NS" >/dev/null 2>&1; then
     {"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"SSL_CERT_FILE","value":"/etc/pki/tls/custom/ca.crt"}}
   ]'
   echo "Authorino CA trust configured."
+
+  echo "Creating Authorino TLS serving certificate (xKS equivalent of setup-authorino-tls.sh)..."
+  kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: authorino-server-cert
+  namespace: $KUADRANT_NS
+spec:
+  secretName: authorino-server-cert
+  issuerRef:
+    name: {{ $tls.issuerRef.name }}
+    kind: {{ $tls.issuerRef.kind }}
+    group: cert-manager.io
+  dnsNames:
+    - "authorino.$KUADRANT_NS.svc"
+    - "authorino.$KUADRANT_NS.svc.cluster.local"
+    - "authorino-authorino-authorization.$KUADRANT_NS.svc"
+    - "authorino-authorino-authorization.$KUADRANT_NS.svc.cluster.local"
+EOF
+  echo "Waiting for Authorino server cert to be ready..."
+  kubectl wait --for=condition=Ready certificate/authorino-server-cert \
+    -n "$KUADRANT_NS" --timeout=60s 2>/dev/null || true
+
+  echo "Patching Authorino CR to enable TLS with cert-manager certificate..."
+  if kubectl get authorino authorino -n "$KUADRANT_NS" >/dev/null 2>&1; then
+    kubectl patch authorino authorino -n "$KUADRANT_NS" --type=merge -p '{
+      "spec": {
+        "listener": {
+          "tls": {
+            "enabled": true,
+            "certSecretRef": {
+              "name": "authorino-server-cert"
+            }
+          }
+        }
+      }
+    }'
+    echo "Authorino TLS listener configured with cert-manager certificate."
+  else
+    echo "Authorino CR not found, skipping TLS listener config."
+  fi
 else
   echo "Kuadrant namespace not found, skipping Authorino CA trust."
 fi

--- a/charts/rhai-on-xks-chart/files/create-maas-gateway.sh
+++ b/charts/rhai-on-xks-chart/files/create-maas-gateway.sh
@@ -186,11 +186,20 @@ if kubectl get namespace "$KUADRANT_NS" >/dev/null 2>&1; then
   kubectl create configmap rhai-ca-bundle --from-file=ca.crt=/tmp/ca.crt \
     -n "$KUADRANT_NS" --dry-run=client -o yaml | kubectl apply -f -
 
-  kubectl patch deployment authorino -n "$KUADRANT_NS" --type=json -p='[
-    {"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"rhai-ca","configMap":{"name":"rhai-ca-bundle"}}},
-    {"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"rhai-ca","mountPath":"/etc/pki/tls/custom","readOnly":true}},
-    {"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"SSL_CERT_FILE","value":"/etc/pki/tls/custom/ca.crt"}}
-  ]'
+  kubectl patch deployment authorino -n "$KUADRANT_NS" --type=strategic -p='{
+    "spec": {
+      "template": {
+        "spec": {
+          "volumes": [{"name":"rhai-ca","configMap":{"name":"rhai-ca-bundle"}}],
+          "containers": [{
+            "name": "authorino",
+            "volumeMounts": [{"name":"rhai-ca","mountPath":"/etc/pki/tls/custom","readOnly":true}],
+            "env": [{"name":"SSL_CERT_FILE","value":"/etc/pki/tls/custom/ca.crt"}]
+          }]
+        }
+      }
+    }
+  }'
   echo "Authorino CA trust configured."
 
   echo "Creating Authorino TLS serving certificate (xKS equivalent of setup-authorino-tls.sh)..."

--- a/charts/rhai-on-xks-chart/files/create-maas-gateway.sh
+++ b/charts/rhai-on-xks-chart/files/create-maas-gateway.sh
@@ -1,5 +1,5 @@
 {{- $appNs := .Values.rhaiOperator.applicationsNamespace -}}
-{{- $infraNs := .Values.rhaiOperator.infrastructureNamespace -}}
+{{- $infraNs := include "rhai-on-xks-chart.infrastructureNamespace" . -}}
 {{- $tls := .Values.gateway.tls -}}
 {{- $maasGwNs := .Values.components.aigateway.modelsAsAService.gateway.namespace | default $appNs -}}
 {{- $maasGwName := .Values.components.aigateway.modelsAsAService.gateway.name -}}
@@ -201,49 +201,6 @@ if kubectl get namespace "$KUADRANT_NS" >/dev/null 2>&1; then
     }
   }'
   echo "Authorino CA trust configured."
-
-  echo "Creating Authorino TLS serving certificate (xKS equivalent of setup-authorino-tls.sh)..."
-  kubectl apply -f - <<EOF
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: authorino-server-cert
-  namespace: $KUADRANT_NS
-spec:
-  secretName: authorino-server-cert
-  issuerRef:
-    name: {{ $tls.issuerRef.name }}
-    kind: {{ $tls.issuerRef.kind }}
-    group: cert-manager.io
-  dnsNames:
-    - "authorino.$KUADRANT_NS.svc"
-    - "authorino.$KUADRANT_NS.svc.cluster.local"
-    - "authorino-authorino-authorization.$KUADRANT_NS.svc"
-    - "authorino-authorino-authorization.$KUADRANT_NS.svc.cluster.local"
-EOF
-  authorino_cert_ready() {
-    [ "$(kubectl get certificate authorino-server-cert -n "$KUADRANT_NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)" = "True" ]
-  }
-  wait_for "Authorino server cert to be Ready" authorino_cert_ready
-
-  echo "Patching Authorino CR to enable TLS with cert-manager certificate..."
-  if kubectl get authorino authorino -n "$KUADRANT_NS" >/dev/null 2>&1; then
-    kubectl patch authorino authorino -n "$KUADRANT_NS" --type=merge -p '{
-      "spec": {
-        "listener": {
-          "tls": {
-            "enabled": true,
-            "certSecretRef": {
-              "name": "authorino-server-cert"
-            }
-          }
-        }
-      }
-    }'
-    echo "Authorino TLS listener configured with cert-manager certificate."
-  else
-    echo "Authorino CR not found, skipping TLS listener config."
-  fi
 else
   echo "Kuadrant namespace not found, skipping Authorino CA trust."
 fi

--- a/charts/rhai-on-xks-chart/files/create-maas-gateway.sh
+++ b/charts/rhai-on-xks-chart/files/create-maas-gateway.sh
@@ -1,4 +1,5 @@
 {{- $appNs := .Values.rhaiOperator.applicationsNamespace -}}
+{{- $infraNs := .Values.rhaiOperator.infrastructureNamespace -}}
 {{- $tls := .Values.gateway.tls -}}
 {{- $maasGwNs := .Values.components.aigateway.modelsAsAService.gateway.namespace | default $appNs -}}
 {{- $maasGwName := .Values.components.aigateway.modelsAsAService.gateway.name -}}
@@ -99,7 +100,7 @@ wait_for "MaaS gateway Certificate to be Ready" maas_gw_cert_ready
 {{- end }}
 
 echo "Step 5: Create MaaS API serving Certificate..."
-INFRA_NS="redhat-ai-gateway-infra"
+INFRA_NS={{ $infraNs | quote }}
 kubectl apply -f - <<EOF
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -115,6 +116,18 @@ spec:
   dnsNames:
     - "maas-api.${INFRA_NS}.svc"
     - "maas-api.${INFRA_NS}.svc.cluster.local"
+EOF
+
+echo "Step 5b: Create odh-kserve-config ConfigMap (cert-manager issuer for KServe module)..."
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: odh-kserve-config
+  namespace: {{ $appNs | quote }}
+data:
+  certManager.issuer: {{ $tls.issuerRef.name | quote }}
+  certManager.issuerKind: {{ $tls.issuerRef.kind | quote }}
 EOF
 
 echo "Step 6: Create MaaS Gateway..."
@@ -199,9 +212,10 @@ spec:
     - "authorino-authorino-authorization.$KUADRANT_NS.svc"
     - "authorino-authorino-authorization.$KUADRANT_NS.svc.cluster.local"
 EOF
-  echo "Waiting for Authorino server cert to be ready..."
-  kubectl wait --for=condition=Ready certificate/authorino-server-cert \
-    -n "$KUADRANT_NS" --timeout=60s 2>/dev/null || true
+  authorino_cert_ready() {
+    [ "$(kubectl get certificate authorino-server-cert -n "$KUADRANT_NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)" = "True" ]
+  }
+  wait_for "Authorino server cert to be Ready" authorino_cert_ready
 
   echo "Patching Authorino CR to enable TLS with cert-manager certificate..."
   if kubectl get authorino authorino -n "$KUADRANT_NS" >/dev/null 2>&1; then

--- a/charts/rhai-on-xks-chart/templates/_helpers.tpl
+++ b/charts/rhai-on-xks-chart/templates/_helpers.tpl
@@ -112,7 +112,7 @@ Usage:
   {{- end }}
 {{- end }}
 {{- if and .root.Values.components.aigateway.enabled (eq (dig "spec" "modelsAsAService" "managementState" "" .root.Values.components.aigateway) "Managed") }}
-  {{- $namespaces = append $namespaces "redhat-ai-gateway-infra" }}
+  {{- $namespaces = append $namespaces .root.Values.rhaiOperator.infrastructureNamespace }}
 {{- end }}
 {{- dict "items" ($namespaces | uniq) | toJson }}
 {{- end -}}

--- a/charts/rhai-on-xks-chart/templates/_helpers.tpl
+++ b/charts/rhai-on-xks-chart/templates/_helpers.tpl
@@ -6,6 +6,14 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Internal infrastructure namespace used by ai-gateway-operator for maas-api and payload-processing.
+Not user-configurable — defined here to avoid repetition across templates.
+*/}}
+{{- define "rhai-on-xks-chart.infrastructureNamespace" -}}
+redhat-ai-gateway-infra
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "rhai-on-xks-chart.chart" -}}
@@ -112,7 +120,7 @@ Usage:
   {{- end }}
 {{- end }}
 {{- if and .root.Values.components.aigateway.enabled (eq (dig "spec" "modelsAsAService" "managementState" "" .root.Values.components.aigateway) "Managed") }}
-  {{- $namespaces = append $namespaces .root.Values.rhaiOperator.infrastructureNamespace }}
+  {{- $namespaces = append $namespaces (include "rhai-on-xks-chart.infrastructureNamespace" .root) }}
 {{- end }}
 {{- dict "items" ($namespaces | uniq) | toJson }}
 {{- end -}}

--- a/charts/rhai-on-xks-chart/templates/_helpers.tpl
+++ b/charts/rhai-on-xks-chart/templates/_helpers.tpl
@@ -119,10 +119,23 @@ Usage:
     {{- end }}
   {{- end }}
 {{- end }}
-{{- if and .root.Values.components.aigateway.enabled (eq (dig "spec" "modelsAsAService" "managementState" "" .root.Values.components.aigateway) "Managed") }}
-  {{- $namespaces = append $namespaces (include "rhai-on-xks-chart.infrastructureNamespace" .root) }}
-{{- end }}
 {{- dict "items" ($namespaces | uniq) | toJson }}
+{{- end -}}
+
+{{/*
+Return "true" when MaaS (modelsAsAService) is enabled and Managed.
+*/}}
+{{- define "rhai-on-xks-chart.maasManaged" -}}
+{{- if and .Values.components.aigateway.enabled (eq (dig "spec" "modelsAsAService" "managementState" "" .Values.components.aigateway) "Managed") -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the infrastructure namespace for MaaS workloads (e.g. payload-processing).
+*/}}
+{{- define "rhai-on-xks-chart.maasInfrastructureNamespace" -}}
+redhat-ai-gateway-infra
 {{- end -}}
 
 {{/*

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -281,6 +281,8 @@ rules:
       - operator.authorino.kuadrant.io
     resources:
       - authorinos
+    resourceNames:
+      - authorino
     verbs:
       - get
       - patch
@@ -289,6 +291,8 @@ rules:
       - apps
     resources:
       - deployments
+    resourceNames:
+      - authorino
     verbs:
       - get
       - patch

--- a/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
@@ -150,6 +150,7 @@ rules:
       - namespaces
     resourceNames:
       - {{ $maasGwNs }}
+      - kuadrant-system
     verbs:
       - get
       - create
@@ -239,6 +240,73 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: rhai-post-install-hook-cert
+subjects:
+  - kind: ServiceAccount
+    name: rhai-post-install-hook
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if and .Values.components.aigateway.enabled (eq (dig "spec" "modelsAsAService" "managementState" "" .Values.components.aigateway) "Managed") }}
+---
+# Permissions in kuadrant-system for Authorino TLS and CA trust setup.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rhai-post-install-hook-kuadrant
+  namespace: kuadrant-system
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - operator.authorino.kuadrant.io
+    resources:
+      - authorinos
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rhai-post-install-hook-kuadrant
+  namespace: kuadrant-system
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rhai-post-install-hook-kuadrant
 subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook

--- a/charts/rhai-on-xks-chart/templates/hooks/pre-install-maas-ns-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/pre-install-maas-ns-job.yaml
@@ -26,11 +26,8 @@ rules:
       - ""
     resources:
       - namespaces
-      - serviceaccounts
     verbs:
       - get
-      - list
-      - watch
       - create
       - patch
 ---

--- a/charts/rhai-on-xks-chart/templates/hooks/pre-install-maas-ns-job.yaml
+++ b/charts/rhai-on-xks-chart/templates/hooks/pre-install-maas-ns-job.yaml
@@ -1,0 +1,102 @@
+{{- if and .Values.enabled (include "rhai-on-xks-chart.imagePullSecretEnabled" .) (include "rhai-on-xks-chart.maasManaged" .) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-install-maas-ns
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-install-maas-ns
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-install-maas-ns
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-install-maas-ns
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-install-maas-ns
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-install-maas-ns
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rhai-on-xks-chart.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "rhai-on-xks-chart.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-install-maas-ns
+      {{- include "rhai-on-xks-chart.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: create-namespace
+          image: {{ required "hooks.cliImage is required" .Values.hooks.cliImage | quote }}
+          resources:
+            {{- toYaml .Values.hooks.resources | nindent 12 }}
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              INFRA_NS={{ include "rhai-on-xks-chart.maasInfrastructureNamespace" . | quote }}
+              echo "Creating ${INFRA_NS} namespace..."
+              kubectl create namespace "${INFRA_NS}" --dry-run=client -o yaml | kubectl apply -f -
+              echo "Namespace ${INFRA_NS} ready."
+{{- end }}

--- a/charts/rhai-on-xks-chart/templates/pull-secret.yaml
+++ b/charts/rhai-on-xks-chart/templates/pull-secret.yaml
@@ -54,7 +54,7 @@ metadata:
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-controller" "namespace" $appNs) }}
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-api" "namespace" $appNs) }}
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-api-cleanup" "namespace" $appNs) }}
-  {{- $serviceAccounts = append $serviceAccounts (dict "name" "payload-processing" "namespace" $.Values.rhaiOperator.infrastructureNamespace) }}
+  {{- $serviceAccounts = append $serviceAccounts (dict "name" "payload-processing" "namespace" (include "rhai-on-xks-chart.infrastructureNamespace" $)) }}
   {{- end }}
   {{- /* The batch-gateway operator is deployed only when batchGateway is Managed. */}}
   {{- if eq (dig "spec" "batchGateway" "managementState" "" $aigw) "Managed" }}

--- a/charts/rhai-on-xks-chart/templates/pull-secret.yaml
+++ b/charts/rhai-on-xks-chart/templates/pull-secret.yaml
@@ -23,6 +23,10 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 {{- end }}
+{{- if (include "rhai-on-xks-chart.maasManaged" $) }}
+  {{- $allNamespaces = append $allNamespaces (include "rhai-on-xks-chart.maasInfrastructureNamespace" $) }}
+{{- end }}
+{{- $allNamespaces = $allNamespaces | uniq }}
 {{- range $ns := $allNamespaces }}
 ---
 {{ include "rhai-on-xks-chart.imagePullSecretResource" (dict "root" $ "namespace" $ns) }}
@@ -50,11 +54,12 @@ metadata:
   {{- /* The AIGateway module operator is always deployed when the module is enabled. */}}
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "ai-gateway-operator" "namespace" $appNs) }}
   {{- /* MaaS (maas-controller/maas-api) is deployed only when modelsAsAService is Managed. */}}
-  {{- if eq (dig "spec" "modelsAsAService" "managementState" "" $aigw) "Managed" }}
+  {{- if (include "rhai-on-xks-chart.maasManaged" $) }}
+  {{- $maasInfraNs := include "rhai-on-xks-chart.maasInfrastructureNamespace" $ }}
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-controller" "namespace" $appNs) }}
-  {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-api" "namespace" $appNs) }}
-  {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-api-cleanup" "namespace" $appNs) }}
-  {{- $serviceAccounts = append $serviceAccounts (dict "name" "payload-processing" "namespace" (include "rhai-on-xks-chart.infrastructureNamespace" $)) }}
+  {{- $serviceAccounts = append $serviceAccounts (dict "name" "payload-processing" "namespace" $appNs) }}
+  {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-api" "namespace" $maasInfraNs) }}
+  {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-api-cleanup" "namespace" $maasInfraNs) }}
   {{- end }}
   {{- /* The batch-gateway operator is deployed only when batchGateway is Managed. */}}
   {{- if eq (dig "spec" "batchGateway" "managementState" "" $aigw) "Managed" }}

--- a/charts/rhai-on-xks-chart/templates/pull-secret.yaml
+++ b/charts/rhai-on-xks-chart/templates/pull-secret.yaml
@@ -54,7 +54,7 @@ metadata:
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-controller" "namespace" $appNs) }}
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-api" "namespace" $appNs) }}
   {{- $serviceAccounts = append $serviceAccounts (dict "name" "maas-api-cleanup" "namespace" $appNs) }}
-  {{- $serviceAccounts = append $serviceAccounts (dict "name" "payload-processing" "namespace" "redhat-ai-gateway-infra") }}
+  {{- $serviceAccounts = append $serviceAccounts (dict "name" "payload-processing" "namespace" $.Values.rhaiOperator.infrastructureNamespace) }}
   {{- end }}
   {{- /* The batch-gateway operator is deployed only when batchGateway is Managed. */}}
   {{- if eq (dig "spec" "batchGateway" "managementState" "" $aigw) "Managed" }}

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
@@ -2901,11 +2901,8 @@ rules:
       - ""
     resources:
       - namespaces
-      - serviceaccounts
     verbs:
       - get
-      - list
-      - watch
       - create
       - patch
 ---

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
@@ -2982,6 +2982,8 @@ rules:
       - operator.authorino.kuadrant.io
     resources:
       - authorinos
+    resourceNames:
+      - authorino
     verbs:
       - get
       - patch
@@ -2990,6 +2992,8 @@ rules:
       - apps
     resources:
       - deployments
+    resourceNames:
+      - authorino
     verbs:
       - get
       - patch
@@ -3615,49 +3619,6 @@ spec:
                   }
                 }'
                 echo "Authorino CA trust configured."
-              
-                echo "Creating Authorino TLS serving certificate (xKS equivalent of setup-authorino-tls.sh)..."
-                kubectl apply -f - <<EOF
-              apiVersion: cert-manager.io/v1
-              kind: Certificate
-              metadata:
-                name: authorino-server-cert
-                namespace: $KUADRANT_NS
-              spec:
-                secretName: authorino-server-cert
-                issuerRef:
-                  name: rhai-ca-issuer
-                  kind: ClusterIssuer
-                  group: cert-manager.io
-                dnsNames:
-                  - "authorino.$KUADRANT_NS.svc"
-                  - "authorino.$KUADRANT_NS.svc.cluster.local"
-                  - "authorino-authorino-authorization.$KUADRANT_NS.svc"
-                  - "authorino-authorino-authorization.$KUADRANT_NS.svc.cluster.local"
-              EOF
-                authorino_cert_ready() {
-                  [ "$(kubectl get certificate authorino-server-cert -n "$KUADRANT_NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)" = "True" ]
-                }
-                wait_for "Authorino server cert to be Ready" authorino_cert_ready
-              
-                echo "Patching Authorino CR to enable TLS with cert-manager certificate..."
-                if kubectl get authorino authorino -n "$KUADRANT_NS" >/dev/null 2>&1; then
-                  kubectl patch authorino authorino -n "$KUADRANT_NS" --type=merge -p '{
-                    "spec": {
-                      "listener": {
-                        "tls": {
-                          "enabled": true,
-                          "certSecretRef": {
-                            "name": "authorino-server-cert"
-                          }
-                        }
-                      }
-                    }
-                  }'
-                  echo "Authorino TLS listener configured with cert-manager certificate."
-                else
-                  echo "Authorino CR not found, skipping TLS listener config."
-                fi
               else
                 echo "Kuadrant namespace not found, skipping Authorino CA trust."
               fi

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
@@ -2810,6 +2810,7 @@ rules:
       - namespaces
     resourceNames:
       - redhat-ods-applications
+      - kuadrant-system
     verbs:
       - get
       - create
@@ -2946,6 +2947,54 @@ rules:
       - update
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
+# Permissions in kuadrant-system for Authorino TLS and CA trust setup.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rhai-post-install-hook-kuadrant
+  namespace: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - operator.authorino.kuadrant.io
+    resources:
+      - authorinos
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - patch
+---
+# Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -2961,6 +3010,27 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: rhai-post-install-hook-cert
+subjects:
+  - kind: ServiceAccount
+    name: rhai-post-install-hook
+    namespace: default
+---
+# Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rhai-post-install-hook-kuadrant
+  namespace: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rhai-post-install-hook-kuadrant
 subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
@@ -3530,11 +3600,20 @@ spec:
                 kubectl create configmap rhai-ca-bundle --from-file=ca.crt=/tmp/ca.crt \
                   -n "$KUADRANT_NS" --dry-run=client -o yaml | kubectl apply -f -
               
-                kubectl patch deployment authorino -n "$KUADRANT_NS" --type=json -p='[
-                  {"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"rhai-ca","configMap":{"name":"rhai-ca-bundle"}}},
-                  {"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"rhai-ca","mountPath":"/etc/pki/tls/custom","readOnly":true}},
-                  {"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"SSL_CERT_FILE","value":"/etc/pki/tls/custom/ca.crt"}}
-                ]'
+                kubectl patch deployment authorino -n "$KUADRANT_NS" --type=strategic -p='{
+                  "spec": {
+                    "template": {
+                      "spec": {
+                        "volumes": [{"name":"rhai-ca","configMap":{"name":"rhai-ca-bundle"}}],
+                        "containers": [{
+                          "name": "authorino",
+                          "volumeMounts": [{"name":"rhai-ca","mountPath":"/etc/pki/tls/custom","readOnly":true}],
+                          "env": [{"name":"SSL_CERT_FILE","value":"/etc/pki/tls/custom/ca.crt"}]
+                        }]
+                      }
+                    }
+                  }
+                }'
                 echo "Authorino CA trust configured."
               
                 echo "Creating Authorino TLS serving certificate (xKS equivalent of setup-authorino-tls.sh)..."

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
@@ -3446,12 +3446,13 @@ spec:
               wait_for "MaaS gateway Certificate to be Ready" maas_gw_cert_ready
               
               echo "Step 5: Create MaaS API serving Certificate..."
-              kubectl apply -f - <<'EOF'
+              INFRA_NS="redhat-ai-gateway-infra"
+              kubectl apply -f - <<EOF
               apiVersion: cert-manager.io/v1
               kind: Certificate
               metadata:
                 name: maas-api-serving-cert
-                namespace: "redhat-ods-applications"
+                namespace: ${INFRA_NS}
               spec:
                 secretName: maas-api-serving-cert
                 issuerRef:
@@ -3459,8 +3460,8 @@ spec:
                   kind: "ClusterIssuer"
                   group: cert-manager.io
                 dnsNames:
-                  - "maas-api.redhat-ods-applications.svc"
-                  - "maas-api.redhat-ods-applications.svc.cluster.local"
+                  - "maas-api.${INFRA_NS}.svc"
+                  - "maas-api.${INFRA_NS}.svc.cluster.local"
               EOF
               
               echo "Step 6: Create MaaS Gateway..."
@@ -3523,6 +3524,48 @@ spec:
                   {"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"SSL_CERT_FILE","value":"/etc/pki/tls/custom/ca.crt"}}
                 ]'
                 echo "Authorino CA trust configured."
+              
+                echo "Creating Authorino TLS serving certificate (xKS equivalent of setup-authorino-tls.sh)..."
+                kubectl apply -f - <<EOF
+              apiVersion: cert-manager.io/v1
+              kind: Certificate
+              metadata:
+                name: authorino-server-cert
+                namespace: $KUADRANT_NS
+              spec:
+                secretName: authorino-server-cert
+                issuerRef:
+                  name: rhai-ca-issuer
+                  kind: ClusterIssuer
+                  group: cert-manager.io
+                dnsNames:
+                  - "authorino.$KUADRANT_NS.svc"
+                  - "authorino.$KUADRANT_NS.svc.cluster.local"
+                  - "authorino-authorino-authorization.$KUADRANT_NS.svc"
+                  - "authorino-authorino-authorization.$KUADRANT_NS.svc.cluster.local"
+              EOF
+                echo "Waiting for Authorino server cert to be ready..."
+                kubectl wait --for=condition=Ready certificate/authorino-server-cert \
+                  -n "$KUADRANT_NS" --timeout=60s 2>/dev/null || true
+              
+                echo "Patching Authorino CR to enable TLS with cert-manager certificate..."
+                if kubectl get authorino authorino -n "$KUADRANT_NS" >/dev/null 2>&1; then
+                  kubectl patch authorino authorino -n "$KUADRANT_NS" --type=merge -p '{
+                    "spec": {
+                      "listener": {
+                        "tls": {
+                          "enabled": true,
+                          "certSecretRef": {
+                            "name": "authorino-server-cert"
+                          }
+                        }
+                      }
+                    }
+                  }'
+                  echo "Authorino TLS listener configured with cert-manager certificate."
+                else
+                  echo "Authorino CR not found, skipping TLS listener config."
+                fi
               else
                 echo "Kuadrant namespace not found, skipping Authorino CA trust."
               fi

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
@@ -3464,6 +3464,18 @@ spec:
                   - "maas-api.${INFRA_NS}.svc.cluster.local"
               EOF
               
+              echo "Step 5b: Create odh-kserve-config ConfigMap (cert-manager issuer for KServe module)..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: odh-kserve-config
+                namespace: "redhat-ods-applications"
+              data:
+                certManager.issuer: "rhai-ca-issuer"
+                certManager.issuerKind: "ClusterIssuer"
+              EOF
+              
               echo "Step 6: Create MaaS Gateway..."
               kubectl apply -f - <<'EOF'
               apiVersion: gateway.networking.k8s.io/v1
@@ -3544,9 +3556,10 @@ spec:
                   - "authorino-authorino-authorization.$KUADRANT_NS.svc"
                   - "authorino-authorino-authorization.$KUADRANT_NS.svc.cluster.local"
               EOF
-                echo "Waiting for Authorino server cert to be ready..."
-                kubectl wait --for=condition=Ready certificate/authorino-server-cert \
-                  -n "$KUADRANT_NS" --timeout=60s 2>/dev/null || true
+                authorino_cert_ready() {
+                  [ "$(kubectl get certificate authorino-server-cert -n "$KUADRANT_NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)" = "True" ]
+                }
+                wait_for "Authorino server cert to be Ready" authorino_cert_ready
               
                 echo "Patching Authorino CR to enable TLS with cert-manager certificate..."
                 if kubectl get authorino authorino -n "$KUADRANT_NS" >/dev/null 2>&1; then

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas-and-pull-secret.snap.yaml
@@ -68,17 +68,6 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 ---
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: redhat-ai-gateway-infra
-  labels:
-    helm.sh/chart: HELM_CHART_VERSION_REDACTED
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-    helm.sh/resource-policy: keep
----
 # Source: rhai-on-xks-chart/templates/cloudmanager/azure/rbac/serviceaccount-azure-cloud-manager-operator.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -129,8 +118,17 @@ imagePullSecrets:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: maas-api
+  name: payload-processing
   namespace: redhat-ods-applications
+imagePullSecrets:
+  - name: rhai-pull-secret
+---
+# Source: rhai-on-xks-chart/templates/pull-secret.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: maas-api
+  namespace: redhat-ai-gateway-infra
 imagePullSecrets:
   - name: rhai-pull-secret
 ---
@@ -139,15 +137,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: maas-api-cleanup
-  namespace: redhat-ods-applications
-imagePullSecrets:
-  - name: rhai-pull-secret
----
-# Source: rhai-on-xks-chart/templates/pull-secret.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: payload-processing
   namespace: redhat-ai-gateway-infra
 imagePullSecrets:
   - name: rhai-pull-secret
@@ -2668,6 +2657,20 @@ metadata:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-maas-ns-job.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhai-pre-install-maas-ns
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
 # Source: rhai-on-xks-chart/templates/hooks/pre-delete-crs-rbac.yaml
 apiVersion: v1
 kind: Secret
@@ -2881,6 +2884,31 @@ rules:
       - get
       - delete
 ---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-maas-ns-job.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rhai-pre-install-maas-ns
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -2921,6 +2949,27 @@ subjects:
     name: rhai-pre-delete-hook
     namespace: default
 
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-maas-ns-job.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhai-pre-install-maas-ns
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhai-pre-install-maas-ns
+subjects:
+  - kind: ServiceAccount
+    name: rhai-pre-install-maas-ns
+    namespace: default
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 # Certificate is namespaced to the applications namespace.
@@ -3688,4 +3737,61 @@ spec:
               echo "Deleting AzureKubernetesEngine CR 'default-azurekubernetesengine'..."
               kubectl delete azurekubernetesengine default-azurekubernetesengine --ignore-not-found --timeout=300s
               echo "Done."
+
+---
+# Source: rhai-on-xks-chart/templates/hooks/pre-install-maas-ns-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhai-pre-install-maas-ns
+  namespace: default
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: HELM_CHART_VERSION_REDACTED
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      restartPolicy: Never
+      serviceAccountName: rhai-pre-install-maas-ns
+      imagePullSecrets:
+        - name: rhai-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: create-namespace
+          image: "registry.redhat.io/openshift4/ose-cli-rhel9:v4.20@sha256:d876c1d98b39d65c00c4261431bb84b90284699f3aef84d8701a25c786fb79a1"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              INFRA_NS="redhat-ai-gateway-infra"
+              echo "Creating ${INFRA_NS} namespace..."
+              kubectl create namespace "${INFRA_NS}" --dry-run=client -o yaml | kubectl apply -f -
+              echo "Namespace ${INFRA_NS} ready."
 

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
@@ -3218,12 +3218,13 @@ spec:
               wait_for "MaaS gateway Certificate to be Ready" maas_gw_cert_ready
               
               echo "Step 5: Create MaaS API serving Certificate..."
-              kubectl apply -f - <<'EOF'
+              INFRA_NS="redhat-ai-gateway-infra"
+              kubectl apply -f - <<EOF
               apiVersion: cert-manager.io/v1
               kind: Certificate
               metadata:
                 name: maas-api-serving-cert
-                namespace: "redhat-ods-applications"
+                namespace: ${INFRA_NS}
               spec:
                 secretName: maas-api-serving-cert
                 issuerRef:
@@ -3231,8 +3232,8 @@ spec:
                   kind: "ClusterIssuer"
                   group: cert-manager.io
                 dnsNames:
-                  - "maas-api.redhat-ods-applications.svc"
-                  - "maas-api.redhat-ods-applications.svc.cluster.local"
+                  - "maas-api.${INFRA_NS}.svc"
+                  - "maas-api.${INFRA_NS}.svc.cluster.local"
               EOF
               
               echo "Step 6: Create MaaS Gateway..."
@@ -3295,6 +3296,48 @@ spec:
                   {"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"SSL_CERT_FILE","value":"/etc/pki/tls/custom/ca.crt"}}
                 ]'
                 echo "Authorino CA trust configured."
+              
+                echo "Creating Authorino TLS serving certificate (xKS equivalent of setup-authorino-tls.sh)..."
+                kubectl apply -f - <<EOF
+              apiVersion: cert-manager.io/v1
+              kind: Certificate
+              metadata:
+                name: authorino-server-cert
+                namespace: $KUADRANT_NS
+              spec:
+                secretName: authorino-server-cert
+                issuerRef:
+                  name: rhai-ca-issuer
+                  kind: ClusterIssuer
+                  group: cert-manager.io
+                dnsNames:
+                  - "authorino.$KUADRANT_NS.svc"
+                  - "authorino.$KUADRANT_NS.svc.cluster.local"
+                  - "authorino-authorino-authorization.$KUADRANT_NS.svc"
+                  - "authorino-authorino-authorization.$KUADRANT_NS.svc.cluster.local"
+              EOF
+                echo "Waiting for Authorino server cert to be ready..."
+                kubectl wait --for=condition=Ready certificate/authorino-server-cert \
+                  -n "$KUADRANT_NS" --timeout=60s 2>/dev/null || true
+              
+                echo "Patching Authorino CR to enable TLS with cert-manager certificate..."
+                if kubectl get authorino authorino -n "$KUADRANT_NS" >/dev/null 2>&1; then
+                  kubectl patch authorino authorino -n "$KUADRANT_NS" --type=merge -p '{
+                    "spec": {
+                      "listener": {
+                        "tls": {
+                          "enabled": true,
+                          "certSecretRef": {
+                            "name": "authorino-server-cert"
+                          }
+                        }
+                      }
+                    }
+                  }'
+                  echo "Authorino TLS listener configured with cert-manager certificate."
+                else
+                  echo "Authorino CR not found, skipping TLS listener config."
+                fi
               else
                 echo "Kuadrant namespace not found, skipping Authorino CA trust."
               fi

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
@@ -2582,6 +2582,7 @@ rules:
       - namespaces
     resourceNames:
       - redhat-ods-applications
+      - kuadrant-system
     verbs:
       - get
       - create
@@ -2718,6 +2719,54 @@ rules:
       - update
 ---
 # Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
+# Permissions in kuadrant-system for Authorino TLS and CA trust setup.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rhai-post-install-hook-kuadrant
+  namespace: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - operator.authorino.kuadrant.io
+    resources:
+      - authorinos
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - patch
+---
+# Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -2733,6 +2782,27 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: rhai-post-install-hook-cert
+subjects:
+  - kind: ServiceAccount
+    name: rhai-post-install-hook
+    namespace: default
+---
+# Source: rhai-on-xks-chart/templates/hooks/post-install-crs-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rhai-post-install-hook-kuadrant
+  namespace: kuadrant-system
+  labels:
+    helm.sh/chart: HELM_CHART_VERSION_REDACTED
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rhai-post-install-hook-kuadrant
 subjects:
   - kind: ServiceAccount
     name: rhai-post-install-hook
@@ -3302,11 +3372,20 @@ spec:
                 kubectl create configmap rhai-ca-bundle --from-file=ca.crt=/tmp/ca.crt \
                   -n "$KUADRANT_NS" --dry-run=client -o yaml | kubectl apply -f -
               
-                kubectl patch deployment authorino -n "$KUADRANT_NS" --type=json -p='[
-                  {"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"rhai-ca","configMap":{"name":"rhai-ca-bundle"}}},
-                  {"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"rhai-ca","mountPath":"/etc/pki/tls/custom","readOnly":true}},
-                  {"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"SSL_CERT_FILE","value":"/etc/pki/tls/custom/ca.crt"}}
-                ]'
+                kubectl patch deployment authorino -n "$KUADRANT_NS" --type=strategic -p='{
+                  "spec": {
+                    "template": {
+                      "spec": {
+                        "volumes": [{"name":"rhai-ca","configMap":{"name":"rhai-ca-bundle"}}],
+                        "containers": [{
+                          "name": "authorino",
+                          "volumeMounts": [{"name":"rhai-ca","mountPath":"/etc/pki/tls/custom","readOnly":true}],
+                          "env": [{"name":"SSL_CERT_FILE","value":"/etc/pki/tls/custom/ca.crt"}]
+                        }]
+                      }
+                    }
+                  }
+                }'
                 echo "Authorino CA trust configured."
               
                 echo "Creating Authorino TLS serving certificate (xKS equivalent of setup-authorino-tls.sh)..."

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
@@ -3236,6 +3236,18 @@ spec:
                   - "maas-api.${INFRA_NS}.svc.cluster.local"
               EOF
               
+              echo "Step 5b: Create odh-kserve-config ConfigMap (cert-manager issuer for KServe module)..."
+              kubectl apply -f - <<'EOF'
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: odh-kserve-config
+                namespace: "redhat-ods-applications"
+              data:
+                certManager.issuer: "rhai-ca-issuer"
+                certManager.issuerKind: "ClusterIssuer"
+              EOF
+              
               echo "Step 6: Create MaaS Gateway..."
               kubectl apply -f - <<'EOF'
               apiVersion: gateway.networking.k8s.io/v1
@@ -3316,9 +3328,10 @@ spec:
                   - "authorino-authorino-authorization.$KUADRANT_NS.svc"
                   - "authorino-authorino-authorization.$KUADRANT_NS.svc.cluster.local"
               EOF
-                echo "Waiting for Authorino server cert to be ready..."
-                kubectl wait --for=condition=Ready certificate/authorino-server-cert \
-                  -n "$KUADRANT_NS" --timeout=60s 2>/dev/null || true
+                authorino_cert_ready() {
+                  [ "$(kubectl get certificate authorino-server-cert -n "$KUADRANT_NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)" = "True" ]
+                }
+                wait_for "Authorino server cert to be Ready" authorino_cert_ready
               
                 echo "Patching Authorino CR to enable TLS with cert-manager certificate..."
                 if kubectl get authorino authorino -n "$KUADRANT_NS" >/dev/null 2>&1; then

--- a/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
+++ b/charts/rhai-on-xks-chart/test/snapshots/azure-with-maas.snap.yaml
@@ -2754,6 +2754,8 @@ rules:
       - operator.authorino.kuadrant.io
     resources:
       - authorinos
+    resourceNames:
+      - authorino
     verbs:
       - get
       - patch
@@ -2762,6 +2764,8 @@ rules:
       - apps
     resources:
       - deployments
+    resourceNames:
+      - authorino
     verbs:
       - get
       - patch
@@ -3387,49 +3391,6 @@ spec:
                   }
                 }'
                 echo "Authorino CA trust configured."
-              
-                echo "Creating Authorino TLS serving certificate (xKS equivalent of setup-authorino-tls.sh)..."
-                kubectl apply -f - <<EOF
-              apiVersion: cert-manager.io/v1
-              kind: Certificate
-              metadata:
-                name: authorino-server-cert
-                namespace: $KUADRANT_NS
-              spec:
-                secretName: authorino-server-cert
-                issuerRef:
-                  name: rhai-ca-issuer
-                  kind: ClusterIssuer
-                  group: cert-manager.io
-                dnsNames:
-                  - "authorino.$KUADRANT_NS.svc"
-                  - "authorino.$KUADRANT_NS.svc.cluster.local"
-                  - "authorino-authorino-authorization.$KUADRANT_NS.svc"
-                  - "authorino-authorino-authorization.$KUADRANT_NS.svc.cluster.local"
-              EOF
-                authorino_cert_ready() {
-                  [ "$(kubectl get certificate authorino-server-cert -n "$KUADRANT_NS" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)" = "True" ]
-                }
-                wait_for "Authorino server cert to be Ready" authorino_cert_ready
-              
-                echo "Patching Authorino CR to enable TLS with cert-manager certificate..."
-                if kubectl get authorino authorino -n "$KUADRANT_NS" >/dev/null 2>&1; then
-                  kubectl patch authorino authorino -n "$KUADRANT_NS" --type=merge -p '{
-                    "spec": {
-                      "listener": {
-                        "tls": {
-                          "enabled": true,
-                          "certSecretRef": {
-                            "name": "authorino-server-cert"
-                          }
-                        }
-                      }
-                    }
-                  }'
-                  echo "Authorino TLS listener configured with cert-manager certificate."
-                else
-                  echo "Authorino CR not found, skipping TLS listener config."
-                fi
               else
                 echo "Kuadrant namespace not found, skipping Authorino CA trust."
               fi

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -120,17 +120,22 @@ components:
         gatewayClassName: istio
         allowedRoutes:
           namespaces:
-            # Which namespaces can attach HTTPRoutes to the MaaS Gateway (All, Same, or Selector).
+            # Which namespaces can attach HTTPRoutes to the MaaS Gateway.
             # Defaults to Same (secure by default): only the Gateway's own namespace can attach routes.
-            from: Same
-            # Example for All (any namespace can attach routes):
-            # from: All
             #
-            # Example for Selector (only namespaces matching labels):
-            # from: Selector
-            # selector:
-            #   matchLabels:
-            #     maas-gateway-access: "true"
+            # IMPORTANT: MaaS creates HTTPRoutes in the model namespace (e.g. models-as-a-service),
+            # which differs from the gateway namespace (redhat-ods-applications). To allow
+            # ExternalModel/LLMInferenceService routes to attach, use a Selector to grant
+            # access to the model namespace:
+            #
+            #   from: Selector
+            #   selector:
+            #     matchLabels:
+            #       maas-gateway-access: "true"
+            #
+            # Then label the model namespace:
+            #   kubectl label ns models-as-a-service maas-gateway-access=true
+            from: Same
 
 # Azure cloud configuration
 azure:

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -18,6 +18,7 @@ rhaiOperator:
   # Operator namespace
   namespace: redhat-ods-operator
   applicationsNamespace: redhat-ods-applications
+  infrastructureNamespace: redhat-ai-gateway-infra
   # Manager container image
   image: quay.io/opendatahub/opendatahub-operator:latest # image is updated during Helm chart build by konflux
   # Image pull policy
@@ -123,10 +124,9 @@ components:
             # Which namespaces can attach HTTPRoutes to the MaaS Gateway.
             # Defaults to Same (secure by default): only the Gateway's own namespace can attach routes.
             #
-            # IMPORTANT: MaaS creates HTTPRoutes in the model namespace (e.g. models-as-a-service),
+            # MaaS creates HTTPRoutes in the model namespace (e.g. models-as-a-service),
             # which differs from the gateway namespace (redhat-ods-applications). To allow
-            # ExternalModel/LLMInferenceService routes to attach, use a Selector to grant
-            # access to the model namespace:
+            # ExternalModel/LLMInferenceService routes to attach, configure a Selector:
             #
             #   from: Selector
             #   selector:

--- a/charts/rhai-on-xks-chart/values.yaml
+++ b/charts/rhai-on-xks-chart/values.yaml
@@ -18,7 +18,6 @@ rhaiOperator:
   # Operator namespace
   namespace: redhat-ods-operator
   applicationsNamespace: redhat-ods-applications
-  infrastructureNamespace: redhat-ai-gateway-infra
   # Manager container image
   image: quay.io/opendatahub/opendatahub-operator:latest # image is updated during Helm chart build by konflux
   # Image pull policy


### PR DESCRIPTION
## Summary

- Automates Authorino TLS setup in the post-install hook (no more manual intervention)
- Fixes hook RBAC to allow access to `kuadrant-system` namespace
- Fixes Authorino deployment patch to work when volumes/env arrays are null
- Adds `odh-kserve-config` ConfigMap creation for KServe cert-manager issuer
- Fixes `maas-api-serving-cert` placement (moved to `redhat-ai-gateway-infra`)
- Documents `allowedRoutes` configuration (Selector method for cross-namespace HTTPRoutes)

## Details

### Hook RBAC fix
The hook ClusterRole only listed the MaaS gateway namespace in `resourceNames` for the namespace `get` permission. When the script ran `kubectl get namespace kuadrant-system`, it received a 403 (silenced by `>/dev/null 2>&1`), causing the entire Authorino block to be skipped silently.

**Fix**: Added `kuadrant-system` to allowed namespace resourceNames + added a dedicated Role/RoleBinding in `kuadrant-system` for configmaps, certificates, authorinos, and deployments.

### Authorino deployment patch fix
The JSON patch used `"op":"add","path":"/spec/template/spec/volumes/-"` which fails when the array is `null` (RHCL deploys Authorino with no volumes/env).

**Fix**: Switched to `--type=strategic` merge patch which correctly initializes null arrays.

### Authorino TLS
The hook creates a cert-manager Certificate (`authorino-server-cert`) signed by `rhai-ca-issuer`, patches the Authorino deployment with CA trust volume, and patches the Authorino CR to enable TLS on its listener. Required for MaaS auth flow (WasmPlugin -> Authorino gRPC).

### odh-kserve-config ConfigMap
Creates `odh-kserve-config` in `redhat-ods-applications` with `certManager.issuer: rhai-ca-issuer` so KServe module uses the correct issuer instead of hardcoded `opendatahub-ca-issuer`.

### allowedRoutes
Keeps `from: Same` as secure default and documents how users should configure `Selector` to allow MaaS HTTPRoutes from the model namespace.

### maas-api-serving-cert namespace
`maas-api` runs in `redhat-ai-gateway-infra`. The serving certificate must be co-located with the workload that mounts it.

## Test plan
- [x] Deploy on fresh AKS cluster with RHCL + rhai-on-xks chart
- [x] Verify Authorino TLS is configured automatically by hook (authorino-server-cert Ready, tls.enabled=true)
- [x] Verify rhai-ca-bundle ConfigMap created in kuadrant-system
- [x] Verify maas-api-serving-cert is created in redhat-ai-gateway-infra
- [x] Verify odh-kserve-config ConfigMap created with correct issuer
- [ ] Verify MaaS E2E flow (ExternalModel -> auth -> inference)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable infrastructure namespace support for AI Gateway and managed models-as-a-service resources.
  * Added automatic setup of the MaaS infrastructure namespace and required service accounts.
  * Added certificate issuer configuration for MaaS API services.
  * Added guidance for cross-namespace model routing.

* **Bug Fixes**
  * Improved certificate placement and DNS configuration for MaaS APIs.
  * Updated Authorino TLS and CA trust configuration for more reliable deployment updates.
  * Improved permissions for MaaS and Authorino setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->