### PR TITLE
Add helm dependency build step to CI workflows

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -13,6 +13,12 @@ jobs:
         with:
           fetch-depth: 0
       - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+      - name: Build chart dependencies
+        run: |
+          set -euo pipefail
+          for chart in $(find charts -name Chart.yaml -exec dirname {} \;); do
+            helm dependency build "$chart"
+          done
       - name: Linting Charts
         run: |
           set -euo pipefail

--- a/.github/workflows/rhai-on-xks-chart-test.yaml
+++ b/.github/workflows/rhai-on-xks-chart-test.yaml
@@ -73,6 +73,9 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
 
+      - name: Build chart dependencies
+        run: helm dependency build charts/rhai-on-xks-chart
+
       - name: Install and verify chart
         timeout-minutes: 60
         env:
@@ -123,6 +126,9 @@ jobs:
 
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+
+      - name: Build chart dependencies
+        run: helm dependency build charts/rhai-on-xks-chart
 
       - name: Upgrade test
         timeout-minutes: 60


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Add `helm dependency build` before helm install in CI workflows to support gitignored subchart packages.


## Release tracking

Jira: https://redhat.atlassian.net/browse/RHOAIENG-69980


## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm chart validation by building chart dependencies before linting.
  * Updated installation, verification, and upgrade tests to prepare chart dependencies automatically.
  * Increased reliability of Helm chart checks and deployment testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->