### PR TITLE
fix: auto-build chart dependencies in chart-snapshots script

### DIFF
--- a/scripts/chart-snapshots.sh
+++ b/scripts/chart-snapshots.sh
@@ -333,6 +333,12 @@ process_chart() {
         clean_snapshots "${chart_name}"
     fi
 
+    # Build chart dependencies if defined
+    if [[ -f "${chart_path}/Chart.yaml" ]] && grep -q '^dependencies:' "${chart_path}/Chart.yaml"; then
+        echo "  Building chart dependencies for ${chart_name}..."
+        helm dependency build "${chart_path}"
+    fi
+
     local failed=0
     for ((i = 0; i < snapshot_count; i++)); do
         if ! process_snapshot "${chart_name}" "${i}"; then


### PR DESCRIPTION
## Description

Charts with subchart dependencies (like rhai-on-xks-chart) fail during
helm template execution unless dependencies are built first. Running
helm dependency build automatically in chart-snapshots.sh to ensure
snapshot generation and testing work reliably in local dev and CI
workflows without extra manual steps.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira:

## Has it been tested?
```sh
rm -rf charts/rhai-on-xks-chart/charts
make chart-snapshots CHART_NAME=rhai-on-xks-chart
git diff   # no output
```

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] You have read the [contributors guide](https://github.com/opendatahub-io/odh-gitops/blob/main/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
